### PR TITLE
feat(feed): production readiness (F0 + F1)

### DIFF
--- a/apps/hybrid-expo/features/feed/FeedScreen.tsx
+++ b/apps/hybrid-expo/features/feed/FeedScreen.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomGlassNav } from '@/features/feed/components/BottomGlassNav';
 import { FeedHeader } from '@/features/feed/components/FeedHeader';
 import { FeedList } from '@/features/feed/components/FeedList';
+import { FeedSkeleton } from '@/features/feed/components/FeedSkeleton';
 import { NarrativeSheet } from '@/features/feed/components/NarrativeSheet';
 import type { NarrativeSheetItem } from '@/features/feed/components/NarrativeSheet';
 import { fetchFeedItems } from '@/features/feed/feed.api';
@@ -11,37 +12,90 @@ import { BOTTOM_NAV_ITEMS } from '@/features/feed/feed.mock';
 import type { FeedItem } from '@/features/feed/feed.types';
 import { semantic, tokens } from '@/theme';
 
+const PAGE_SIZE = 20;
+const AUTO_REFRESH_MS = 5 * 60 * 1000; // 5 minutes
+const TIMEAGO_TICK_MS = 60 * 1000; // 1 minute
+
 export default function FeedScreen() {
   const [items, setItems] = useState<FeedItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [sheetItem, setSheetItem] = useState<NarrativeSheetItem | null>(null);
+  const [, setTick] = useState(0); // force re-render for live timeAgo
 
-  async function loadFeed(): Promise<void> {
-    setIsLoading(true);
+  const loadingMoreRef = useRef(false);
+
+  async function loadFeed(silent = false): Promise<void> {
+    if (!silent) setIsLoading(true);
     setErrorMessage(null);
 
     try {
-      const nextItems = await fetchFeedItems(20);
+      const nextItems = await fetchFeedItems(PAGE_SIZE, 0);
       setItems(nextItems);
+      setHasMore(nextItems.length >= PAGE_SIZE);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to load feed';
-      setErrorMessage(message);
-      setItems([]);
+      if (!silent) setErrorMessage(message);
     } finally {
-      setIsLoading(false);
+      if (!silent) setIsLoading(false);
     }
   }
 
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const nextItems = await fetchFeedItems(PAGE_SIZE, 0);
+      setItems(nextItems);
+      setHasMore(nextItems.length >= PAGE_SIZE);
+    } catch {
+      // silent fail on pull-to-refresh
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const handleEndReached = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+
+    try {
+      const moreItems = await fetchFeedItems(PAGE_SIZE, items.length);
+      if (moreItems.length < PAGE_SIZE) setHasMore(false);
+      setItems((prev) => [...prev, ...moreItems]);
+    } catch {
+      // silent fail on pagination
+    } finally {
+      setLoadingMore(false);
+      loadingMoreRef.current = false;
+    }
+  }, [hasMore, items.length]);
+
+  // Initial load
   useEffect(() => {
     void loadFeed();
+  }, []);
+
+  // Auto-refresh every 5 minutes (silent)
+  useEffect(() => {
+    const id = setInterval(() => void loadFeed(true), AUTO_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Tick every minute to update timeAgo displays
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), TIMEAGO_TICK_MS);
+    return () => clearInterval(id);
   }, []);
 
   const handleCardPress = useCallback((item: FeedItem) => {
     setSheetItem({
       id: item.id,
       category: item.category,
-      timeAgo: item.timeAgo,
+      createdAt: item.createdAt,
       actions: item.actions,
     });
   }, []);
