### PR TITLE
fix(perps): proxy Pacifica markets through API

### DIFF
--- a/apps/hybrid-expo/features/perps/TradeListScreen.tsx
+++ b/apps/hybrid-expo/features/perps/TradeListScreen.tsx
@@ -1,7 +1,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { fetchWithTimeout } from '@/lib/api';
+import { fetchWithTimeout, resolveApiBaseUrl } from '@/lib/api';
 import {
   ActivityIndicator,
   Pressable,
@@ -30,19 +30,20 @@ type TradeView = 'markets' | 'profile';
 // In-memory SVG cache — persists for the app session
 const svgCache = new Map<string, string | null>();
 
-const TokenIcon = memo(function TokenIcon({ symbol }: { symbol: string }) {
+const TokenIcon = memo(function TokenIcon({ symbol, iconPath }: { symbol: string; iconPath: string }) {
   const base = symbol.split('-')[0];
-  const uri = `https://app.pacifica.fi/imgs/tokens/${base}.svg`;
-  const [xml, setXml] = useState<string | null>(svgCache.get(base) ?? null);
-  const [failed, setFailed] = useState(svgCache.get(base) === null && svgCache.has(base));
+  const cacheKey = iconPath || base;
+  const uri = `${resolveApiBaseUrl()}${iconPath}`;
+  const [xml, setXml] = useState<string | null>(svgCache.get(cacheKey) ?? null);
+  const [failed, setFailed] = useState(svgCache.get(cacheKey) === null && svgCache.has(cacheKey));
 
   useEffect(() => {
-    if (svgCache.has(base)) return;
+    if (svgCache.has(cacheKey)) return;
     fetchWithTimeout(uri)
       .then((res) => (res.ok ? res.text() : Promise.reject()))
-      .then((text) => { svgCache.set(base, text); setXml(text); })
-      .catch(() => { svgCache.set(base, null); setFailed(true); });
-  }, [base, uri]);
+      .then((text) => { svgCache.set(cacheKey, text); setXml(text); })
+      .catch(() => { svgCache.set(cacheKey, null); setFailed(true); });
+  }, [cacheKey, uri]);
 
   if (failed || !xml) {
     return (
@@ -69,10 +70,11 @@ export function TradeListScreen() {
   const [view, setView] = useState<TradeView>(viewParam === 'profile' ? 'profile' : 'markets');
   const [searchText, setSearchText] = useState('');
 
-  const filteredMarkets = markets.filter((m) => {
-    if (!searchText.trim()) return true;
-    return m.symbol.toLowerCase().includes(searchText.trim().toLowerCase());
-  });
+  const filteredMarkets = useMemo(() => {
+    const query = searchText.trim().toLowerCase();
+    if (!query) return markets;
+    return markets.filter((m) => m.symbol.toLowerCase().includes(query));
+  }, [markets, searchText]);
   async function loadMarkets() {
     setLoading(true);
     setErrorMessage(null);
@@ -151,7 +153,7 @@ export function TradeListScreen() {
                       key={market.symbol}
                       style={({ pressed }) => [styles.tableRow, pressed && styles.tableRowPressed]}
                       onPress={() => goToMarket(market.symbol)}>
-                      <TokenIcon symbol={market.symbol} />
+                      <TokenIcon symbol={market.symbol} iconPath={market.iconPath} />
                       <View style={styles.symCol}>
                         <Text style={styles.rowSym}>{market.symbol} <Text style={styles.rowLev}>{market.maxLeverage}×</Text></Text>
                       </View>

--- a/apps/hybrid-expo/features/perps/perps.api.ts
+++ b/apps/hybrid-expo/features/perps/perps.api.ts
@@ -11,7 +11,7 @@ import type {
   RawPosition,
   RawPriceInfo,
 } from '@/features/perps/perps.types';
-import { fetchWithTimeout } from '@/lib/api';
+import { fetchWithTimeout, resolveApiBaseUrl } from '@/lib/api';
 
 import bs58 from 'bs58';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
@@ -123,41 +123,13 @@ async function pacificGet<T>(path: string): Promise<T> {
 }
 
 export async function fetchPerpsMarkets(): Promise<PerpsMarket[]> {
-  const [markets, prices] = await Promise.all([
-    pacificGet<RawMarketInfo[]>('/info'),
-    pacificGet<RawPriceInfo[]>('/info/prices'),
-  ]);
+  const baseUrl = resolveApiBaseUrl();
+  const res = await fetchWithTimeout(`${baseUrl}/perps/pacifica/markets`);
+  if (!res.ok) throw new Error(`Markets unavailable (${res.status})`);
 
-  const priceMap = new Map(prices.map((p) => [p.symbol, p]));
-
-  return markets
-    .filter((m) => m.instrument_type === 'perpetual')
-    .map((m): PerpsMarket | null => {
-      const p = priceMap.get(m.symbol);
-      if (!p) return null;
-
-      const mark = safeNum(p.mark);
-      const yesterday = safeNum(p.yesterday_price);
-      const change24h = yesterday > 0 ? ((mark - yesterday) / yesterday) * 100 : 0;
-
-      return {
-        symbol: m.symbol,
-        maxLeverage: m.max_leverage,
-        tickSize: m.tick_size,
-        lotSize: m.lot_size,
-        minOrderSize: m.min_order_size,
-        markPrice: mark,
-        oraclePrice: safeNum(p.oracle),
-        midPrice: safeNum(p.mid),
-        fundingRate: safeNum(p.funding),
-        openInterest: safeNum(p.open_interest),
-        volume24h: safeNum(p.volume_24h),
-        change24h,
-        yesterdayPrice: yesterday,
-      };
-    })
-    .filter((m): m is PerpsMarket => m !== null)
-    .sort((a, b) => b.volume24h - a.volume24h);
+  const payload = await res.json();
+  if (!Array.isArray(payload)) throw new Error('Invalid markets response');
+  return payload as PerpsMarket[];
 }
 
 export async function fetchPerpsPositions(address: string): Promise<PerpsPosition[]> {

--- a/apps/hybrid-expo/features/perps/perps.types.ts
+++ b/apps/hybrid-expo/features/perps/perps.types.ts
@@ -67,6 +67,7 @@ export interface PerpsMarket {
   volume24h: number;      // USD
   change24h: number;      // percentage, e.g. 2.14 means +2.14%
   yesterdayPrice: number;
+  iconPath: string;        // API-relative cached SVG path
 }
 
 export interface PerpsPosition {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -7,6 +7,7 @@ import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { serve } from '@hono/node-server'
 import { clobRoutes } from './clob.js'
+import { pacificaRoutes } from './pacifica.js'
 import { CURATED_GEOPOLITICS_SLUGS, deriveCategoryFromText } from './curated.js'
 import type { SupportedSport } from './curated.js'
 import {
@@ -207,6 +208,9 @@ app.use('*', logger())
 
 // --- CLOB routes (Polymarket Builder) ---
 app.route('/clob', clobRoutes)
+
+// --- Pacifica perps proxy routes ---
+app.route('/perps/pacifica', pacificaRoutes)
 
 // GET /health
 app.get('/health', (c) => {

--- a/packages/api/src/pacifica.ts
+++ b/packages/api/src/pacifica.ts
@@ -1,0 +1,164 @@
+import { Hono } from 'hono'
+
+const PACIFICA_API_BASE = process.env.PACIFICA_API_BASE || 'https://api.pacifica.fi/api/v1'
+const PACIFICA_ICON_BASE = process.env.PACIFICA_ICON_BASE || 'https://app.pacifica.fi/imgs/tokens'
+const MARKETS_CACHE_TTL_MS = 15_000
+const ICON_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+const marketCache = new Map<string, { data: unknown; expiresAt: number }>()
+const iconCache = new Map<string, { svg: string | null; expiresAt: number }>()
+
+interface RawMarketInfo {
+  symbol: string
+  tick_size: string
+  lot_size: string
+  max_leverage: number
+  min_order_size: string
+  instrument_type: string
+}
+
+interface RawPriceInfo {
+  symbol: string
+  oracle: string
+  mark: string
+  mid: string
+  funding: string
+  open_interest: string
+  volume_24h: string
+  yesterday_price: string
+}
+
+interface PacificaMarket {
+  symbol: string
+  maxLeverage: number
+  tickSize: string
+  lotSize: string
+  minOrderSize: string
+  markPrice: number
+  oraclePrice: number
+  midPrice: number
+  fundingRate: number
+  openInterest: number
+  volume24h: number
+  change24h: number
+  yesterdayPrice: number
+  iconPath: string
+}
+
+function safeNumber(value: unknown): number {
+  const parsed = Number.parseFloat(String(value))
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function tokenBase(symbol: string): string {
+  return symbol.split('-')[0].replace(/[^A-Za-z0-9_]/g, '').toUpperCase()
+}
+
+async function pacificaGetJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${PACIFICA_API_BASE}${path}`)
+  if (!res.ok) throw new Error(`Pacifica ${path} failed (${res.status})`)
+
+  const json = await res.json() as { success?: boolean; data?: T; error?: string; message?: string }
+  if (json.success === false) {
+    throw new Error(json.error ?? json.message ?? `Pacifica ${path} failed`)
+  }
+  return json.data as T
+}
+
+async function getMarkets(): Promise<PacificaMarket[]> {
+  const cacheKey = 'markets'
+  const now = Date.now()
+  const cached = marketCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) return cached.data as PacificaMarket[]
+
+  const [markets, prices] = await Promise.all([
+    pacificaGetJson<RawMarketInfo[]>('/info'),
+    pacificaGetJson<RawPriceInfo[]>('/info/prices'),
+  ])
+  const priceMap = new Map(prices.map((price) => [price.symbol, price]))
+
+  const data = markets
+    .filter((market) => market.instrument_type === 'perpetual')
+    .map((market): PacificaMarket | null => {
+      const price = priceMap.get(market.symbol)
+      if (!price) return null
+
+      const markPrice = safeNumber(price.mark)
+      const yesterdayPrice = safeNumber(price.yesterday_price)
+      const change24h = yesterdayPrice > 0 ? ((markPrice - yesterdayPrice) / yesterdayPrice) * 100 : 0
+      const iconBase = tokenBase(market.symbol)
+
+      return {
+        symbol: market.symbol,
+        maxLeverage: market.max_leverage,
+        tickSize: market.tick_size,
+        lotSize: market.lot_size,
+        minOrderSize: market.min_order_size,
+        markPrice,
+        oraclePrice: safeNumber(price.oracle),
+        midPrice: safeNumber(price.mid),
+        fundingRate: safeNumber(price.funding),
+        openInterest: safeNumber(price.open_interest),
+        volume24h: safeNumber(price.volume_24h),
+        change24h,
+        yesterdayPrice,
+        iconPath: `/perps/pacifica/icons/${encodeURIComponent(iconBase)}.svg`,
+      }
+    })
+    .filter((market): market is PacificaMarket => market !== null)
+    .sort((a, b) => b.volume24h - a.volume24h)
+
+  marketCache.set(cacheKey, { data, expiresAt: now + MARKETS_CACHE_TTL_MS })
+  return data
+}
+
+export const pacificaRoutes = new Hono()
+
+// GET /perps/pacifica/markets
+pacificaRoutes.get('/markets', async (c) => {
+  try {
+    return c.json(await getMarkets())
+  } catch (err) {
+    console.error('[api] Pacifica markets unavailable:', err instanceof Error ? err.message : err)
+    return c.json({ error: 'Pacifica markets unavailable' }, 502)
+  }
+})
+
+// GET /perps/pacifica/icons/:file — cached SVG proxy to avoid client fan-out to Pacifica.
+pacificaRoutes.get('/icons/:file', async (c) => {
+  const rawFile = c.req.param('file')
+  const base = rawFile.replace(/\.svg$/i, '').replace(/[^A-Za-z0-9_]/g, '').toUpperCase()
+  if (!base) return c.json({ error: 'Invalid icon' }, 400)
+
+  const now = Date.now()
+  const cached = iconCache.get(base)
+  if (cached && cached.expiresAt > now) {
+    if (cached.svg === null) return c.body(null, 404)
+    return new Response(cached.svg, {
+      headers: {
+        'Content-Type': 'image/svg+xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400',
+      },
+    })
+  }
+
+  try {
+    const res = await fetch(`${PACIFICA_ICON_BASE}/${encodeURIComponent(base)}.svg`)
+    if (!res.ok) {
+      iconCache.set(base, { svg: null, expiresAt: now + ICON_CACHE_TTL_MS })
+      return c.body(null, 404)
+    }
+
+    const svg = await res.text()
+    iconCache.set(base, { svg, expiresAt: now + ICON_CACHE_TTL_MS })
+    return new Response(svg, {
+      headers: {
+        'Content-Type': 'image/svg+xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400',
+      },
+    })
+  } catch (err) {
+    console.error(`[api] Pacifica icon ${base} unavailable:`, err instanceof Error ? err.message : err)
+    return c.body(null, 502)
+  }
+})


### PR DESCRIPTION
## Summary
- add `GET /perps/pacifica/markets` API route to proxy/normalize Pacifica market + price data
- add cached `GET /perps/pacifica/icons/:file` SVG proxy for token icons
- switch mobile Trade market list/icon loading to use myboon API instead of direct Pacifica calls
- memoize Trade list filtering

## Validation
- Started `@myboon/api` with root `.env` on `PORT=3099`
- `curl http://127.0.0.1:3099/perps/pacifica/markets` returned `200` with `64` markets
- `curl -I http://127.0.0.1:3099/perps/pacifica/icons/BTC.svg` returned `200 image/svg+xml`
- `pnpm --filter @myboon/api exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck src/pacifica.ts`
- `pnpm --dir apps/hybrid-expo exec eslint features/perps/TradeListScreen.tsx features/perps/perps.api.ts features/perps/perps.types.ts` passed with one existing warning in `perps.api.ts`

Closes #117
