### PR TITLE
Predict: Production Readiness (P0 + P1)

### DIFF
--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -16,8 +16,8 @@ import { BottomGlassNav } from '@/features/feed/components/BottomGlassNav';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
 import { BOTTOM_NAV_ITEMS } from '@/features/feed/feed.mock';
-import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, cancelOrder } from '@/features/predict/predict.api';
-import type { PortfolioData, PortfolioPosition, OpenOrder } from '@/features/predict/predict.api';
+import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity, cancelOrder } from '@/features/predict/predict.api';
+import type { ActivityItem, PortfolioData, PortfolioPosition, OpenOrder } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { semantic, tokens } from '@/theme';
@@ -52,6 +52,7 @@ export default function PredictProfileScreen() {
   const [portfolio, setPortfolio] = useState<PortfolioData | null>(null);
   const [cashBalance, setCashBalance] = useState<number | null>(null);
   const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
+  const [tradeHistory, setTradeHistory] = useState<ActivityItem[]>([]);
   const [portfolioLoading, setPortfolioLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
@@ -83,14 +84,16 @@ export default function PredictProfileScreen() {
     // CLOB operations use EOA (polygonAddress) for session auth
     const gammaAddr = poly.safeAddress ?? poly.polygonAddress;
     console.log('[profile] Loading — EOA:', poly.polygonAddress, '| Gamma addr (Safe):', gammaAddr);
-    const [portfolioData, balanceData, ordersData] = await Promise.all([
+    const [portfolioData, balanceData, ordersData, activityData] = await Promise.all([
       fetchPortfolio(gammaAddr).catch(() => null),
       fetchClobBalance(poly.polygonAddress),
       fetchOpenOrders(poly.polygonAddress).catch(() => []),
+      fetchActivity(gammaAddr).catch(() => []),
     ]);
     console.log('[profile] Balance:', balanceData?.balance ?? 'no session', '| Positions:', portfolioData?.positions?.length ?? 0, '| Orders:', ordersData.length);
     if (portfolioData) setPortfolio(portfolioData);
     setOpenOrders(ordersData);
+    setTradeHistory(activityData);
     if (balanceData) {
       setCashBalance(balanceData.balance);
       setSessionExpired(false);
@@ -426,6 +429,37 @@ export default function PredictProfileScreen() {
                 );
               })}
             </View>
+
+            {/* Trade History */}
+            {tradeHistory.length > 0 && (
+              <View style={styles.positionsSection}>
+                <View style={styles.posHeader}>
+                  <Text style={styles.posTitle}>Trade History</Text>
+                  <Text style={styles.posCount}>{tradeHistory.length} trades</Text>
+                </View>
+                {tradeHistory.slice(0, 20).map((t, i) => {
+                  const isBuy = t.side === 'BUY';
+                  const date = new Date(t.timestamp * 1000);
+                  const timeStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}`;
+                  return (
+                    <View key={`${t.timestamp}-${i}`} style={styles.posRow}>
+                      <View style={[styles.sideBadge, isBuy ? styles.sideBadgeYes : styles.sideBadgeNo]}>
+                        <Text style={[styles.sideBadgeText, isBuy ? styles.posText : styles.negText]}>
+                          {t.side}
+                        </Text>
+                      </View>
+                      <View style={{ flex: 1, marginLeft: 8 }}>
+                        <Text style={styles.posQuestion} numberOfLines={1}>{t.title || t.slug}</Text>
+                        <Text style={styles.tradeTime}>{timeStr}</Text>
+                      </View>
+                      <Text style={[styles.posPnl, isBuy ? styles.posText : styles.negText]}>
+                        ${t.usdcSize.toFixed(2)}
+                      </Text>
+                    </View>
+                  );
+                })}
+              </View>
+            )}
 
             {/* Addresses + disable */}
             <View style={styles.addressesSection}>
@@ -778,6 +812,12 @@ const styles = StyleSheet.create({
     fontFamily: 'monospace',
     fontSize: 7.5,
     color: semantic.text.faint,
+  },
+  tradeTime: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+    marginTop: 1,
   },
 
   // Order cards

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -448,7 +448,7 @@ export default function PredictProfileScreen() {
                           {t.side}
                         </Text>
                       </View>
-                      <View style={{ flex: 1, marginLeft: 8 }}>
+                      <View style={styles.tradeInfoWrap}>
                         <Text style={styles.posQuestion} numberOfLines={1}>{t.title || t.slug}</Text>
                         <Text style={styles.tradeTime}>{timeStr}</Text>
                       </View>
@@ -818,6 +818,10 @@ const styles = StyleSheet.create({
     fontSize: 7.5,
     color: semantic.text.faint,
     marginTop: 1,
+  },
+  tradeInfoWrap: {
+    flex: 1,
+    marginLeft: 8,
   },
 
   // Order cards

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -156,11 +156,12 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
   // Sell mode state
   const [betSlipMode, setBetSlipMode] = useState<'buy' | 'sell'>('buy');
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
 
   const refreshTimer = useRef<ReturnType<typeof globalThis.setInterval> | null>(null);
 
-  async function loadMarket() {
-    setLoading(true);
+  async function loadMarket(silent = false) {
+    if (!silent) setLoading(true);
     setErrorMessage(null);
     try {
       const next = await fetchCuratedMarketDetail(slug);
@@ -169,7 +170,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       setErrorMessage(error instanceof Error ? error.message : 'Unable to load market');
       setDetail(null);
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }
 
@@ -195,7 +196,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     await Promise.all([
-      loadMarket(),
+      loadMarket(true),
       refreshPrice(),
       loadHistory(interval),
     ]);
@@ -222,9 +223,17 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const loadOrdersAndPositions = useCallback(() => {
     if (!poly.polygonAddress) return;
     const gammaAddr = poly.safeAddress ?? poly.polygonAddress;
-    fetchOpenOrders(poly.polygonAddress).then(setOpenOrders).catch(() => setOpenOrders([]));
+    fetchOpenOrders(poly.polygonAddress).then((orders) => {
+      // Filter to orders matching this market's token IDs
+      const marketTokens = detail?.clobTokenIds ?? [];
+      if (marketTokens.length > 0) {
+        setOpenOrders(orders.filter((o) => marketTokens.includes(o.asset_id)));
+      } else {
+        setOpenOrders(orders);
+      }
+    }).catch(() => setOpenOrders([]));
     fetchMarketPositions(gammaAddr, slug).then(setMarketPositions).catch(() => setMarketPositions([]));
-  }, [poly.polygonAddress, poly.safeAddress, slug]);
+  }, [poly.polygonAddress, poly.safeAddress, slug, detail?.clobTokenIds]);
 
   useEffect(() => {
     if (poly.polygonAddress && detail) loadOrdersAndPositions();
@@ -301,7 +310,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
       let signedOrder: unknown = undefined;
       if (poly.canSignLocally) {
-        console.log('[order] Signing locally:', { tokenID, price: betSlipPrice, size, side: orderSide, exchangeAddress });
         signedOrder = await poly.signOrder({
           tokenID,
           price: betSlipPrice,
@@ -309,7 +317,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           side: orderSide,
           exchangeAddress,
         });
-        console.log('[order] Signed locally, posting to server');
       }
 
       const result = await placeBet({
@@ -465,7 +472,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
               {/* POSITION TAB */}
               {activeTab === 'position' ? (
-                <View style={{ gap: 12 }}>
+                <View style={styles.positionTabWrap}>
                   {/* Open Orders */}
                   {openOrders.length > 0 && (
                     <View>
@@ -486,13 +493,22 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                               </View>
                               <Text style={styles.orderOutcomeText} numberOfLines={1}>{o.outcome || '--'}</Text>
                               <Pressable
+                                disabled={cancellingId === o.id}
                                 onPress={async () => {
                                   if (!poly.polygonAddress) return;
-                                  await cancelOrder(poly.polygonAddress, o.id);
-                                  loadOrdersAndPositions();
+                                  setCancellingId(o.id);
+                                  try {
+                                    const res = await cancelOrder(poly.polygonAddress, o.id);
+                                    if (res.ok) loadOrdersAndPositions();
+                                  } catch { /* silent */ }
+                                  finally { setCancellingId(null); }
                                 }}
                                 style={styles.cancelBtn}>
-                                <Text style={styles.cancelBtnText}>Cancel</Text>
+                                {cancellingId === o.id ? (
+                                  <ActivityIndicator size={10} color={semantic.text.dim} />
+                                ) : (
+                                  <Text style={styles.cancelBtnText}>Cancel</Text>
+                                )}
                               </Pressable>
                             </View>
                             <View style={styles.positionStats}>
@@ -541,10 +557,11 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                                 onPress={() => {
                                   const side = pos.outcome === 'No' ? 'no' : 'yes';
                                   const price = side === 'yes' ? (yesPrice ?? 0.5) : (noPrice ?? 0.5);
+                                  const maxSellValue = Math.floor((pos.size ?? 0) * price * 100) / 100;
                                   setBetSlipSide(side);
                                   setBetSlipLabel(side === 'yes' ? 'YES' : 'NO');
                                   setBetSlipPrice(price);
-                                  setBetSlipAmount(0);
+                                  setBetSlipAmount(maxSellValue);
                                   setBetSlipMode('sell');
                                   setOrderResult(null);
                                   setOrderError(null);
@@ -769,7 +786,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           {/* Payout row */}
           <View style={styles.payoutRow}>
             <View>
-              <Text style={styles.betSlipMetaLabel}>Est. Payout</Text>
+              <Text style={styles.betSlipMetaLabel}>{betSlipMode === 'sell' ? 'Est. Return' : 'Est. Payout'}</Text>
               <Text style={[styles.betSlipMetaValue, { color: semantic.sentiment.positive }]}>
                 ${payout.toFixed(2)}
               </Text>
@@ -1073,6 +1090,7 @@ const styles = StyleSheet.create({
   },
 
   // ── Position section ──
+  positionTabWrap: { gap: 12 },
   posSecTitle: {
     color: semantic.text.faint,
     fontSize: tokens.fontSize.xxs,

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -5,10 +5,12 @@ import {
   ActivityIndicator,
   Modal,
   Pressable,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -121,9 +123,12 @@ const TABS: { key: Tab; label: string }[] = [
 export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenProps) {
   const router = useRouter();
   const poly = usePolymarketWallet();
+  const { width: screenWidth } = useWindowDimensions();
   const [detail, setDetail] = useState<GeopoliticsMarketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const [interval, setInterval] = useState<Interval>('1h');
   const [history, setHistory] = useState<PricePoint[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
@@ -187,6 +192,17 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
     } catch { /* silent */ }
   }
 
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([
+      loadMarket(),
+      refreshPrice(),
+      loadHistory(interval),
+    ]);
+    loadOrdersAndPositions();
+    setRefreshing(false);
+  }, [interval]);
+
   useEffect(() => {
     if (!detail) return;
     void loadHistory(interval);
@@ -240,8 +256,9 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       fetchClobBalance(poly.polygonAddress).then((b) => {
         if (b) {
           setClobBalance(b.balance);
+          setSessionExpired(false);
         } else {
-          poly.disable();
+          setSessionExpired(true);
         }
       });
     }
@@ -312,11 +329,11 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           fetchClobBalance(poly.polygonAddress).then((b) => { if (b) setClobBalance(b.balance); });
         }
       } else {
-        // Session expired — clear stale state so wallet connect button appears
+        // Session expired — mark expired, don't nuke wallet
         if (result.error?.includes('No active session')) {
-          poly.disable();
+          setSessionExpired(true);
           setOrderResult('error');
-          setOrderError('Session expired — connect wallet to continue');
+          setOrderError('Session expired — reconnect from profile');
           return;
         }
         setOrderResult('error');
@@ -349,6 +366,14 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           <View style={styles.avatarInner} />
         </Pressable>
       </View>
+
+      {/* ── SESSION EXPIRED BANNER ── */}
+      {sessionExpired && poly.isReady && (
+        <Pressable onPress={() => router.push('/predict-profile')} style={styles.sessionBanner}>
+          <MaterialIcons name="refresh" size={14} color={semantic.text.accent} />
+          <Text style={styles.sessionBannerText}>Session expired — tap to reconnect</Text>
+        </Pressable>
+      )}
 
       {/* ── LOADING / ERROR ── */}
       {loading ? (
@@ -395,7 +420,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                         onPress={() => setInterval(iv)}
                         style={[styles.intervalChip, interval === iv && styles.intervalChipActive]}>
                         <Text style={[styles.intervalText, interval === iv && styles.intervalTextActive]}>
-                          {iv === '1h' ? '1D' : '1W'}
+                          {iv === '1h' ? '1H' : '1D'}
                         </Text>
                       </Pressable>
                     ))}
@@ -407,7 +432,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                 {historyLoading ? (
                   <View style={styles.chartSkeleton} />
                 ) : history.length >= 2 ? (
-                  <Sparkline points={history} width={315} height={64} />
+                  <Sparkline points={history} width={screenWidth - 64} height={64} />
                 ) : (
                   <View style={[styles.chartSkeleton, { opacity: 0.4 }]} />
                 )}
@@ -432,7 +457,11 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
             </View>
 
             {/* Tab content */}
-            <ScrollView style={styles.tabContent} showsVerticalScrollIndicator={false} contentContainerStyle={styles.tabContentInner}>
+            <ScrollView
+              style={styles.tabContent}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={styles.tabContentInner}
+              refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={semantic.text.accent} />}>
 
               {/* POSITION TAB */}
               {activeTab === 'position' ? (
@@ -719,7 +748,23 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                 }}
               />
             </View>
+            {/* Amount presets */}
+            <View style={styles.presetsRow}>
+              {[5, 10, 25, 50].map((amt) => (
+                <Pressable key={amt} onPress={() => setBetSlipAmount(amt)} style={styles.presetChip}>
+                  <Text style={styles.presetText}>${amt}</Text>
+                </Pressable>
+              ))}
+            </View>
           </View>
+
+          {/* Deposit CTA when balance is $0 */}
+          {clobBalance !== null && clobBalance === 0 && poly.isReady && (
+            <Pressable onPress={() => router.push('/predict-profile')} style={styles.depositCta}>
+              <MaterialIcons name="account-balance-wallet" size={14} color={semantic.text.accent} />
+              <Text style={styles.depositCtaText}>Deposit funds to start trading</Text>
+            </Pressable>
+          )}
 
           {/* Payout row */}
           <View style={styles.payoutRow}>
@@ -1465,5 +1510,64 @@ const styles = StyleSheet.create({
     fontFamily: 'monospace',
     textTransform: 'uppercase',
     fontWeight: '700',
+  },
+
+  // ── Session banner ──
+  sessionBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: tokens.spacing.lg,
+    paddingVertical: tokens.spacing.sm,
+    backgroundColor: 'rgba(232,197,71,0.08)',
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(232,197,71,0.15)',
+  },
+  sessionBannerText: {
+    color: semantic.text.accent,
+    fontSize: tokens.fontSize.xxs,
+    fontFamily: 'monospace',
+    letterSpacing: 0.5,
+  },
+
+  // ── Amount presets ──
+  presetsRow: {
+    flexDirection: 'row',
+    gap: tokens.spacing.xs,
+    marginTop: tokens.spacing.xs,
+  },
+  presetChip: {
+    flex: 1,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.xs,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surfaceRaised,
+    alignItems: 'center',
+  },
+  presetText: {
+    color: semantic.text.dim,
+    fontSize: tokens.fontSize.xxs,
+    fontFamily: 'monospace',
+    fontWeight: '700',
+  },
+
+  // ── Deposit CTA ──
+  depositCta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: tokens.spacing.sm,
+    paddingHorizontal: tokens.spacing.md,
+    borderRadius: tokens.radius.sm,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.15)',
+    backgroundColor: 'rgba(232,197,71,0.06)',
+  },
+  depositCtaText: {
+    color: semantic.text.accent,
+    fontSize: tokens.fontSize.xxs,
+    fontFamily: 'monospace',
+    letterSpacing: 0.5,
   },
 });

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -15,8 +15,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, { Defs, LinearGradient, Path, Stop, Circle } from 'react-native-svg';
 import { BottomGlassNav } from '@/features/feed/components/BottomGlassNav';
 import { BOTTOM_NAV_ITEMS } from '@/features/feed/feed.mock';
-import { fetchCuratedMarketDetail, fetchMarketPrice, fetchMarketPositions, fetchPriceHistory, fetchClobBalance, placeBet } from '@/features/predict/predict.api';
-import type { PortfolioPosition } from '@/features/predict/predict.api';
+import { fetchCuratedMarketDetail, fetchMarketPrice, fetchMarketPositions, fetchPriceHistory, fetchClobBalance, fetchOpenOrders, cancelOrder, placeBet } from '@/features/predict/predict.api';
+import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import type { GeopoliticsMarketDetail, LivePrice, PricePoint } from '@/features/predict/predict.types';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { V2_CONTRACTS } from '@/hooks/useEvmSigner';
@@ -145,8 +145,12 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   // CLOB balance for bet slip
   const [clobBalance, setClobBalance] = useState<number | null>(null);
 
-  // Market positions for current user
+  // Market positions + open orders for current user
   const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
+  const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
+
+  // Sell mode state
+  const [betSlipMode, setBetSlipMode] = useState<'buy' | 'sell'>('buy');
 
   const refreshTimer = useRef<ReturnType<typeof globalThis.setInterval> | null>(null);
 
@@ -198,19 +202,17 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
   useEffect(() => { void loadMarket(); }, [slug]);
 
-  // Fetch user's positions for this market
-  useEffect(() => {
-    if (!detail || !poly.polygonAddress) {
-      setMarketPositions([]);
-      return;
-    }
-    // Use conditionId from the detail's clobTokenIds — the conditionId is embedded in positions data
-    // For now, fetch all positions and filter client-side by slug
+  // Fetch user's orders + positions for this market
+  const loadOrdersAndPositions = useCallback(() => {
+    if (!poly.polygonAddress) return;
     const gammaAddr = poly.safeAddress ?? poly.polygonAddress;
-    fetchMarketPositions(gammaAddr, slug)
-      .then(setMarketPositions)
-      .catch(() => setMarketPositions([]));
-  }, [detail, poly.polygonAddress, poly.safeAddress, slug]);
+    fetchOpenOrders(poly.polygonAddress).then(setOpenOrders).catch(() => setOpenOrders([]));
+    fetchMarketPositions(gammaAddr, slug).then(setMarketPositions).catch(() => setMarketPositions([]));
+  }, [poly.polygonAddress, poly.safeAddress, slug]);
+
+  useEffect(() => {
+    if (poly.polygonAddress && detail) loadOrdersAndPositions();
+  }, [poly.polygonAddress, detail, loadOrdersAndPositions]);
 
   const yesPrice = livePrice?.yesPrice ?? (detail?.outcomePrices[0] ?? null);
   const noPrice  = livePrice?.noPrice  ?? (detail?.outcomePrices[1] ?? null);
@@ -228,6 +230,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
     setBetSlipLabel(side === 'yes' ? 'YES' : 'NO');
     setBetSlipPrice(price);
     setBetSlipAmount(0);
+    setBetSlipMode('buy');
     setOrderResult(null);
     setOrderError(null);
     setBetSlipVisible(true);
@@ -273,18 +276,20 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
     try {
       // Local signing: phone signs EIP-712, server just proxies
-      // Geopolitics markets are typically not neg-risk (binary yes/no)
-      const exchangeAddress = V2_CONTRACTS.CTF_EXCHANGE;
+      const exchangeAddress = detail?.negRisk
+        ? V2_CONTRACTS.NEG_RISK_CTF_EXCHANGE
+        : V2_CONTRACTS.CTF_EXCHANGE;
+      const orderSide = betSlipMode === 'sell' ? 'SELL' : 'BUY';
       const size = Math.floor((betSlipAmount / betSlipPrice) * 100) / 100;
 
       let signedOrder: unknown = undefined;
       if (poly.canSignLocally) {
-        console.log('[order] Signing locally:', { tokenID, price: betSlipPrice, size, side: 'BUY', exchangeAddress });
+        console.log('[order] Signing locally:', { tokenID, price: betSlipPrice, size, side: orderSide, exchangeAddress });
         signedOrder = await poly.signOrder({
           tokenID,
           price: betSlipPrice,
           size,
-          side: 'BUY',
+          side: orderSide,
           exchangeAddress,
         });
         console.log('[order] Signed locally, posting to server');
@@ -295,12 +300,17 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
         tokenID,
         price: betSlipPrice,
         amount: betSlipAmount,
-        side: 'BUY',
+        side: orderSide,
         signedOrder,
       });
 
       if (result.success) {
         setOrderResult('success');
+        // Refresh orders, positions, balance
+        loadOrdersAndPositions();
+        if (poly.polygonAddress) {
+          fetchClobBalance(poly.polygonAddress).then((b) => { if (b) setClobBalance(b.balance); });
+        }
       } else {
         // Session expired — clear stale state so wallet connect button appears
         if (result.error?.includes('No active session')) {
@@ -335,9 +345,9 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
         <Text style={styles.headerTitle} numberOfLines={2}>
           {detail?.question ?? 'Loading...'}
         </Text>
-        <View style={styles.avatarRing}>
+        <Pressable onPress={() => router.push('/predict-profile')} style={styles.avatarRing}>
           <View style={styles.avatarInner} />
-        </View>
+        </Pressable>
       </View>
 
       {/* ── LOADING / ERROR ── */}
@@ -426,60 +436,141 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
               {/* POSITION TAB */}
               {activeTab === 'position' ? (
-                marketPositions.length === 0 ? (
-                  <View style={styles.emptyState}>
-                    <MaterialIcons name="show-chart" size={32} color={semantic.text.faint} />
-                    <Text style={styles.emptyTitle}>No positions yet</Text>
-                    <Text style={styles.emptyBody}>Trade below to open a position</Text>
-                  </View>
-                ) : (
-                  <View style={styles.tabSection}>
-                    {marketPositions.map((pos, i) => {
-                      const pnl = pos.cashPnl ?? 0;
-                      const isPositive = pnl >= 0;
-                      return (
-                        <View key={`${pos.conditionId}-${i}`} style={styles.positionCard}>
-                          <View style={styles.positionHeader}>
-                            <View style={[styles.posSideBadge, pos.outcome === 'No' ? styles.posSideBadgeNo : styles.posSideBadgeYes]}>
-                              <Text style={[styles.posSideBadgeText, { color: pos.outcome === 'No' ? semantic.sentiment.negative : semantic.sentiment.positive }]}>
-                                {pos.outcome?.toUpperCase() ?? 'YES'}
+                <View style={{ gap: 12 }}>
+                  {/* Open Orders */}
+                  {openOrders.length > 0 && (
+                    <View>
+                      <Text style={styles.posSecTitle}>Open Orders</Text>
+                      {openOrders.map((o) => {
+                        const sizeNum = parseFloat(o.original_size) || 0;
+                        const matched = parseFloat(o.size_matched) || 0;
+                        const priceNum = parseFloat(o.price) || 0;
+                        const cost = sizeNum * priceNum;
+                        const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
+                        return (
+                          <View key={o.id} style={styles.positionCard}>
+                            <View style={styles.positionHeader}>
+                              <View style={[styles.posSideBadge, o.side === 'BUY' ? styles.posSideBadgeYes : styles.posSideBadgeNo]}>
+                                <Text style={[styles.posSideBadgeText, { color: o.side === 'BUY' ? semantic.sentiment.positive : semantic.sentiment.negative }]}>
+                                  {o.side}
+                                </Text>
+                              </View>
+                              <Text style={styles.orderOutcomeText} numberOfLines={1}>{o.outcome || '--'}</Text>
+                              <Pressable
+                                onPress={async () => {
+                                  if (!poly.polygonAddress) return;
+                                  await cancelOrder(poly.polygonAddress, o.id);
+                                  loadOrdersAndPositions();
+                                }}
+                                style={styles.cancelBtn}>
+                                <Text style={styles.cancelBtnText}>Cancel</Text>
+                              </Pressable>
+                            </View>
+                            <View style={styles.positionStats}>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Price</Text>
+                                <Text style={styles.posStatVal}>{Math.round(priceNum * 100)}¢</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Shares</Text>
+                                <Text style={styles.posStatVal}>{sizeNum.toFixed(2)}</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Cost</Text>
+                                <Text style={styles.posStatVal}>${cost.toFixed(2)}</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Filled</Text>
+                                <Text style={styles.posStatVal}>{fillPct}%</Text>
+                              </View>
+                            </View>
+                          </View>
+                        );
+                      })}
+                    </View>
+                  )}
+
+                  {/* Positions */}
+                  {marketPositions.length > 0 && (
+                    <View>
+                      <Text style={styles.posSecTitle}>Positions</Text>
+                      {marketPositions.map((pos, i) => {
+                        const pnl = pos.cashPnl ?? 0;
+                        const isPositive = pnl >= 0;
+                        return (
+                          <View key={`${pos.conditionId}-${i}`} style={styles.positionCard}>
+                            <View style={styles.positionHeader}>
+                              <View style={[styles.posSideBadge, pos.outcome === 'No' ? styles.posSideBadgeNo : styles.posSideBadgeYes]}>
+                                <Text style={[styles.posSideBadgeText, { color: pos.outcome === 'No' ? semantic.sentiment.negative : semantic.sentiment.positive }]}>
+                                  {pos.outcome?.toUpperCase() ?? 'YES'}
+                                </Text>
+                              </View>
+                              <Text style={[styles.positionPnl, { color: isPositive ? semantic.sentiment.positive : semantic.sentiment.negative }]}>
+                                {pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}
                               </Text>
+                              <Pressable
+                                onPress={() => {
+                                  const side = pos.outcome === 'No' ? 'no' : 'yes';
+                                  const price = side === 'yes' ? (yesPrice ?? 0.5) : (noPrice ?? 0.5);
+                                  setBetSlipSide(side);
+                                  setBetSlipLabel(side === 'yes' ? 'YES' : 'NO');
+                                  setBetSlipPrice(price);
+                                  setBetSlipAmount(0);
+                                  setBetSlipMode('sell');
+                                  setOrderResult(null);
+                                  setOrderError(null);
+                                  setBetSlipVisible(true);
+                                  if (poly.polygonAddress) {
+                                    fetchClobBalance(poly.polygonAddress).then((b) => {
+                                      if (b) setClobBalance(b.balance);
+                                    });
+                                  }
+                                }}
+                                style={styles.sellBtn}>
+                                <Text style={styles.sellBtnText}>Sell</Text>
+                              </Pressable>
                             </View>
-                            <Text style={[styles.positionPnl, { color: isPositive ? semantic.sentiment.positive : semantic.sentiment.negative }]}>
-                              {pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}
-                            </Text>
+                            <View style={styles.positionStats}>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Shares</Text>
+                                <Text style={styles.posStatVal}>{pos.size?.toFixed(1) ?? '--'}</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Avg</Text>
+                                <Text style={styles.posStatVal}>{pos.avgPrice?.toFixed(2) ?? '--'}¢</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Current</Text>
+                                <Text style={styles.posStatVal}>{pos.curPrice?.toFixed(2) ?? '--'}¢</Text>
+                              </View>
+                              <View style={styles.positionStat}>
+                                <Text style={styles.posStatLabel}>Value</Text>
+                                <Text style={styles.posStatVal}>${pos.currentValue?.toFixed(2) ?? '--'}</Text>
+                              </View>
+                            </View>
                           </View>
-                          <View style={styles.positionStats}>
-                            <View style={styles.positionStat}>
-                              <Text style={styles.posStatLabel}>Shares</Text>
-                              <Text style={styles.posStatVal}>{pos.size?.toFixed(1) ?? '--'}</Text>
-                            </View>
-                            <View style={styles.positionStat}>
-                              <Text style={styles.posStatLabel}>Avg</Text>
-                              <Text style={styles.posStatVal}>{pos.avgPrice?.toFixed(2) ?? '--'}¢</Text>
-                            </View>
-                            <View style={styles.positionStat}>
-                              <Text style={styles.posStatLabel}>Current</Text>
-                              <Text style={styles.posStatVal}>{pos.curPrice?.toFixed(2) ?? '--'}¢</Text>
-                            </View>
-                            <View style={styles.positionStat}>
-                              <Text style={styles.posStatLabel}>Value</Text>
-                              <Text style={styles.posStatVal}>${pos.currentValue?.toFixed(2) ?? '--'}</Text>
-                            </View>
-                          </View>
-                        </View>
-                      );
-                    })}
-                  </View>
-                )
+                        );
+                      })}
+                    </View>
+                  )}
+
+                  {/* Empty state */}
+                  {openOrders.length === 0 && marketPositions.length === 0 && (
+                    <View style={styles.emptyState}>
+                      <MaterialIcons name="show-chart" size={32} color={semantic.text.faint} />
+                      <Text style={styles.emptyTitle}>No positions yet</Text>
+                      <Text style={styles.emptyBody}>Trade below to open a position</Text>
+                    </View>
+                  )}
+                </View>
               ) : null}
 
               {/* STATS TAB */}
               {activeTab === 'stats' ? (
                 <View style={styles.tabSection}>
-                  {/* Smart money bar */}
+                  {/* Market sentiment bar */}
                   <View style={styles.statsCard}>
-                    <Text style={styles.cardLabel}>Smart Money</Text>
+                    <Text style={styles.cardLabel}>Market Sentiment</Text>
                     <View style={styles.smartMoneyRow}>
                       <Text style={styles.smYesLabel}>YES</Text>
                       <View style={styles.smTrack}>
@@ -495,10 +586,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
                   {/* Metric row */}
                   <View style={styles.metricRow}>
-                    <View style={styles.metricBox}>
-                      <Text style={styles.metricLabel}>Traders</Text>
-                      <Text style={styles.metricValue}>--</Text>
-                    </View>
                     <View style={styles.metricBox}>
                       <Text style={styles.metricLabel}>Volume</Text>
                       <Text style={styles.metricValue}>{formatUsdCompact(detail.volume24h)}</Text>
@@ -544,20 +631,10 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
               {/* FEED TAB */}
               {activeTab === 'feed' ? (
-                <View style={styles.tabSection}>
-                  {[
-                    { source: 'Smart Money Alert', text: 'Large YES position opened — $12K notional at 61¢', time: '4m ago' },
-                    { source: 'Market Signal', text: 'Price moved +3.2% in the last 2h on elevated volume', time: '18m ago' },
-                    { source: 'Whale Watch', text: 'Top 5 traders net long YES by $28K combined', time: '1h ago' },
-                  ].map((item, i) => (
-                    <View key={i} style={styles.feedCard}>
-                      <View style={styles.feedCardHeader}>
-                        <Text style={styles.feedSource}>{item.source}</Text>
-                        <Text style={styles.feedTime}>{item.time}</Text>
-                      </View>
-                      <Text style={styles.feedText}>{item.text}</Text>
-                    </View>
-                  ))}
+                <View style={styles.emptyState}>
+                  <MaterialIcons name="rss-feed" size={32} color={semantic.text.faint} />
+                  <Text style={styles.emptyTitle}>Coming Soon</Text>
+                  <Text style={styles.emptyBody}>Live market activity and signals will appear here</Text>
                 </View>
               ) : null}
 
@@ -596,9 +673,9 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           <View style={styles.betSlipHandle} />
           <View style={styles.betSlipHeader}>
             <Text style={styles.betSlipTitle}>{detail?.question ?? ''}</Text>
-            <View style={[styles.sideBadge, betSlipSide === 'yes' ? styles.sideBadgeYes : styles.sideBadgeNo]}>
-              <Text style={[styles.sideBadgeText, { color: betSlipSide === 'yes' ? semantic.sentiment.positive : semantic.sentiment.negative }]}>
-                {betSlipLabel}
+            <View style={[styles.sideBadge, betSlipMode === 'sell' ? styles.sideBadgeNo : betSlipSide === 'yes' ? styles.sideBadgeYes : styles.sideBadgeNo]}>
+              <Text style={[styles.sideBadgeText, { color: betSlipMode === 'sell' ? semantic.sentiment.negative : betSlipSide === 'yes' ? semantic.sentiment.positive : semantic.sentiment.negative }]}>
+                {betSlipMode === 'sell' ? `SELL ${betSlipLabel}` : betSlipLabel}
               </Text>
             </View>
           </View>
@@ -703,7 +780,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                 <ActivityIndicator size="small" color={semantic.text.primary} />
               ) : (
                 <Text style={styles.confirmBtnText}>
-                  Confirm {betSlipLabel} — ${betSlipAmount}
+                  {betSlipMode === 'sell' ? 'Sell' : 'Confirm'} {betSlipLabel} — ${betSlipAmount}
                 </Text>
               )}
             </Pressable>
@@ -948,6 +1025,55 @@ const styles = StyleSheet.create({
     fontSize: tokens.fontSize.xs,
     fontWeight: '700',
     color: semantic.text.primary,
+  },
+
+  // ── Position section ──
+  posSecTitle: {
+    color: semantic.text.faint,
+    fontSize: tokens.fontSize.xxs,
+    fontFamily: 'monospace',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    marginBottom: 8,
+  },
+  orderOutcomeText: {
+    flex: 1,
+    color: semantic.text.dim,
+    fontSize: tokens.fontSize.xs,
+    fontFamily: 'monospace',
+    marginLeft: 8,
+  },
+  cancelBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: tokens.radius.xs,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surfaceRaised,
+  },
+  cancelBtnText: {
+    color: semantic.text.dim,
+    fontSize: 8,
+    fontFamily: 'monospace',
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  sellBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: 'rgba(244,88,78,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(244,88,78,0.3)',
+  },
+  sellBtnText: {
+    color: semantic.sentiment.negative,
+    fontSize: 8,
+    fontFamily: 'monospace',
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
   },
 
   // ── Stats tab ──

--- a/apps/hybrid-expo/features/predict/PredictScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictScreen.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'expo-router';
-import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomGlassNav } from '@/features/feed/components/BottomGlassNav';
 import { BOTTOM_NAV_ITEMS } from '@/features/feed/feed.mock';
 import { WalletHeaderButton } from '@/components/wallet/WalletHeaderButton';
-import { OddsFormatToggle } from '@/features/predict/components/OddsFormatToggle';
 import { fetchCuratedMarkets, fetchSportsMarkets } from '@/features/predict/predict.api';
 import type { GeopoliticsMarket, PredictFilter, SportMarket } from '@/features/predict/predict.types';
 import { useOddsFormat } from '@/hooks/useOddsFormat';
@@ -97,7 +97,9 @@ function BinaryMarketCard({ market, featured, onPress, formatOdds }: { market: G
         <Text style={styles.volText}>
           Vol 24h <Text style={styles.volTextValue}>{formatUsdCompact(market.volume24h)}</Text>
         </Text>
-        <Text style={styles.volText}>{formatDeadline(market.endDate, market.active)}</Text>
+        <Text style={styles.volText}>
+          Liq <Text style={styles.volTextValue}>{formatUsdCompact(market.liquidity)}</Text>
+        </Text>
       </View>
     </Pressable>
   );
@@ -161,13 +163,15 @@ function SportMarketCard({ market, onPress, formatOdds }: { market: SportMarket;
 
 export default function PredictScreen() {
   const router = useRouter();
-  const { format, setFormat, formatOdds } = useOddsFormat();
+  const { formatOdds } = useOddsFormat();
   const [filter, setFilter] = useState<PredictFilter>('All');
   const [geoMarkets, setGeoMarkets] = useState<GeopoliticsMarket[]>([]);
   const [eplMarkets, setEplMarkets] = useState<SportMarket[]>([]);
   const [uclMarkets, setUclMarkets] = useState<SportMarket[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [searchText, setSearchText] = useState('');
 
   async function loadPredictData() {
     setLoading(true);
@@ -197,9 +201,31 @@ export default function PredictScreen() {
     void loadPredictData();
   }, []);
 
-  const sortedGeo = useMemo(() => [...geoMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0)), [geoMarkets]);
-  const sortedEpl = useMemo(() => [...eplMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0)), [eplMarkets]);
-  const sortedUcl = useMemo(() => [...uclMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0)), [uclMarkets]);
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadPredictData();
+    setRefreshing(false);
+  }, []);
+
+  const query = searchText.trim().toLowerCase();
+
+  const sortedGeo = useMemo(() => {
+    const sorted = [...geoMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0));
+    if (!query) return sorted;
+    return sorted.filter((m) => m.question.toLowerCase().includes(query));
+  }, [geoMarkets, query]);
+
+  const sortedEpl = useMemo(() => {
+    const sorted = [...eplMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0));
+    if (!query) return sorted;
+    return sorted.filter((m) => m.title.toLowerCase().includes(query) || m.outcomes.some((o) => o.label.toLowerCase().includes(query)));
+  }, [eplMarkets, query]);
+
+  const sortedUcl = useMemo(() => {
+    const sorted = [...uclMarkets].sort((a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0));
+    if (!query) return sorted;
+    return sorted.filter((m) => m.title.toLowerCase().includes(query) || m.outcomes.some((o) => o.label.toLowerCase().includes(query)));
+  }, [uclMarkets, query]);
 
   const insets = useSafeAreaInsets();
 
@@ -215,30 +241,28 @@ export default function PredictScreen() {
       </View>
 
       <View style={styles.filterStripShell}>
-        <View style={styles.filterRow}>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.filterStrip}>
-            {FILTERS.map((value) => {
-              const active = value === filter;
-              return (
-                <Pressable
-                  key={value}
-                  onPress={() => setFilter(value)}
-                  style={[styles.filterChip, active ? styles.filterChipOn : styles.filterChipOff]}>
-                  <Text style={active ? styles.filterTextOn : styles.filterTextOff}>{value}</Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-          <View style={styles.toggleWrap}>
-            <OddsFormatToggle format={format} onFormatChange={setFormat} />
-          </View>
-        </View>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterStrip}>
+          {FILTERS.map((value) => {
+            const active = value === filter;
+            return (
+              <Pressable
+                key={value}
+                onPress={() => setFilter(value)}
+                style={[styles.filterChip, active ? styles.filterChipOn : styles.filterChipOff]}>
+                <Text style={active ? styles.filterTextOn : styles.filterTextOff}>{value}</Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
       </View>
 
-      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.feedContent}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.feedContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={semantic.text.accent} />}>
         {loading ? (
           <View style={styles.stateCard}>
             <ActivityIndicator size="small" color={semantic.text.accent} />
@@ -319,6 +343,24 @@ export default function PredictScreen() {
         ) : null}
       </ScrollView>
 
+      {/* Bottom search bar */}
+      <View style={styles.searchBar}>
+        <MaterialIcons name="search" size={16} color={semantic.text.dim} />
+        <TextInput
+          style={styles.searchInput}
+          value={searchText}
+          onChangeText={setSearchText}
+          placeholder="Search markets..."
+          placeholderTextColor={semantic.text.faint}
+          autoCorrect={false}
+        />
+        {searchText.length > 0 && (
+          <Pressable onPress={() => setSearchText('')} hitSlop={8} style={styles.searchClear}>
+            <MaterialIcons name="close" size={14} color={semantic.text.dim} />
+          </Pressable>
+        )}
+      </View>
+
       <BottomGlassNav items={BOTTOM_NAV_ITEMS} />
     </View>
   );
@@ -375,18 +417,9 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: semantic.border.muted,
   },
-  filterRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
   filterStrip: {
     gap: tokens.spacing.xs,
     paddingHorizontal: tokens.spacing.lg,
-    paddingVertical: tokens.spacing.sm,
-    flex: 1,
-  },
-  toggleWrap: {
-    paddingRight: tokens.spacing.lg,
     paddingVertical: tokens.spacing.sm,
   },
   filterChip: {
@@ -687,5 +720,31 @@ const styles = StyleSheet.create({
     fontFamily: 'monospace',
     fontWeight: '700',
     textTransform: 'uppercase',
+  },
+  // ─── search bar ───
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: tokens.spacing.lg,
+    paddingVertical: tokens.spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+  },
+  searchInput: {
+    flex: 1,
+    fontFamily: 'monospace',
+    fontSize: tokens.fontSize.sm,
+    color: semantic.text.primary,
+    padding: 0,
+  },
+  searchClear: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: semantic.background.surfaceRaised,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -321,9 +321,9 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
         <Text style={styles.headerTitle} numberOfLines={2}>
           {detail?.title ?? 'Loading...'}
         </Text>
-        <View style={styles.avatarRing}>
+        <Pressable onPress={() => router.push('/predict-profile')} style={styles.avatarRing}>
           <View style={styles.avatarInner} />
-        </View>
+        </Pressable>
       </View>
 
       {/* ── LOADING / ERROR ── */}

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -114,6 +115,7 @@ function outcomeColor(outcome: SportOutcomeDetail, isLead: boolean): string {
 export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScreenProps) {
   const router = useRouter();
   const poly = usePolymarketWallet();
+  const { width: screenWidth } = useWindowDimensions();
   const [detail, setDetail] = useState<SportMarketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -367,7 +369,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                         onPress={() => setInterval(iv)}
                         style={[styles.intervalChip, interval === iv && styles.intervalChipActive]}>
                         <Text style={[styles.intervalText, interval === iv && styles.intervalTextActive]}>
-                          {iv === '1h' ? '1D' : '1W'}
+                          {iv === '1h' ? '1H' : '1D'}
                         </Text>
                       </Pressable>
                     ))}
@@ -399,7 +401,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                 {historyLoading ? (
                   <View style={styles.chartSkeleton} />
                 ) : history.length >= 2 ? (
-                  <Sparkline points={history} width={315} height={64} color={sparkColor} />
+                  <Sparkline points={history} width={screenWidth - 64} height={64} color={sparkColor} />
                 ) : (
                   <View style={[styles.chartSkeleton, { opacity: 0.4 }]} />
                 )}

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -61,6 +61,7 @@ function mapGeopoliticsMarket(row: unknown): GeopoliticsMarket | null {
     yesPrice: toNumber(market.yesPrice),
     noPrice: toNumber(market.noPrice),
     volume24h: toNumber(market.volume24h),
+    liquidity: toNumber(market.liquidityNum ?? market.liquidity),
     endDate: typeof market.endDate === 'string' ? market.endDate : null,
     active: typeof market.active === 'boolean' ? market.active : null,
     image: typeof market.image === 'string' ? market.image : null,

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -157,6 +157,7 @@ function mapGeopoliticsMarketDetail(row: unknown): GeopoliticsMarketDetail | nul
     outcomePrices,
     clobTokenIds: toStringArray(market.clobTokenIds),
     image: typeof market.image === 'string' ? market.image : null,
+    negRisk: market.negRisk === true,
   };
 }
 

--- a/apps/hybrid-expo/features/predict/predict.types.ts
+++ b/apps/hybrid-expo/features/predict/predict.types.ts
@@ -77,6 +77,7 @@ export interface GeopoliticsMarketDetail {
   outcomePrices: number[];
   clobTokenIds: string[];
   image: string | null;
+  negRisk: boolean;
 }
 
 export interface SportOutcomeDetail extends SportOutcome {

--- a/apps/hybrid-expo/features/predict/predict.types.ts
+++ b/apps/hybrid-expo/features/predict/predict.types.ts
@@ -38,6 +38,7 @@ export interface GeopoliticsMarket {
   yesPrice: number | null;
   noPrice: number | null;
   volume24h: number | null;
+  liquidity: number | null;
   endDate: string | null;
   active: boolean | null;
   image: string | null;


### PR DESCRIPTION
## Summary
- **P0 fixes**: SELL functionality, open orders in binary detail, post-order refresh, negRisk exchange address fix, fake feed → coming soon, "Smart Money" → "Market Sentiment", avatar navigation to profile
- **P1 improvements**: search bar, pull-to-refresh, responsive sparkline width, interval label fix, deposit CTA at $0 balance, session expiry banner (no wallet nuke), amount presets ($5/$10/$25/$50), trade history in profile

Closes #37 (P0 + P1 items, P2 deferred, P-16 split to separate issue).

## Test plan
- [ ] Open Predict tab — search filters across all categories, pull-to-refresh reloads
- [ ] Binary market detail — sell button on positions, open orders with cancel, session banner on expiry
- [ ] Sport market detail — avatar navigates to profile, interval labels correct (1H/1D)
- [ ] Bet slip — amount presets work, deposit CTA shows at $0, sell mode shows SELL badge
- [ ] Profile — trade history section populated from fetchActivity()
- [ ] Sparkline adapts to screen width on different devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)