@@ -57,12 +111,7 @@ export default function FeedScreen() {
       <FeedHeader />
 
       {isLoading ? (
-        <View style={styles.bodyFill}>
-          <View style={styles.stateWrap}>
-            <ActivityIndicator size="small" color={semantic.text.accent} />
-            <Text style={styles.stateText}>Loading feed...</Text>
-          </View>
-        </View>
+        <FeedSkeleton />
       ) : null}
 
       {!isLoading && errorMessage ? (
@@ -87,7 +136,14 @@ export default function FeedScreen() {
       ) : null}
 
       {!isLoading && !errorMessage && items.length > 0 ? (
-        <FeedList items={items} onCardPress={handleCardPress} />
+        <FeedList
+          items={items}
+          onCardPress={handleCardPress}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          onEndReached={handleEndReached}
+          loadingMore={loadingMore}
+        />
       ) : null}
 
       <BottomGlassNav items={BOTTOM_NAV_ITEMS} />

--- a/apps/hybrid-expo/features/feed/components/BottomGlassNav.tsx
+++ b/apps/hybrid-expo/features/feed/components/BottomGlassNav.tsx
@@ -18,7 +18,7 @@ export function BottomGlassNav({ items }: BottomGlassNavProps) {
     if (route === '/') {
       return pathname === '/' || pathname === '/index';
     }
-    return pathname === route;
+    return pathname === route || pathname.startsWith(`${route}/`);
   }
 
   return (

--- a/apps/hybrid-expo/features/feed/components/FeedCard.tsx
+++ b/apps/hybrid-expo/features/feed/components/FeedCard.tsx
@@ -1,18 +1,8 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { CATEGORY_STYLES, DEFAULT_CATEGORY_STYLE } from '@/features/feed/feed.constants';
+import { toRelativeTime } from '@/features/feed/feed.api';
 import type { FeedItem } from '@/features/feed/feed.types';
 import { tokens } from '@/theme';
-
-// Category pill colors — spec-matched, not derived from theme tokens
-// (these are intentionally narrow, not in semantic.ts)
-const CATEGORY_STYLES: Record<
-  string,
-  { backgroundColor: string; color: string }
-> = {
-  Geopolitics: { backgroundColor: 'rgba(199,183,112,0.12)', color: '#c7b770' },
-  Macro:       { backgroundColor: 'rgba(90,88,64,0.30)',    color: '#8A7A50' },
-  Markets:     { backgroundColor: 'rgba(74,140,111,0.12)',  color: '#4A8C6F' },
-  Tech:        { backgroundColor: 'rgba(100,120,200,0.12)', color: '#7A9AC8' },
-};
 
 interface FeedCardProps {
   item: FeedItem;
@@ -20,7 +10,8 @@ interface FeedCardProps {
 }
 
 export function FeedCard({ item, onPress }: FeedCardProps) {
-  const catStyle = CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES.Macro;
+  const catStyle = CATEGORY_STYLES[item.category] ?? DEFAULT_CATEGORY_STYLE;
+  const timeAgo = toRelativeTime(item.createdAt);
 
   return (
     <Pressable
@@ -31,7 +22,7 @@ export function FeedCard({ item, onPress }: FeedCardProps) {
       ]}
       onPress={() => onPress(item)}
       accessibilityRole="button"
-      accessibilityLabel={`${item.category} narrative from ${item.timeAgo}`}
+      accessibilityLabel={`${item.category} narrative from ${timeAgo}`}
     >
       <View style={styles.body}>
         {/* Meta row: category pill + time */}
@@ -41,11 +32,16 @@ export function FeedCard({ item, onPress }: FeedCardProps) {
               {item.category.toUpperCase()}
             </Text>
           </View>
-          <Text style={styles.timeText}>{item.timeAgo}</Text>
+          <Text style={styles.timeText}>{timeAgo}</Text>
         </View>
 
+        {/* Headline */}
+        <Text style={styles.headlineText} numberOfLines={2}>{item.headline}</Text>
+
         {/* Body text */}
-        <Text style={styles.bodyText}>{item.description}</Text>
+        {item.description ? (
+          <Text style={styles.bodyText} numberOfLines={3}>{item.description}</Text>
+        ) : null}
       </View>
     </Pressable>
   );
@@ -95,10 +91,17 @@ const styles = StyleSheet.create({
     fontFamily: 'monospace',
     color: '#5A5840',
   },
-  bodyText: {
+  headlineText: {
     fontSize: tokens.fontSize.md,    // 14
-    color: 'rgba(208,202,168,0.88)',
-    lineHeight: 21,
+    color: 'rgba(208,202,168,0.95)',
+    lineHeight: 20,
     letterSpacing: -0.2,
+    fontWeight: '600',
+  },
+  bodyText: {
+    fontSize: tokens.fontSize.sm,    // 12
+    color: 'rgba(208,202,168,0.65)',
+    lineHeight: 18,
+    letterSpacing: -0.1,
   },
 });

--- a/apps/hybrid-expo/features/feed/components/FeedList.tsx
+++ b/apps/hybrid-expo/features/feed/components/FeedList.tsx
@@ -1,14 +1,18 @@
-import { FlatList, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, View } from 'react-native';
 import { FeedCard } from '@/features/feed/components/FeedCard';
 import type { FeedItem } from '@/features/feed/feed.types';
-import { tokens } from '@/theme';
+import { semantic, tokens } from '@/theme';
 
 interface FeedListProps {
   items: FeedItem[];
   onCardPress: (item: FeedItem) => void;
+  refreshing: boolean;
+  onRefresh: () => void;
+  onEndReached: () => void;
+  loadingMore: boolean;
 }
 
-export function FeedList({ items, onCardPress }: FeedListProps) {
+export function FeedList({ items, onCardPress, refreshing, onRefresh, onEndReached, loadingMore }: FeedListProps) {
   return (
     <FlatList
       data={items}
@@ -17,6 +21,23 @@ export function FeedList({ items, onCardPress }: FeedListProps) {
       showsVerticalScrollIndicator={false}
       contentContainerStyle={styles.content}
       ItemSeparatorComponent={() => <View style={styles.separator} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor={semantic.text.accent}
+          colors={[semantic.text.accent]}
+        />
+      }
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.4}
+      ListFooterComponent={
+        loadingMore ? (
+          <View style={styles.footer}>
+            <ActivityIndicator size="small" color={semantic.text.accent} />
+          </View>
+        ) : null
+      }
     />
   );
 }
@@ -29,5 +50,9 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: tokens.spacing.md,
+  },
+  footer: {
+    paddingVertical: tokens.spacing.lg,
+    alignItems: 'center',
   },
 });

--- a/apps/hybrid-expo/features/feed/components/FeedSkeleton.tsx
+++ b/apps/hybrid-expo/features/feed/components/FeedSkeleton.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { tokens } from '@/theme';
+
+function SkeletonCard() {
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const anim = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+      ])
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View style={[styles.card, { opacity }]}>
+      <View style={styles.metaRow}>
+        <View style={styles.pillPlaceholder} />
+        <View style={styles.timePlaceholder} />
+      </View>
+      <View style={styles.headlinePlaceholder} />
+      <View style={styles.bodyPlaceholder} />
+      <View style={styles.bodyPlaceholderShort} />
+    </Animated.View>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <View style={styles.container}>
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+      <SkeletonCard />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: tokens.spacing.lg,
+    paddingTop: tokens.spacing.md,
+    gap: tokens.spacing.md,
+  },
+  card: {
+    backgroundColor: '#222318',
+    borderWidth: 1,
+    borderColor: '#302F20',
+    borderRadius: tokens.radius.md,
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 13,
+    gap: 10,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  pillPlaceholder: {
+    width: 64,
+    height: 18,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: '#302F20',
+  },
+  timePlaceholder: {
+    width: 40,
+    height: 12,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: '#302F20',
+  },
+  headlinePlaceholder: {
+    width: '85%',
+    height: 14,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: '#302F20',
+  },
+  bodyPlaceholder: {
+    width: '100%',
+    height: 12,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: '#2A2B1E',
+  },
+  bodyPlaceholderShort: {
+    width: '60%',
+    height: 12,
+    borderRadius: tokens.radius.xs,
+    backgroundColor: '#2A2B1E',
+  },
+});

--- a/apps/hybrid-expo/features/feed/components/NarrativeSheet.tsx
+++ b/apps/hybrid-expo/features/feed/components/NarrativeSheet.tsx
@@ -12,7 +12,8 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { fetchNarrativeDetail, fetchPredictMarket, extractSport } from '@/features/feed/feed.api';
+import { fetchNarrativeDetail, fetchPredictMarket, extractSport, toRelativeTime } from '@/features/feed/feed.api';
+import { CATEGORY_STYLES, DEFAULT_CATEGORY_STYLE } from '@/features/feed/feed.constants';
 import type { NarrativeAction } from '@/features/feed/feed.types';
 import type { PredictMarketData } from '@/features/feed/feed.api';
 import type { FeedCategory } from '@/features/feed/feed.types';
@@ -20,14 +21,6 @@ import { tokens } from '@/theme';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const SHEET_HEIGHT = Math.round(SCREEN_HEIGHT * 0.75);
-
-// Category pill colors — same as FeedCard
-const CATEGORY_STYLES: Record<string, { backgroundColor: string; color: string }> = {
-  Geopolitics: { backgroundColor: 'rgba(199,183,112,0.12)', color: '#c7b770' },
-  Macro:       { backgroundColor: 'rgba(90,88,64,0.30)',    color: '#8A7A50' },
-  Markets:     { backgroundColor: 'rgba(74,140,111,0.12)',  color: '#4A8C6F' },
-  Tech:        { backgroundColor: 'rgba(100,120,200,0.12)', color: '#7A9AC8' },
-};
 
 function formatVolume(v: number | null): string {
   if (!v || !Number.isFinite(v)) return '—';
@@ -474,7 +467,7 @@ const predictStyles = StyleSheet.create({
 export interface NarrativeSheetItem {
   id: string;
   category: FeedCategory;
-  timeAgo: string;
+  createdAt: string;
   actions: NarrativeAction[];
 }
 
@@ -552,8 +545,8 @@ export function NarrativeSheet({ item, onClose }: NarrativeSheetProps) {
   ).current;
 
   const catStyle = item
-    ? (CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES.Macro)
-    : CATEGORY_STYLES.Macro;
+    ? (CATEGORY_STYLES[item.category] ?? DEFAULT_CATEGORY_STYLE)
+    : DEFAULT_CATEGORY_STYLE;
 
   // Collect up to 3 predict actions with slugs
   const predictActions = (item?.actions ?? [])
@@ -594,7 +587,7 @@ export function NarrativeSheet({ item, onClose }: NarrativeSheetProps) {
                 {item?.category.toUpperCase() ?? ''}
               </Text>
             </View>
-            <Text style={styles.timeText}>{item?.timeAgo ?? ''}</Text>
+            <Text style={styles.timeText}>{item?.createdAt ? toRelativeTime(item.createdAt) : ''}</Text>
           </View>
 
           {/* Full text */}

--- a/apps/hybrid-expo/features/feed/feed.api.ts
+++ b/apps/hybrid-expo/features/feed/feed.api.ts
@@ -34,7 +34,7 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 
-function toRelativeTime(iso: string): string {
+export function toRelativeTime(iso: string): string {
   const createdAt = new Date(iso).getTime();
   if (Number.isNaN(createdAt)) return 'now';
 
@@ -67,21 +67,48 @@ function parseActions(raw: unknown): NarrativeAction[] {
   return result;
 }
 
+function extractHeadline(content: string): { headline: string; body: string } {
+  const trimmed = content.trim();
+  // Try splitting on first period or newline to get a headline
+  const periodIdx = trimmed.indexOf('. ');
+  const newlineIdx = trimmed.indexOf('\n');
+  let splitIdx = -1;
+  if (periodIdx > 0 && periodIdx < 120) splitIdx = periodIdx + 1;
+  else if (newlineIdx > 0 && newlineIdx < 120) splitIdx = newlineIdx;
+
+  if (splitIdx > 0) {
+    return {
+      headline: trimmed.slice(0, splitIdx).trim(),
+      body: trimmed.slice(splitIdx).trim(),
+    };
+  }
+  // If no good split point, use first 80 chars as headline
+  if (trimmed.length > 80) {
+    const spaceIdx = trimmed.lastIndexOf(' ', 80);
+    const cut = spaceIdx > 40 ? spaceIdx : 80;
+    return { headline: trimmed.slice(0, cut).trim(), body: trimmed.slice(cut).trim() };
+  }
+  return { headline: trimmed, body: '' };
+}
+
 function mapNarrativeToFeedItem(item: PublishedNarrativeListItem, index: number): FeedItem {
+  const raw = item.content_small?.trim() ?? '';
+  const { headline, body } = extractHeadline(raw);
   return {
     id: item.id,
     category: item.tags?.[0] ?? 'macro',
-    timeAgo: toRelativeTime(item.created_at),
-    description: item.content_small?.trim() ?? '',
+    createdAt: item.created_at,
+    headline,
+    description: body,
     isTop: index === 0,
     actions: parseActions(item.actions),
   };
 }
 
-export async function fetchFeedItems(limit = 20): Promise<FeedItem[]> {
-  const clamped = clamp(limit, 1, 20);
+export async function fetchFeedItems(limit = 20, offset = 0): Promise<FeedItem[]> {
+  const clamped = clamp(limit, 1, 50);
   const baseUrl = resolveApiBaseUrl();
-  const response = await fetch(`${baseUrl}/narratives?limit=${clamped}`);
+  const response = await fetch(`${baseUrl}/narratives?limit=${clamped}&offset=${offset}`);
 
   if (!response.ok) {
     throw new Error(`Feed request failed (${response.status})`);

--- a/apps/hybrid-expo/features/feed/feed.constants.ts
+++ b/apps/hybrid-expo/features/feed/feed.constants.ts
@@ -1,0 +1,18 @@
+// Category pill colors — shared between FeedCard and NarrativeSheet
+export const CATEGORY_STYLES: Record<
+  string,
+  { backgroundColor: string; color: string }
+> = {
+  Geopolitics: { backgroundColor: 'rgba(199,183,112,0.12)', color: '#c7b770' },
+  Macro:       { backgroundColor: 'rgba(90,88,64,0.30)',    color: '#8A7A50' },
+  Markets:     { backgroundColor: 'rgba(74,140,111,0.12)',  color: '#4A8C6F' },
+  Tech:        { backgroundColor: 'rgba(100,120,200,0.12)', color: '#7A9AC8' },
+  Crypto:      { backgroundColor: 'rgba(245,158,11,0.12)',  color: '#F59E0B' },
+  AI:          { backgroundColor: 'rgba(168,85,247,0.12)',  color: '#A855F7' },
+  Energy:      { backgroundColor: 'rgba(34,197,94,0.12)',   color: '#22C55E' },
+  Conflict:    { backgroundColor: 'rgba(239,68,68,0.12)',   color: '#EF4444' },
+  Trade:       { backgroundColor: 'rgba(59,130,246,0.12)',  color: '#3B82F6' },
+  Climate:     { backgroundColor: 'rgba(6,182,212,0.12)',   color: '#06B6D4' },
+};
+
+export const DEFAULT_CATEGORY_STYLE = CATEGORY_STYLES.Macro;

--- a/apps/hybrid-expo/features/feed/feed.types.ts
+++ b/apps/hybrid-expo/features/feed/feed.types.ts
@@ -17,7 +17,8 @@ export interface NarrativeAction {
 export interface FeedItem {
   id: string;
   category: FeedCategory;
-  timeAgo: string;
+  createdAt: string; // ISO timestamp — timeAgo computed dynamically
+  headline: string;
   description: string;
   isTop?: boolean;
   actions: NarrativeAction[];

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -130,11 +130,13 @@ app.get('/health', (c) => {
 // GET /narratives
 app.get('/narratives', async (c) => {
   const rawLimit = parseInt(c.req.query('limit') ?? '20', 10)
-  const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 20)
+  const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 50)
+  const rawOffset = parseInt(c.req.query('offset') ?? '0', 10)
+  const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
 
   try {
     const res = await supabaseFetch(
-      `published_narratives?select=id,narrative_id,content_small,tags,priority,actions,thread_id,created_at&order=created_at.desc,priority.desc&limit=${limit}`
+      `published_narratives?select=id,narrative_id,content_small,tags,priority,actions,thread_id,created_at&order=created_at.desc,priority.desc&limit=${limit}&offset=${offset}`
     )
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- **Pull-to-refresh** (F-01): RefreshControl on FeedList
- **Auto-refresh** (F-05): Silent poll every 5 minutes
- **Pagination** (F-06): Infinite scroll with offset-based pagination, backend cap raised to 50
- **Card visual hierarchy** (F-07): Headline extracted and rendered bold/larger, body dimmer/smaller
- **Live timeAgo** (F-09): Stores `createdAt`, computes relative time at render, ticks every minute
- **Nav highlighting** (F-10): `startsWith` for sub-route matching in BottomGlassNav
- **Category colors** (F-12): Shared constant with 10 categories (added Crypto, AI, Energy, Conflict, Trade, Climate)
- **Loading skeletons** (F-13): Animated placeholder cards replace "Loading feed..." text

Closes #36

## Test plan
- [ ] Pull-to-refresh triggers reload, shows spinner
- [ ] Feed auto-refreshes after 5 min (check network tab)
- [ ] Scroll to bottom loads next page
- [ ] Cards show headline (bold) + body (dimmer)
- [ ] timeAgo updates without page refresh
- [ ] Tapping Predict → market detail → Predict tab stays highlighted
- [ ] New categories (Crypto, AI, etc.) render correct pill colors
- [ ] Initial load shows skeleton cards, not text

🤖 Generated with [Claude Code](https://claude.com/claude-code)