### PR TITLE
feat: complete intelligence engine v2 validation slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ Thumbs.db
 coverage/
 .nyc_output/
 
+# Generated analysis artifacts
+artifacts/
+packages/*/artifacts/
+
 # Cache
 .cache/
 .turbo/

--- a/docs/INTELLIGENCE-ENGINE-V2.md
+++ b/docs/INTELLIGENCE-ENGINE-V2.md
@@ -1,6 +1,6 @@
 # myboon Intelligence Engine v2
 
-Status: draft implementation design  
+Status: implementation vertical slice / validation pass
 Issue: #123  
 V1 source: Polymarket
 
@@ -74,6 +74,8 @@ Use monotonic integer versions for machine contracts:
 
 Published narratives and outcomes are frozen with the versions used at publish time. New scoring versions can replay old raw data into new backtest runs, but historical published records should not be silently mutated.
 
+Runtime validation lives in `packages/brain/src/intelligence/schemas.ts`. Backtest artifacts validate `BacktestRunSummary` and `NarrativeOutcome` before writing JSON, so schema drift fails fast instead of silently corrupting evidence. Durable outcome row mapping lives in `packages/brain/src/intelligence/outcomes.ts` and targets the `narrative_outcomes` table added by migration `037-intelligence-v2-metadata.sql`.
+
 ## Success criteria policy
 
 A narrative/outcome must store its success criteria at publish time.
@@ -144,16 +146,21 @@ For the first source path, document:
 - backpressure behavior
 - stale data handling
 
-V1 default: polling is acceptable if timestamps and dedupe keys are stable.
+Concrete Polymarket v1 semantics:
 
-## Action model dependency
+| Source path | Mode | Interval / lag | Ordering key | Dedupe key | Retry / backpressure | Stale handling | Cursor state |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ODDS_SHIFT` legacy replay | Supabase historical replay | Backtest query window; no realtime promise | `signals.created_at` asc per slug | legacy signal `id` | paged reads, bounded by `POLYMARKET_BACKTEST_MAX_ROWS` | candidates without a full evaluation window become inconclusive/excluded | query window + artifact params |
+| `WHALE_BET` user tracker | Polling | `POLL_INTERVAL_MS` currently 5m; acceptable lag <= one poll + API latency | `metadata.activityTimestamp` preferred, DB `created_at` fallback | future raw-event key should include source, wallet, condition/slug, timestamp, side, outcome, amount | sequential per tracked wallet; fetch/insert errors logged and next poll retries | backtest excludes bets without elapsed evaluation window; realtime should skip/flag stale activity outside watch window | current in-memory `lastSeen`, needs durable cursor before scale-out |
+| `WHALE_BET` match watcher | Polling during match watch window | 5m loop while fixture is in watch window | trade `timestamp` per condition/slug | future raw-event key should include source, condition, trade id/timestamp, side, outcome, amount | sequential fixture loop; fetch/insert errors logged and next poll retries | watch-window bounded; future classifier should emit stale/illiquid warning instead of narrating old trades | current in-memory `lastSeen`, needs durable cursor before multi-process deployment |
 
-Before API/action-router work, create an ADR deciding whether myboon is:
+Prod note: current collectors still write legacy `signals` rows directly. For #123 this is documented as proxy mode; before horizontal scaling, collectors should persist `RawEvent` rows with durable cursor/upsert semantics, then classify into signals from that auditable raw layer.
 
-- Publisher mode: feed + alerts + deep links to venues
-- Executor mode: in-app signing/execution across venues
+## Action model decision
 
-This decision changes API shape, auth, custody/risk assumptions, and frontend flows.
+ADR: [`docs/adr/0001-publisher-vs-executor.md`](adr/0001-publisher-vs-executor.md)
+
+Decision: **publisher mode** for Intelligence Engine v2. V1 actions are feed/alert/deep-link actions only. No in-app execution, signing, custody, or order routing belongs in this validation slice. Executor mode requires a separate accepted ADR after the Polymarket signal quality gate is proven.
 
 ## Current v1 backtest scaffold
 
@@ -164,6 +171,8 @@ Implemented first vertical slice:
 - evaluator: checks whether odds continue in the same direction by the publish-time threshold within the configured window
 - baseline: largest raw odds delta over the same candidate pool
 - runner: `pnpm --filter @myboon/brain intelligence:polymarket:backtest`
+- artifacts: each run writes full params, summary, selected outcomes, baseline outcomes, and examples to `packages/brain/artifacts/intelligence-backtests/*.json`
+- override artifact path with `POLYMARKET_BACKTEST_OUTPUT=/path/to/result.json`
 
 Default criteria:
 
@@ -172,4 +181,21 @@ Default criteria:
 - selected set: top `30%` by v1 confidence score
 - max rows: `5000` unless `POLYMARKET_BACKTEST_MAX_ROWS` is set
 
-Latest local full run used `POLYMARKET_BACKTEST_MAX_ROWS=50000` and processed 44k+ recent ODDS_SHIFT rows. This is still a first-pass proxy backtest, not final proof of alpha: it uses existing event signals rather than raw market snapshots and evaluates continuation, not final market resolution.
+Latest acceptance ODDS_SHIFT run used `POLYMARKET_BACKTEST_DAYS=35 POLYMARKET_BACKTEST_MAX_ROWS=100000`. It processed 50,908 raw rows and produced 50,423 conclusive candidates over an actual 32.80-day candidate window. Selected hit rate was 68.47% vs 50.33% largest-raw-delta baseline, with 95% Wilson interval 67.72%-69.20%. Artifact: `packages/brain/artifacts/intelligence-backtests/backtest-polymarket.odds_shift-1777891475535.json`.
+
+## Current whale/user backtest scaffold
+
+Implemented second proxy slice:
+
+- source: existing Supabase `signals` rows where `source = POLYMARKET` and `type = WHALE_BET`
+- classifier: converts user-tracker and match-watcher rows into `polymarket.large_trade` classified signals
+- direction: BUY YES / SELL NO => up; BUY NO / SELL YES => down; non-YES/NO sports/outcome slugs are treated as outcome-specific YES markets
+- evaluator: checks whether the slug's YES odds continue in the inferred direction within the configured window
+- baseline: largest trade amount over the same conclusive candidate pool
+- runner: `pnpm --filter @myboon/brain intelligence:polymarket:whale-backtest`
+
+Latest acceptance WHALE_BET proxy run used `POLYMARKET_BACKTEST_DAYS=35 POLYMARKET_WHALE_BACKTEST_MAX_ROWS=50000 POLYMARKET_BACKTEST_MAX_ODDS_ROWS=100000`. It processed 50,000 whale rows and 50,923 odds rows, produced 1,293 conclusive candidates over an actual 30.02-day candidate window, and scored 66.67% selected hit rate vs 55.56% largest-trade baseline, with 95% Wilson interval 53.36%-77.76%. Artifact: `packages/brain/artifacts/intelligence-backtests/backtest-polymarket.whale_bet-1777891560255.json`.
+
+Important caveat: historical WHALE_BET rows mostly used DB `created_at` as the bet time, not the Polymarket activity timestamp, so this is not final proof. The collectors now persist `metadata.activityTimestamp` for future WHALE_BET rows; the backtest prefers that timestamp when present.
+
+Both current slices are still proxy backtests: they use existing event signals rather than durable raw market/trade snapshots and evaluate continuation, not final market resolution. However, #123 now has a measured >=30d Polymarket vertical slice that beats baseline with Wilson confidence intervals, plus a second whale/user proxy slice that also beats baseline over >=30d after timestamp fixes.

--- a/docs/INTELLIGENCE-ENGINE-V2.md
+++ b/docs/INTELLIGENCE-ENGINE-V2.md
@@ -154,3 +154,22 @@ Before API/action-router work, create an ADR deciding whether myboon is:
 - Executor mode: in-app signing/execution across venues
 
 This decision changes API shape, auth, custody/risk assumptions, and frontend flows.
+
+## Current v1 backtest scaffold
+
+Implemented first vertical slice:
+
+- source: existing Supabase `signals` rows where `source = POLYMARKET` and `type = ODDS_SHIFT`
+- classifier: converts legacy odds-shift rows into `ClassifiedSignal`
+- evaluator: checks whether odds continue in the same direction by the publish-time threshold within the configured window
+- baseline: largest raw odds delta over the same candidate pool
+- runner: `pnpm --filter @myboon/brain intelligence:polymarket:backtest`
+
+Default criteria:
+
+- continuation delta: `0.03`
+- window: `24h`
+- selected set: top `30%` by v1 confidence score
+- max rows: `5000` unless `POLYMARKET_BACKTEST_MAX_ROWS` is set
+
+Latest local full run used `POLYMARKET_BACKTEST_MAX_ROWS=50000` and processed 44k+ recent ODDS_SHIFT rows. This is still a first-pass proxy backtest, not final proof of alpha: it uses existing event signals rather than raw market snapshots and evaluates continuation, not final market resolution.

--- a/docs/INTELLIGENCE-ENGINE-V2.md
+++ b/docs/INTELLIGENCE-ENGINE-V2.md
@@ -1,0 +1,156 @@
+# myboon Intelligence Engine v2
+
+Status: draft implementation design  
+Issue: #123  
+V1 source: Polymarket
+
+## Why this exists
+
+The current architecture has useful collectors and narrative agents, but the next version needs to be measurable before it becomes larger. The v2 engine should prove one narrow vertical slice before adding more perps venues, wallet data, options data, or meme coin intelligence.
+
+The v1 goal is not “add more data”. The v1 goal is:
+
+> replay Polymarket history, classify deterministic signals, score them, generate narrative candidates, and measure whether they beat a trivial baseline.
+
+## Pipeline
+
+```text
+RawEvent
+  → FeatureSnapshot
+  → ClassifiedSignal
+  → NarrativeCandidate
+  → PublishedNarrative
+  → NarrativeOutcome
+```
+
+LLMs are allowed at the narrative generation/editing layer only. They should not calculate funding deltas, odds movement, wallet accumulation, dedupe, freshness, or confidence math.
+
+## V1 Polymarket source path
+
+### Raw events
+
+Polymarket v1 should start with raw events such as:
+
+- market metadata snapshot
+- odds/price snapshot
+- volume/liquidity snapshot
+- large trade / whale activity event, where available
+- market resolution event
+
+Collectors should preserve raw payloads and source trace. They should not emit “important signal” enums directly.
+
+### Features
+
+Feature extraction should derive deterministic fields from raw events:
+
+- yes/no price
+- odds delta over configured windows
+- volume delta
+- liquidity delta
+- market age
+- time to close
+- resolution status
+- source freshness
+
+### Classified signals
+
+Signal classification happens after features exist. V1 Polymarket signal candidates:
+
+- `polymarket.odds_shift`
+- `polymarket.volume_spike`
+- `polymarket.liquidity_expansion`
+- `polymarket.large_trade`
+- `polymarket.resolution`
+
+Each classification must record the rule and scoring version used.
+
+## Schema versioning policy
+
+Use monotonic integer versions for machine contracts:
+
+- `schemaVersion: 1`, `2`, `3`, etc.
+- `scoringVersion: 1`, `2`, `3`, etc.
+- `editorVersion` for LLM narrative/editor behavior
+
+Published narratives and outcomes are frozen with the versions used at publish time. New scoring versions can replay old raw data into new backtest runs, but historical published records should not be silently mutated.
+
+## Success criteria policy
+
+A narrative/outcome must store its success criteria at publish time.
+
+Example:
+
+```json
+{
+  "kind": "odds_move",
+  "direction": "up",
+  "targetDelta": 0.08,
+  "windowHours": 24
+}
+```
+
+This prevents old narratives being judged against newer threshold definitions.
+
+## V1 scoring
+
+V1 scoring can be hand-tuned, but it must be explicit and versioned.
+
+Required fields:
+
+- confidence
+- urgency
+- freshness
+- source reliability
+- signal weight
+- dedupe priority
+- narrative score
+
+Initial guidance:
+
+- confidence: likelihood the signal has follow-through
+- urgency: how time-sensitive it is
+- freshness: age-adjusted decay from source timestamp
+- source reliability: static/source-specific score until enough outcomes exist
+- signal weight: strength of the deterministic feature move
+- dedupe priority: ordering when multiple candidates describe the same market
+- narrative score: composite used to rank feed candidates
+
+## Baseline
+
+V1 must compare against at least one trivial baseline:
+
+1. random candidate selection from the same eligible pool, or
+2. largest raw odds delta over the same window
+
+The engine should not be expanded to other sources until the Polymarket slice is compared against baseline.
+
+## Backtest success metric
+
+Product-complete for v1 means:
+
+> At least one Polymarket narrative/signal type over ≥30 days shows hit rate measurably above baseline, with confidence intervals reported.
+
+If it does not beat baseline, that is still useful. It means we should adjust scoring/thesis before adding more sources.
+
+## Real-time semantics
+
+For the first source path, document:
+
+- polling vs streaming
+- acceptable lag
+- event ordering
+- duplicate handling
+- retry behavior
+- backpressure behavior
+- stale data handling
+
+V1 default: polling is acceptable if timestamps and dedupe keys are stable.
+
+## Action model dependency
+
+Before API/action-router work, create an ADR deciding whether myboon is:
+
+- Publisher mode: feed + alerts + deep links to venues
+- Executor mode: in-app signing/execution across venues
+
+This decision changes API shape, auth, custody/risk assumptions, and frontend flows.

--- a/docs/adr/0001-publisher-vs-executor.md
+++ b/docs/adr/0001-publisher-vs-executor.md
@@ -1,6 +1,7 @@
 # ADR 0001: Publisher vs Executor Action Model
 
-Status: proposed
+Status: accepted
+Decision date: 2026-05-04
 
 ## Context
 
@@ -40,8 +41,18 @@ Cons:
 - more complex API and frontend state
 - harder to build safely while validating intelligence quality
 
-## Proposed decision
+## Decision
 
 Start Intelligence Engine v2 in **publisher mode** until the Polymarket replay/backtest proves the signal pipeline beats baseline.
 
-Revisit executor mode after v1 validation.
+V1 actions are limited to feed items, alerts, explanations, and external venue deep links. myboon will not add in-app execution, signing, custody, or cross-venue order routing as part of this validation slice.
+
+Executor mode requires a follow-up ADR and security/product review after v1 intelligence quality is validated.
+
+## Consequences
+
+- API/action-router work must model actions as publisher actions, not executable orders.
+- No private-key custody or transaction signing is introduced by Intelligence Engine v2.
+- Frontend can prioritize explanation, confidence, urgency, and venue deep links.
+- Backtest quality gates stay independent from monetization/execution concerns.
+- If executor mode is revisited, auth, custody, risk controls, supported venues, and user consent flows must be redesigned explicitly.

--- a/docs/adr/0001-publisher-vs-executor.md
+++ b/docs/adr/0001-publisher-vs-executor.md
@@ -1,0 +1,47 @@
+# ADR 0001: Publisher vs Executor Action Model
+
+Status: proposed
+
+## Context
+
+Intelligence Engine v2 can attach actions to narratives. Those actions can either deep-link users to venues or execute trades inside myboon.
+
+## Options
+
+### Publisher mode
+
+myboon provides feed, alerts, explanations, and deep links to external venues.
+
+Pros:
+
+- lower custody/signing risk
+- simpler API
+- faster to ship
+- easier to validate intelligence quality first
+
+Cons:
+
+- weaker execution UX
+- less control over conversion/fees
+
+### Executor mode
+
+myboon supports in-app signing/execution across venues.
+
+Pros:
+
+- strongest UX
+- better monetization path
+- can close the loop from signal to action
+
+Cons:
+
+- larger auth/custody/risk surface
+- more complex API and frontend state
+- harder to build safely while validating intelligence quality
+
+## Proposed decision
+
+Start Intelligence Engine v2 in **publisher mode** until the Polymarket replay/backtest proves the signal pipeline beats baseline.
+
+Revisit executor mode after v1 validation.

--- a/docs/db-migrations/037-intelligence-v2-metadata.sql
+++ b/docs/db-migrations/037-intelligence-v2-metadata.sql
@@ -1,0 +1,24 @@
+-- Intelligence Engine v2 metadata bridge for issue #123.
+-- Safe to run repeatedly. Publisher retries legacy inserts if these columns are not applied yet.
+
+ALTER TABLE published_narratives
+  ADD COLUMN IF NOT EXISTS schema_version INTEGER,
+  ADD COLUMN IF NOT EXISTS scoring_version INTEGER,
+  ADD COLUMN IF NOT EXISTS editor_version INTEGER,
+  ADD COLUMN IF NOT EXISTS success_criteria JSONB;
+
+CREATE TABLE IF NOT EXISTS narrative_outcomes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  narrative_id UUID REFERENCES published_narratives(id) ON DELETE CASCADE,
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  scoring_version INTEGER NOT NULL DEFAULT 1,
+  evaluated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  criteria JSONB NOT NULL,
+  result TEXT NOT NULL CHECK (result IN ('hit', 'miss', 'inconclusive')),
+  measured_values JSONB NOT NULL DEFAULT '{}'::jsonb,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS narrative_outcomes_narrative_id_idx ON narrative_outcomes(narrative_id);
+CREATE INDEX IF NOT EXISTS narrative_outcomes_result_idx ON narrative_outcomes(result);

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -24,7 +24,8 @@
     "crypto-god:test": "tsx src/test-crypto-god.ts",
     "event:analyst": "tsx src/event-analyst.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "intelligence:polymarket:backtest": "tsx src/run-polymarket-odds-backtest.ts"
   },
   "dependencies": {
     "@langchain/langgraph": "^1.2.3",

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -25,7 +25,8 @@
     "event:analyst": "tsx src/event-analyst.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "intelligence:polymarket:backtest": "tsx src/run-polymarket-odds-backtest.ts"
+    "intelligence:polymarket:backtest": "tsx src/run-polymarket-odds-backtest.ts",
+    "intelligence:polymarket:whale-backtest": "tsx src/run-polymarket-whale-backtest.ts"
   },
   "dependencies": {
     "@langchain/langgraph": "^1.2.3",

--- a/packages/brain/src/fomo-master.ts
+++ b/packages/brain/src/fomo-master.ts
@@ -3,6 +3,7 @@ import 'dotenv/config'
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { PolymarketProfileClient } from '@myboon/shared'
 import { fomoMasterGraph, type FormattedSignal, type XPostRow } from './graphs/fomo-master-graph.js'
+import { classifyPolymarketWhaleBet, type PolymarketWhaleBetClassification } from './intelligence/scoring.js'
 
 // --- env validation ---
 
@@ -76,6 +77,27 @@ function formatAmount(amount: number): string {
   return `$${Math.round(amount).toLocaleString()}`
 }
 
+function numberOrNull(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function formatProbability(value: number | null): string {
+  return value == null ? 'unknown' : `${(value * 100).toFixed(0)}%`
+}
+
+function classifyFomoSignal(meta: Record<string, unknown>, liveOdds: number | null): PolymarketWhaleBetClassification {
+  return classifyPolymarketWhaleBet({
+    amountUsd: numberOrNull(meta.amount) ?? 0,
+    hoursSinceObserved: 0,
+    tradePrice: numberOrNull(meta.tradePrice),
+    marketOddsAtBet: numberOrNull(meta.marketOddsAtBet) ?? liveOdds,
+    outcome: typeof meta.outcome === 'string' ? meta.outcome : null,
+    walletTotalBets: numberOrNull(meta.walletTotalBets),
+    walletWinRate: numberOrNull(meta.walletWinRate),
+  })
+}
+
 interface BettorProfile {
   portfolio_value: number
   markets_traded: number
@@ -124,6 +146,7 @@ function formatSignalBlock(signal: {
     total_volume: number
     latest_at: string
   } | null
+  whale_classification: PolymarketWhaleBetClassification
 }): FormattedSignal {
   const meta = signal.metadata
   const amount = typeof meta?.amount === 'number' ? meta.amount : null
@@ -131,6 +154,7 @@ function formatSignalBlock(signal: {
   const question = typeof meta?.question === 'string' ? meta.question : typeof meta?.title === 'string' ? meta.title : 'Unknown market'
   const slug = typeof meta?.slug === 'string' ? meta.slug : null
   const address = typeof meta?.user === 'string' ? meta.user : null
+  const whale = signal.whale_classification
 
   // Line 1: SIGNAL
   const amountStr = amount !== null ? formatAmount(amount) : 'Unknown amount'
@@ -140,6 +164,7 @@ function formatSignalBlock(signal: {
   // Line 2: Market + odds
   const oddsStr = signal.live_odds !== null ? `${(signal.live_odds * 100).toFixed(0)}% YES` : 'unknown'
   const line2 = `Market: ${slug ?? 'unknown'} | Current odds: ${oddsStr}`
+  const line2b = `Whale classification: ${whale.archetype} | Bet probability: ${formatProbability(whale.betProbability)} | Est. risk: ${whale.riskUsd == null ? 'unknown' : formatAmount(whale.riskUsd)} | ${whale.reason}`
 
   // Line 3: Bettor profile (from Polymarket data APIs)
   const profile = signal.bettor_profile
@@ -169,7 +194,7 @@ function formatSignalBlock(signal: {
     : `Market activity (7d): no prior bets on record`
 
   // Line 5: Cluster (only if cluster_context exists)
-  const lines = [line1, line2, line3, line4]
+  const lines = [line1, line2, line2b, line3, line4]
   if (signal.cluster_context) {
     const cc = signal.cluster_context
     const line5 = `Cluster: ${cc.signal_count} bets in last 4h, ${cc.distinct_wallets} wallets, ${formatVolume(cc.total_volume)} total`
@@ -289,20 +314,43 @@ export async function runFomoMaster(): Promise<void> {
     })
   )
 
-  // Step 6: format into plaintext signal blocks
-  const formatted_signals: FormattedSignal[] = enriched.map((signal) =>
-    formatSignalBlock({
+  // Step 6: deterministic odds-aware classification before any LLM sees the signals
+  const formattedAll: FormattedSignal[] = enriched.map((signal) => {
+    const metadata = signal.metadata as Record<string, unknown>
+    return formatSignalBlock({
       id: signal.id,
       type: signal.type,
       weight: signal.weight,
-      metadata: signal.metadata as Record<string, unknown>,
+      metadata,
       created_at: signal.created_at,
       bettor_profile: signal.bettor_profile,
       live_odds: signal.live_odds,
       market_history: signal.market_history,
       cluster_context: signal.cluster_context,
+      whale_classification: classifyFomoSignal(metadata, signal.live_odds),
     })
+  })
+
+  const deterministicSkips = Object.fromEntries(
+    formattedAll
+      .filter((signal) => !signal.whale_classification.publishableAsConviction)
+      .map((signal) => [signal.id, `deterministic whale filter: ${signal.whale_classification.archetype} — ${signal.whale_classification.reason}`])
   )
+  const formatted_signals = formattedAll.filter((signal) => signal.whale_classification.publishableAsConviction)
+
+  if (Object.keys(deterministicSkips).length > 0) {
+    await Promise.all(
+      Object.entries(deterministicSkips).map(([signal_id, reason]) =>
+        supabase.from('signals').update({ skip_reasoning: reason }).eq('id', signal_id)
+      )
+    )
+    console.log(`[fomo_master] Deterministically filtered ${Object.keys(deterministicSkips).length} signal(s)`)
+  }
+
+  if (!formatted_signals.length) {
+    console.log('[fomo_master] No publishable whale signals after deterministic filtering')
+    return
+  }
 
   // Step 7: fetch timelines
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()

--- a/packages/brain/src/graphs/fomo-master-graph.ts
+++ b/packages/brain/src/graphs/fomo-master-graph.ts
@@ -30,6 +30,13 @@ export interface FormattedSignal {
     total_volume: number
     latest_at: string
   } | null
+  whale_classification: {
+    archetype: 'penny_pickup' | 'lottery' | 'contrarian' | 'conviction' | 'noise'
+    betProbability: number | null
+    riskUsd: number | null
+    reason: string
+    publishableAsConviction: boolean
+  }
   formatted_text: string
 }
 
@@ -212,11 +219,14 @@ const RANKER_SYSTEM_PROMPT = `You are the editorial director for a financial int
 Your job: from a batch of whale bet signals, pick the 1-3 most compelling stories to post about.
 
 Ranking criteria (in order):
-1. Contrarian conviction — large bet on a low-probability outcome is the strongest signal
-2. Wallet credibility — a high win-rate wallet with proven PnL matters more than an unknown wallet
-3. Pattern — multiple wallets betting the same market is a story on its own
-4. Size — raw dollar amount (everyone can read this, so it's the weakest differentiator alone)
-5. Timing — a fresh bet is more relevant than a stale one
+1. Deterministic whale classification — contrarian/conviction/lottery beats raw notional size
+2. Contrarian conviction — meaningful risk on a low-probability outcome is the strongest signal
+3. Wallet credibility — a high win-rate wallet with proven PnL matters more than an unknown wallet
+4. Pattern — multiple wallets betting the same market is a story on its own
+5. Risk-adjusted size — estimated max loss matters more than displayed trade amount
+6. Timing — a fresh bet is more relevant than a stale one
+
+Never rank 95%+ consensus bets as whale conviction. Those should already be filtered as penny_pickup; if one appears, skip it.
 
 You will receive formatted signal blocks with short IDs (S1, S2, ...). Each block includes: bet direction+odds (for contrarian scoring), bettor profile (win rate, PnL, trade count from Polymarket data), market_history (for pattern), and cluster_context (if multiple wallets hit this market).
 
@@ -242,12 +252,17 @@ Build tension through facts. Let the implication land in the final line.
 The reader should finish and think "huh" — not "so what."
 
 [Classification]
-Before writing, classify the signal. First match wins:
-1. CONTRARIAN: live_odds < 0.30 — wallet betting heavily against consensus
-2. CLUSTER: 3+ wallets, same market, last 4h (cluster_context.signal_count)
-3. AUTHORITY: bettor_profile.win_rate >= 0.60 AND bettor_profile.trade_count >= 10
-4. FRESH_WALLET: no bettor_profile OR bettor_profile.trade_count < 3
-5. GENERAL: fallback — lead with the most specific number in the signal
+The code has already classified each bet using odds/risk math before you see it. Use that classification; do not invent signal math.
+First match wins for the writing frame:
+1. CONTRARIAN: whale_classification.archetype = contrarian
+2. LOTTERY: whale_classification.archetype = lottery
+3. CONVICTION: whale_classification.archetype = conviction
+4. CLUSTER: 3+ wallets, same market, last 4h (cluster_context.signal_count)
+5. AUTHORITY: bettor_profile.win_rate >= 0.60 AND bettor_profile.trade_count >= 10
+6. FRESH_WALLET: no bettor_profile OR bettor_profile.trade_count < 3
+7. GENERAL: fallback — lead with the most specific number in the signal
+
+Never call penny-pickup / 95%+ consensus bets whale conviction. If a penny_pickup reaches you, refuse it.
 
 [TIME_SENSITIVE modifier]
 If the market resolves within 48h (detectable from question text: "by March 31", "tonight", etc.),
@@ -272,7 +287,7 @@ Return JSON:
   "drafts": [
     {
       "signal_id": "uuid",
-      "archetype": "CONTRARIAN | CLUSTER | AUTHORITY | FRESH_WALLET | GENERAL",
+      "archetype": "CONTRARIAN | LOTTERY | CONVICTION | CLUSTER | AUTHORITY | FRESH_WALLET | GENERAL",
       "draft_text": "...",
       "reasoning": "why this archetype, what you led with"
     }

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -3,3 +3,4 @@ export * from './orchestrator.js';
 export * from './prompts/classifier.js';
 export * from './research/index.js';
 export * from './types/index.js';
+export * from './intelligence/index.js';

--- a/packages/brain/src/intelligence/backtest-artifacts.test.ts
+++ b/packages/brain/src/intelligence/backtest-artifacts.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { INTELLIGENCE_SCHEMA_VERSION, INTELLIGENCE_SCORING_VERSION } from './contracts.js'
+import { writeBacktestArtifact, type BacktestRunArtifact } from './backtest-artifacts.js'
+
+const artifact: BacktestRunArtifact = {
+  params: { days: 30, rawSignals: 2 },
+  summary: {
+    schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+    id: 'backtest:polymarket.odds_shift:test',
+    source: 'polymarket',
+    signalKind: 'polymarket.odds_shift',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    completedAt: '2026-01-01T00:00:01.000Z',
+    windowStart: '2026-01-01T00:00:00.000Z',
+    windowEnd: '2026-01-02T00:00:00.000Z',
+    requestedWindowDays: 1,
+    actualWindowDays: 1,
+    scoringVersion: INTELLIGENCE_SCORING_VERSION,
+    baseline: 'largest_raw_odds_delta',
+    candidateCount: 1,
+    hitRate: 1,
+    baselineHitRate: 0,
+    confidenceInterval: { lower: 0.2, upper: 1, level: 0.95 },
+  },
+  selected: [],
+  baseline: [],
+  examples: { hits: [], misses: [] },
+}
+
+describe('backtest artifacts', () => {
+  it('writes a complete JSON artifact', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'myboon-backtest-'))
+    const outputPath = path.join(dir, 'result.json')
+
+    const written = await writeBacktestArtifact(artifact, outputPath)
+    const parsed = JSON.parse(await readFile(written, 'utf8')) as BacktestRunArtifact
+
+    expect(parsed.summary.id).toBe(artifact.summary.id)
+    expect(parsed.params.rawSignals).toBe(2)
+    expect(parsed.examples.hits).toEqual([])
+  })
+})

--- a/packages/brain/src/intelligence/backtest-artifacts.ts
+++ b/packages/brain/src/intelligence/backtest-artifacts.ts
@@ -1,0 +1,35 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import type { BacktestRunSummary, NarrativeOutcome } from './contracts.js'
+import { BacktestRunSummarySchema, NarrativeOutcomeSchema } from './schemas.js'
+
+export interface BacktestRunArtifact<TParams extends Record<string, unknown> = Record<string, unknown>> {
+  summary: BacktestRunSummary
+  params: TParams
+  selected: NarrativeOutcome[]
+  baseline: NarrativeOutcome[]
+  examples: {
+    hits: NarrativeOutcome[]
+    misses: NarrativeOutcome[]
+  }
+}
+
+export function defaultBacktestArtifactPath(summary: BacktestRunSummary): string {
+  const safeId = summary.id.replace(/[^a-zA-Z0-9._-]/g, '-')
+  return path.resolve(process.cwd(), 'artifacts', 'intelligence-backtests', `${safeId}.json`)
+}
+
+export async function writeBacktestArtifact(
+  artifact: BacktestRunArtifact,
+  outputPath = defaultBacktestArtifactPath(artifact.summary)
+): Promise<string> {
+  BacktestRunSummarySchema.parse(artifact.summary)
+  for (const outcome of [...artifact.selected, ...artifact.baseline, ...artifact.examples.hits, ...artifact.examples.misses]) {
+    NarrativeOutcomeSchema.parse(outcome)
+  }
+
+  const resolved = path.resolve(outputPath)
+  await mkdir(path.dirname(resolved), { recursive: true })
+  await writeFile(resolved, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8')
+  return resolved
+}

--- a/packages/brain/src/intelligence/contracts.ts
+++ b/packages/brain/src/intelligence/contracts.ts
@@ -1,5 +1,6 @@
 export const INTELLIGENCE_SCHEMA_VERSION = 1 as const
 export const INTELLIGENCE_SCORING_VERSION = 1 as const
+export const INTELLIGENCE_EDITOR_VERSION = 1 as const
 
 export type SourceVenue = 'polymarket'
 
@@ -36,6 +37,21 @@ export type OutcomeCriterion =
       targetMultiplier: number
       windowHours: number
     }
+
+export function oddsMoveCriterion(
+  direction: Exclude<SignalDirection, 'neutral' | 'unknown'>,
+  targetDelta: number,
+  windowHours: number
+): Extract<OutcomeCriterion, { kind: 'odds_move' }> {
+  return { kind: 'odds_move', direction, targetDelta, windowHours }
+}
+
+export function marketResolutionCriterion(
+  expectedOutcome: string,
+  windowHours?: number
+): Extract<OutcomeCriterion, { kind: 'market_resolution' }> {
+  return { kind: 'market_resolution', expectedOutcome, ...(windowHours == null ? {} : { windowHours }) }
+}
 
 export interface ContractVersion {
   schemaVersion: typeof INTELLIGENCE_SCHEMA_VERSION
@@ -120,7 +136,7 @@ export interface NarrativeCandidate extends ContractVersion {
 
 export interface PublishedNarrative extends NarrativeCandidate {
   publishedAt: string
-  editorVersion: number
+  editorVersion: typeof INTELLIGENCE_EDITOR_VERSION | number
   status: 'published'
 }
 
@@ -143,8 +159,10 @@ export interface BacktestRunSummary extends ContractVersion {
   completedAt?: string
   windowStart: string
   windowEnd: string
+  requestedWindowDays?: number
+  actualWindowDays: number
   scoringVersion: typeof INTELLIGENCE_SCORING_VERSION
-  baseline: 'random_candidate' | 'largest_raw_odds_delta'
+  baseline: 'random_candidate' | 'largest_raw_odds_delta' | 'largest_trade_amount'
   candidateCount: number
   hitRate: number
   baselineHitRate: number

--- a/packages/brain/src/intelligence/contracts.ts
+++ b/packages/brain/src/intelligence/contracts.ts
@@ -1,0 +1,156 @@
+export const INTELLIGENCE_SCHEMA_VERSION = 1 as const
+export const INTELLIGENCE_SCORING_VERSION = 1 as const
+
+export type SourceVenue = 'polymarket'
+
+export type PolymarketRawEventKind =
+  | 'polymarket.market_snapshot'
+  | 'polymarket.odds_snapshot'
+  | 'polymarket.volume_liquidity_snapshot'
+  | 'polymarket.large_trade'
+  | 'polymarket.resolution'
+
+export type ClassifiedSignalKind =
+  | 'polymarket.odds_shift'
+  | 'polymarket.volume_spike'
+  | 'polymarket.liquidity_expansion'
+  | 'polymarket.large_trade'
+  | 'polymarket.resolution'
+
+export type SignalDirection = 'up' | 'down' | 'neutral' | 'unknown'
+
+export type OutcomeCriterion =
+  | {
+      kind: 'odds_move'
+      direction: Exclude<SignalDirection, 'neutral' | 'unknown'>
+      targetDelta: number
+      windowHours: number
+    }
+  | {
+      kind: 'market_resolution'
+      expectedOutcome: string
+      windowHours?: number
+    }
+  | {
+      kind: 'volume_or_liquidity_follow_through'
+      targetMultiplier: number
+      windowHours: number
+    }
+
+export interface ContractVersion {
+  schemaVersion: typeof INTELLIGENCE_SCHEMA_VERSION
+}
+
+export interface TraceRef {
+  source: SourceVenue
+  sourceId: string
+  fetchedAt: string
+  url?: string
+  rawSnapshotId?: string
+}
+
+export interface RawEvent<TPayload = unknown> extends ContractVersion {
+  id: string
+  source: SourceVenue
+  kind: PolymarketRawEventKind
+  entityRef: {
+    marketId?: string
+    slug?: string
+    conditionId?: string
+    assetId?: string
+  }
+  observedAt: string
+  receivedAt: string
+  dedupeKey: string
+  trace: TraceRef
+  payload: TPayload
+}
+
+export interface FeatureSnapshot<TFeatures extends Record<string, unknown> = Record<string, unknown>> extends ContractVersion {
+  id: string
+  source: SourceVenue
+  rawEventIds: string[]
+  entityRef: RawEvent['entityRef']
+  observedAt: string
+  computedAt: string
+  featureVersion: number
+  features: TFeatures
+  trace: TraceRef[]
+}
+
+export interface ScoreBreakdown {
+  confidence: number
+  urgency: number
+  freshness: number
+  sourceReliability: number
+  signalWeight: number
+  dedupePriority: number
+}
+
+export interface ClassifiedSignal<TMetadata extends Record<string, unknown> = Record<string, unknown>> extends ContractVersion {
+  id: string
+  kind: ClassifiedSignalKind
+  source: SourceVenue
+  featureSnapshotIds: string[]
+  entityRef: RawEvent['entityRef']
+  direction: SignalDirection
+  observedAt: string
+  classifiedAt: string
+  scoringVersion: typeof INTELLIGENCE_SCORING_VERSION
+  ruleId: string
+  score: ScoreBreakdown
+  metadata: TMetadata
+  trace: TraceRef[]
+}
+
+export interface NarrativeCandidate extends ContractVersion {
+  id: string
+  source: SourceVenue
+  signalIds: string[]
+  entityRef: RawEvent['entityRef']
+  title: string
+  thesis: string
+  whyNow: string
+  invalidation: string
+  narrativeScore: number
+  scoringVersion: typeof INTELLIGENCE_SCORING_VERSION
+  successCriteria: OutcomeCriterion[]
+  createdAt: string
+}
+
+export interface PublishedNarrative extends NarrativeCandidate {
+  publishedAt: string
+  editorVersion: number
+  status: 'published'
+}
+
+export interface NarrativeOutcome extends ContractVersion {
+  id: string
+  narrativeId: string
+  evaluatedAt: string
+  criteria: OutcomeCriterion[]
+  result: 'hit' | 'miss' | 'inconclusive'
+  measuredValues: Record<string, number | string | boolean | null>
+  scoringVersion: typeof INTELLIGENCE_SCORING_VERSION
+  notes?: string
+}
+
+export interface BacktestRunSummary extends ContractVersion {
+  id: string
+  source: SourceVenue
+  signalKind: ClassifiedSignalKind
+  startedAt: string
+  completedAt?: string
+  windowStart: string
+  windowEnd: string
+  scoringVersion: typeof INTELLIGENCE_SCORING_VERSION
+  baseline: 'random_candidate' | 'largest_raw_odds_delta'
+  candidateCount: number
+  hitRate: number
+  baselineHitRate: number
+  confidenceInterval?: {
+    lower: number
+    upper: number
+    level: number
+  }
+}

--- a/packages/brain/src/intelligence/index.ts
+++ b/packages/brain/src/intelligence/index.ts
@@ -1,0 +1,2 @@
+export * from './contracts.js'
+export * from './scoring.js'

--- a/packages/brain/src/intelligence/index.ts
+++ b/packages/brain/src/intelligence/index.ts
@@ -1,2 +1,3 @@
 export * from './contracts.js'
 export * from './scoring.js'
+export * from './polymarket-backtest.js'

--- a/packages/brain/src/intelligence/index.ts
+++ b/packages/brain/src/intelligence/index.ts
@@ -1,3 +1,7 @@
 export * from './contracts.js'
+export * from './schemas.js'
+export * from './outcomes.js'
 export * from './scoring.js'
 export * from './polymarket-backtest.js'
+export * from './polymarket-whale-backtest.js'
+export * from './backtest-artifacts.js'

--- a/packages/brain/src/intelligence/outcomes.test.ts
+++ b/packages/brain/src/intelligence/outcomes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { INTELLIGENCE_SCHEMA_VERSION, INTELLIGENCE_SCORING_VERSION, oddsMoveCriterion } from './contracts.js'
+import { narrativeOutcomeToRow } from './outcomes.js'
+
+describe('narrative outcome persistence mapping', () => {
+  it('maps frozen outcome criteria to durable DB row shape', () => {
+    const row = narrativeOutcomeToRow({
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: 'outcome:classified-1',
+      narrativeId: 'published-narrative-1',
+      evaluatedAt: '2026-01-02T00:00:00.000Z',
+      criteria: [oddsMoveCriterion('up', 0.03, 24)],
+      result: 'hit',
+      measuredValues: { startPrice: 0.4, latestPrice: 0.45, measuredMove: 0.05 },
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+    })
+
+    expect(row.id).toBeUndefined()
+    expect(row.narrative_id).toBe('published-narrative-1')
+    expect(row.criteria[0]).toMatchObject({ kind: 'odds_move', targetDelta: 0.03 })
+    expect(row.schema_version).toBe(INTELLIGENCE_SCHEMA_VERSION)
+    expect(row.scoring_version).toBe(INTELLIGENCE_SCORING_VERSION)
+  })
+})

--- a/packages/brain/src/intelligence/outcomes.ts
+++ b/packages/brain/src/intelligence/outcomes.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { NarrativeOutcome, OutcomeCriterion } from './contracts.js'
+import { NarrativeOutcomeSchema } from './schemas.js'
+
+export interface NarrativeOutcomeRow {
+  id?: string
+  narrative_id: string
+  schema_version: number
+  scoring_version: number
+  evaluated_at: string
+  criteria: OutcomeCriterion[]
+  result: NarrativeOutcome['result']
+  measured_values: NarrativeOutcome['measuredValues']
+  notes?: string | null
+}
+
+export function narrativeOutcomeToRow(outcome: NarrativeOutcome): NarrativeOutcomeRow {
+  const parsed = NarrativeOutcomeSchema.parse(outcome)
+  return {
+    id: parsed.id.startsWith('outcome:') ? undefined : parsed.id,
+    narrative_id: parsed.narrativeId,
+    schema_version: parsed.schemaVersion,
+    scoring_version: parsed.scoringVersion,
+    evaluated_at: parsed.evaluatedAt,
+    criteria: parsed.criteria,
+    result: parsed.result,
+    measured_values: parsed.measuredValues,
+    notes: parsed.notes ?? null,
+  }
+}
+
+export async function insertNarrativeOutcome(
+  supabase: Pick<SupabaseClient, 'from'>,
+  outcome: NarrativeOutcome
+): Promise<void> {
+  const row = narrativeOutcomeToRow(outcome)
+  const { error } = await supabase
+    .from('narrative_outcomes')
+    .insert(row)
+
+  if (error) throw error
+}

--- a/packages/brain/src/intelligence/polymarket-backtest.test.ts
+++ b/packages/brain/src/intelligence/polymarket-backtest.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { runPolymarketOddsShiftBacktest, type LegacyOddsShiftSignal } from './polymarket-backtest.js'
+
+const signal = (
+  id: string,
+  slug: string,
+  createdAt: string,
+  from: number,
+  to: number
+): LegacyOddsShiftSignal => ({
+  id,
+  slug,
+  topic: slug,
+  created_at: createdAt,
+  metadata: {
+    slug,
+    shift_from: from,
+    shift_to: to,
+    yes_price: to,
+  },
+})
+
+describe('Polymarket odds-shift backtest', () => {
+  it('evaluates continuation outcomes and baseline', () => {
+    const rows = [
+      signal('1', 'market-a', '2026-01-01T00:00:00.000Z', 0.4, 0.48),
+      signal('2', 'market-a', '2026-01-01T06:00:00.000Z', 0.48, 0.53),
+      signal('3', 'market-b', '2026-01-01T00:00:00.000Z', 0.6, 0.52),
+      signal('4', 'market-b', '2026-01-01T08:00:00.000Z', 0.52, 0.55),
+    ]
+
+    const result = runPolymarketOddsShiftBacktest(rows, {
+      continuationDelta: 0.03,
+      windowHours: 24,
+      topFraction: 1,
+      minCandidates: 1,
+    })
+
+    expect(result.summary.candidateCount).toBeGreaterThan(0)
+    expect(result.summary.hitRate).toBeGreaterThanOrEqual(0)
+    expect(result.summary.hitRate).toBeLessThanOrEqual(1)
+    expect(result.summary.baselineHitRate).toBeGreaterThanOrEqual(0)
+    expect(result.summary.confidenceInterval?.level).toBe(0.95)
+  })
+})

--- a/packages/brain/src/intelligence/polymarket-backtest.test.ts
+++ b/packages/brain/src/intelligence/polymarket-backtest.test.ts
@@ -40,6 +40,8 @@ describe('Polymarket odds-shift backtest', () => {
     expect(result.summary.hitRate).toBeGreaterThanOrEqual(0)
     expect(result.summary.hitRate).toBeLessThanOrEqual(1)
     expect(result.summary.baselineHitRate).toBeGreaterThanOrEqual(0)
+    expect(result.summary.actualWindowDays).toBeGreaterThanOrEqual(0)
+    expect(result.selected[0]?.criteria[0]).toMatchObject({ kind: 'odds_move', targetDelta: 0.03, windowHours: 24 })
     expect(result.summary.confidenceInterval?.level).toBe(0.95)
   })
 })

--- a/packages/brain/src/intelligence/polymarket-backtest.ts
+++ b/packages/brain/src/intelligence/polymarket-backtest.ts
@@ -1,0 +1,242 @@
+import {
+  INTELLIGENCE_SCHEMA_VERSION,
+  INTELLIGENCE_SCORING_VERSION,
+  type BacktestRunSummary,
+  type ClassifiedSignal,
+  type NarrativeOutcome,
+} from './contracts.js'
+import { scorePolymarketOddsShift } from './scoring.js'
+
+export interface LegacyOddsShiftSignal {
+  id: string
+  topic?: string | null
+  slug?: string | null
+  created_at: string
+  metadata?: {
+    marketId?: string
+    slug?: string
+    yes_price?: number
+    shift_from?: number
+    shift_to?: number
+    [key: string]: unknown
+  } | null
+}
+
+export interface OddsShiftBacktestOptions {
+  continuationDelta: number
+  windowHours: number
+  topFraction: number
+  minCandidates?: number
+}
+
+export interface OddsShiftBacktestResult {
+  summary: BacktestRunSummary
+  selected: NarrativeOutcome[]
+  baseline: NarrativeOutcome[]
+  examples: {
+    hits: NarrativeOutcome[]
+    misses: NarrativeOutcome[]
+  }
+}
+
+interface Candidate {
+  signal: ClassifiedSignal<{ oddsDelta: number; from: number; to: number }>
+  outcome: NarrativeOutcome
+  absDelta: number
+}
+
+const DEFAULT_OPTIONS: OddsShiftBacktestOptions = {
+  continuationDelta: 0.03,
+  windowHours: 24,
+  topFraction: 0.3,
+  minCandidates: 10,
+}
+
+const hoursBetween = (from: string, to: string): number =>
+  (new Date(to).getTime() - new Date(from).getTime()) / 3_600_000
+
+const mean = (values: number[]): number =>
+  values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
+
+const wilsonInterval = (hits: number, n: number, z = 1.96): { lower: number; upper: number; level: number } => {
+  if (n === 0) return { lower: 0, upper: 0, level: 0.95 }
+  const p = hits / n
+  const denom = 1 + (z * z) / n
+  const center = (p + (z * z) / (2 * n)) / denom
+  const margin = (z / denom) * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n))
+  return { lower: Math.max(0, center - margin), upper: Math.min(1, center + margin), level: 0.95 }
+}
+
+function normalizePrice(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : null
+}
+
+function toClassifiedSignal(raw: LegacyOddsShiftSignal): ClassifiedSignal<{ oddsDelta: number; from: number; to: number }> | null {
+  const from = normalizePrice(raw.metadata?.shift_from)
+  const to = normalizePrice(raw.metadata?.shift_to ?? raw.metadata?.yes_price)
+  const slug = raw.slug ?? raw.metadata?.slug
+  if (from == null || to == null || !slug) return null
+
+  const oddsDelta = to - from
+  const score = scorePolymarketOddsShift({
+    oddsDelta,
+    hoursSinceObserved: 0,
+    currentPrice: to,
+  })
+
+  return {
+    schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+    id: `classified:${raw.id}`,
+    kind: 'polymarket.odds_shift',
+    source: 'polymarket',
+    featureSnapshotIds: [`legacy-signal:${raw.id}`],
+    entityRef: {
+      marketId: raw.metadata?.marketId,
+      slug,
+    },
+    direction: oddsDelta > 0 ? 'up' : oddsDelta < 0 ? 'down' : 'neutral',
+    observedAt: raw.created_at,
+    classifiedAt: new Date().toISOString(),
+    scoringVersion: INTELLIGENCE_SCORING_VERSION,
+    ruleId: 'polymarket.odds_shift.v1',
+    score,
+    metadata: { oddsDelta, from, to },
+    trace: [
+      {
+        source: 'polymarket',
+        sourceId: raw.id,
+        fetchedAt: raw.created_at,
+      },
+    ],
+  }
+}
+
+function evaluateCandidate(
+  signal: ClassifiedSignal<{ oddsDelta: number; from: number; to: number }>,
+  marketSignals: ClassifiedSignal<{ oddsDelta: number; from: number; to: number }>[],
+  signalIndex: number,
+  options: OddsShiftBacktestOptions
+): NarrativeOutcome {
+  const direction = signal.direction === 'down' ? 'down' : 'up'
+  const startPrice = signal.metadata.to
+  const cutoff = new Date(new Date(signal.observedAt).getTime() + options.windowHours * 3_600_000).toISOString()
+  let matched: ClassifiedSignal<{ oddsDelta: number; from: number; to: number }> | undefined
+  let latestInWindow: ClassifiedSignal<{ oddsDelta: number; from: number; to: number }> | undefined
+
+  for (let i = signalIndex + 1; i < marketSignals.length; i += 1) {
+    const candidate = marketSignals[i]
+    if (!candidate || candidate.observedAt <= signal.observedAt) continue
+    if (candidate.observedAt > cutoff) break
+
+    latestInWindow = candidate
+    if (!matched) {
+      const move = candidate.metadata.to - startPrice
+      if (direction === 'up' ? move >= options.continuationDelta : move <= -options.continuationDelta) {
+        matched = candidate
+      }
+    }
+  }
+
+  const measuredMove = latestInWindow ? latestInWindow.metadata.to - startPrice : 0
+
+  return {
+    schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+    id: `outcome:${signal.id}`,
+    narrativeId: signal.id,
+    evaluatedAt: new Date().toISOString(),
+    criteria: [
+      {
+        kind: 'odds_move',
+        direction,
+        targetDelta: options.continuationDelta,
+        windowHours: options.windowHours,
+      },
+    ],
+    result: matched ? 'hit' : latestInWindow ? 'miss' : 'inconclusive',
+    measuredValues: {
+      startPrice,
+      latestPrice: latestInWindow?.metadata.to ?? null,
+      measuredMove,
+      matchedAt: matched?.observedAt ?? null,
+      matchedPrice: matched?.metadata.to ?? null,
+    },
+    scoringVersion: INTELLIGENCE_SCORING_VERSION,
+  }
+}
+
+export function runPolymarketOddsShiftBacktest(
+  rawSignals: LegacyOddsShiftSignal[],
+  partialOptions: Partial<OddsShiftBacktestOptions> = {}
+): OddsShiftBacktestResult {
+  const options = { ...DEFAULT_OPTIONS, ...partialOptions }
+  const signals = rawSignals
+    .map(toClassifiedSignal)
+    .filter((signal): signal is ClassifiedSignal<{ oddsDelta: number; from: number; to: number }> => Boolean(signal))
+    .sort((a, b) => a.observedAt.localeCompare(b.observedAt))
+
+  const signalsBySlug = new Map<string, ClassifiedSignal<{ oddsDelta: number; from: number; to: number }>[]> ()
+  for (const signal of signals) {
+    const slug = signal.entityRef.slug ?? 'unknown'
+    const group = signalsBySlug.get(slug) ?? []
+    group.push(signal)
+    signalsBySlug.set(slug, group)
+  }
+
+  const signalIndexById = new Map<string, number>()
+  for (const group of signalsBySlug.values()) {
+    group.forEach((signal, index) => signalIndexById.set(signal.id, index))
+  }
+
+  const candidates: Candidate[] = signals.map((signal) => {
+    const marketSignals = signalsBySlug.get(signal.entityRef.slug ?? 'unknown') ?? []
+    return {
+      signal,
+      outcome: evaluateCandidate(signal, marketSignals, signalIndexById.get(signal.id) ?? -1, options),
+      absDelta: Math.abs(signal.metadata.oddsDelta),
+    }
+  })
+
+  const conclusive = candidates.filter((candidate) => candidate.outcome.result !== 'inconclusive')
+  const selectedCount = Math.max(options.minCandidates ?? 1, Math.ceil(conclusive.length * options.topFraction))
+  const boundedSelectedCount = Math.min(selectedCount, conclusive.length)
+
+  const selected = [...conclusive]
+    .sort((a, b) => b.signal.score.confidence - a.signal.score.confidence || b.signal.score.urgency - a.signal.score.urgency)
+    .slice(0, boundedSelectedCount)
+    .map((candidate) => candidate.outcome)
+
+  const baseline = [...conclusive]
+    .sort((a, b) => b.absDelta - a.absDelta)
+    .slice(0, boundedSelectedCount)
+    .map((candidate) => candidate.outcome)
+
+  const hitRate = mean(selected.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
+  const baselineHitRate = mean(baseline.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
+  const hits = selected.filter((outcome) => outcome.result === 'hit').length
+
+  return {
+    summary: {
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: `backtest:polymarket.odds_shift:${Date.now()}`,
+      source: 'polymarket',
+      signalKind: 'polymarket.odds_shift',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      windowStart: signals[0]?.observedAt ?? new Date().toISOString(),
+      windowEnd: signals.at(-1)?.observedAt ?? new Date().toISOString(),
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+      baseline: 'largest_raw_odds_delta',
+      candidateCount: conclusive.length,
+      hitRate,
+      baselineHitRate,
+      confidenceInterval: wilsonInterval(hits, selected.length),
+    },
+    selected,
+    baseline,
+    examples: {
+      hits: selected.filter((outcome) => outcome.result === 'hit').slice(0, 5),
+      misses: selected.filter((outcome) => outcome.result === 'miss').slice(0, 5),
+    },
+  }
+}

--- a/packages/brain/src/intelligence/polymarket-backtest.ts
+++ b/packages/brain/src/intelligence/polymarket-backtest.ts
@@ -1,6 +1,7 @@
 import {
   INTELLIGENCE_SCHEMA_VERSION,
   INTELLIGENCE_SCORING_VERSION,
+  oddsMoveCriterion,
   type BacktestRunSummary,
   type ClassifiedSignal,
   type NarrativeOutcome,
@@ -27,6 +28,7 @@ export interface OddsShiftBacktestOptions {
   windowHours: number
   topFraction: number
   minCandidates?: number
+  requestedWindowDays?: number
 }
 
 export interface OddsShiftBacktestResult {
@@ -145,14 +147,7 @@ function evaluateCandidate(
     id: `outcome:${signal.id}`,
     narrativeId: signal.id,
     evaluatedAt: new Date().toISOString(),
-    criteria: [
-      {
-        kind: 'odds_move',
-        direction,
-        targetDelta: options.continuationDelta,
-        windowHours: options.windowHours,
-      },
-    ],
+    criteria: [oddsMoveCriterion(direction, options.continuationDelta, options.windowHours)],
     result: matched ? 'hit' : latestInWindow ? 'miss' : 'inconclusive',
     measuredValues: {
       startPrice,
@@ -214,6 +209,9 @@ export function runPolymarketOddsShiftBacktest(
   const hitRate = mean(selected.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
   const baselineHitRate = mean(baseline.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
   const hits = selected.filter((outcome) => outcome.result === 'hit').length
+  const windowStart = conclusive[0]?.signal.observedAt ?? signals[0]?.observedAt ?? new Date().toISOString()
+  const windowEnd = conclusive.at(-1)?.signal.observedAt ?? signals.at(-1)?.observedAt ?? windowStart
+  const actualWindowDays = Math.max(0, (new Date(windowEnd).getTime() - new Date(windowStart).getTime()) / 86_400_000)
 
   return {
     summary: {
@@ -223,8 +221,10 @@ export function runPolymarketOddsShiftBacktest(
       signalKind: 'polymarket.odds_shift',
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
-      windowStart: signals[0]?.observedAt ?? new Date().toISOString(),
-      windowEnd: signals.at(-1)?.observedAt ?? new Date().toISOString(),
+      windowStart,
+      windowEnd,
+      requestedWindowDays: options.requestedWindowDays,
+      actualWindowDays,
       scoringVersion: INTELLIGENCE_SCORING_VERSION,
       baseline: 'largest_raw_odds_delta',
       candidateCount: conclusive.length,

--- a/packages/brain/src/intelligence/polymarket-whale-backtest.test.ts
+++ b/packages/brain/src/intelligence/polymarket-whale-backtest.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import { runPolymarketWhaleBetBacktest, type LegacyWhaleBetSignal } from './polymarket-whale-backtest.js'
+import type { LegacyOddsShiftSignal } from './polymarket-backtest.js'
+
+const whale = (
+  id: string,
+  slug: string,
+  createdAt: string,
+  amount: number,
+  side: string,
+  outcome: string,
+  tradePrice?: number
+): LegacyWhaleBetSignal => ({
+  id,
+  slug,
+  topic: slug,
+  created_at: createdAt,
+  weight: amount >= 10_000 ? 10 : 8,
+  metadata: {
+    slug,
+    amount,
+    side,
+    outcome,
+    user: `wallet-${id}`,
+    activityTimestamp: createdAt,
+    walletTotalBets: 100,
+    walletWinRate: 0.6,
+    tradePrice,
+  },
+})
+
+const odds = (
+  id: string,
+  slug: string,
+  createdAt: string,
+  price: number
+): LegacyOddsShiftSignal => ({
+  id,
+  slug,
+  topic: slug,
+  created_at: createdAt,
+  metadata: {
+    slug,
+    shift_from: price - 0.01,
+    shift_to: price,
+    yes_price: price,
+  },
+})
+
+describe('Polymarket whale-bet backtest', () => {
+  it('evaluates whale bet direction against later odds movement', () => {
+    const whales = [
+      whale('1', 'market-a', '2026-01-01T00:00:00.000Z', 5_000, 'BUY', 'Yes'),
+      whale('2', 'market-b', '2026-01-01T00:00:00.000Z', 5_000, 'BUY', 'No'),
+    ]
+    const oddsRows = [
+      odds('o1', 'market-a', '2026-01-01T00:01:00.000Z', 0.4),
+      odds('o2', 'market-a', '2026-01-01T06:00:00.000Z', 0.45),
+      odds('o3', 'market-b', '2026-01-01T00:01:00.000Z', 0.6),
+      odds('o4', 'market-b', '2026-01-01T06:00:00.000Z', 0.55),
+    ]
+
+    const result = runPolymarketWhaleBetBacktest(whales, oddsRows, {
+      continuationDelta: 0.03,
+      windowHours: 24,
+      topFraction: 1,
+      minCandidates: 1,
+    })
+
+    expect(result.summary.signalKind).toBe('polymarket.large_trade')
+    expect(result.summary.baseline).toBe('largest_trade_amount')
+    expect(result.summary.candidateCount).toBe(2)
+    expect(result.summary.hitRate).toBe(1)
+    expect(result.summary.actualWindowDays).toBeGreaterThanOrEqual(0)
+    expect(result.selected[0]?.criteria[0]).toMatchObject({ kind: 'odds_move', targetDelta: 0.03, windowHours: 24 })
+    expect(result.summary.confidenceInterval?.level).toBe(0.95)
+    expect(result.byArchetype.conviction.candidateCount).toBe(2)
+    expect(result.byArchetype.conviction.selectedCount).toBe(2)
+  })
+
+  it('prefers metadata.activityTimestamp over database created_at for historical alignment', () => {
+    const whales: LegacyWhaleBetSignal[] = [{
+      id: 'activity-time',
+      slug: 'market-a',
+      topic: 'market-a',
+      created_at: '2026-01-02T00:00:00.000Z',
+      weight: 8,
+      metadata: {
+        slug: 'market-a',
+        amount: 5_000,
+        side: 'BUY',
+        outcome: 'Yes',
+        user: 'wallet-activity-time',
+        activityTimestamp: '2026-01-01T00:00:00.000Z',
+        walletTotalBets: 100,
+        walletWinRate: 0.6,
+      },
+    }]
+    const oddsRows = [
+      odds('o1', 'market-a', '2026-01-01T00:01:00.000Z', 0.4),
+      odds('o2', 'market-a', '2026-01-01T06:00:00.000Z', 0.45),
+    ]
+
+    const result = runPolymarketWhaleBetBacktest(whales, oddsRows, {
+      continuationDelta: 0.03,
+      windowHours: 24,
+      topFraction: 1,
+      minCandidates: 1,
+    })
+
+    expect(result.summary.candidateCount).toBe(1)
+    expect(result.selected[0]?.result).toBe('hit')
+  })
+
+  it('reports archetype stats and excludes penny-pickup from selected publishable whales', () => {
+    const whales = [
+      whale('1', 'market-a', '2026-01-01T00:00:00.000Z', 100_000, 'BUY', 'Yes', 0.99),
+      whale('2', 'market-b', '2026-01-01T00:00:00.000Z', 10_000, 'BUY', 'Yes', 0.2),
+    ]
+    const oddsRows = [
+      odds('o1', 'market-a', '2026-01-01T00:01:00.000Z', 0.99),
+      odds('o2', 'market-a', '2026-01-01T06:00:00.000Z', 1),
+      odds('o3', 'market-b', '2026-01-01T00:01:00.000Z', 0.2),
+      odds('o4', 'market-b', '2026-01-01T06:00:00.000Z', 0.25),
+    ]
+
+    const result = runPolymarketWhaleBetBacktest(whales, oddsRows, {
+      continuationDelta: 0.03,
+      windowHours: 24,
+      topFraction: 1,
+      minCandidates: 1,
+    })
+
+    expect(result.byArchetype.penny_pickup.candidateCount).toBe(1)
+    expect(result.byArchetype.penny_pickup.selectedCount).toBe(0)
+    expect(result.byArchetype.contrarian.candidateCount).toBe(1)
+    expect(result.byArchetype.contrarian.selectedCount).toBe(1)
+    expect(result.selected).toHaveLength(1)
+    expect(result.baseline).toHaveLength(1)
+    expect(result.baseline[0]?.narrativeId).toContain('classified:2')
+  })
+})

--- a/packages/brain/src/intelligence/polymarket-whale-backtest.ts
+++ b/packages/brain/src/intelligence/polymarket-whale-backtest.ts
@@ -1,0 +1,403 @@
+import {
+  INTELLIGENCE_SCHEMA_VERSION,
+  INTELLIGENCE_SCORING_VERSION,
+  oddsMoveCriterion,
+  type BacktestRunSummary,
+  type ClassifiedSignal,
+  type NarrativeOutcome,
+  type SignalDirection,
+} from './contracts.js'
+import { classifyPolymarketWhaleBet, scorePolymarketWhaleBet, type PolymarketWhaleBetArchetype } from './scoring.js'
+import type { LegacyOddsShiftSignal, OddsShiftBacktestOptions } from './polymarket-backtest.js'
+
+export interface LegacyWhaleBetSignal {
+  id: string
+  topic?: string | null
+  slug?: string | null
+  created_at: string
+  weight?: number | null
+  metadata?: {
+    user?: string
+    amount?: number | string
+    side?: string
+    outcome?: string
+    marketId?: string
+    slug?: string
+    walletTotalBets?: number | string | null
+    walletWinRate?: number | string | null
+    walletLabel?: string
+    tradePrice?: number | string | null
+    marketOddsAtBet?: number | string | null
+    activityTimestamp?: string
+    source?: string
+    [key: string]: unknown
+  } | null
+}
+
+export interface WhaleBetBacktestOptions extends OddsShiftBacktestOptions {
+  minAmountUsd?: number
+}
+
+export interface WhaleBetArchetypeBacktestStats {
+  archetype: PolymarketWhaleBetArchetype
+  candidateCount: number
+  selectedCount: number
+  hitRate: number
+  missRate: number
+  avgRiskUsd: number | null
+  avgAmountUsd: number
+  examples: NarrativeOutcome[]
+}
+
+export interface WhaleBetBacktestResult {
+  summary: BacktestRunSummary
+  selectedSignals: ClassifiedSignal<Candidate['signal']['metadata']>[]
+  selected: NarrativeOutcome[]
+  baselineSignals: ClassifiedSignal<Candidate['signal']['metadata']>[]
+  baseline: NarrativeOutcome[]
+  byArchetype: Record<PolymarketWhaleBetArchetype, WhaleBetArchetypeBacktestStats>
+  examples: {
+    hits: NarrativeOutcome[]
+    misses: NarrativeOutcome[]
+  }
+}
+
+interface OddsPoint {
+  observedAt: string
+  price: number
+}
+
+interface Candidate {
+  signal: ClassifiedSignal<{
+    amountUsd: number
+    side: string | null
+    outcome: string | null
+    wallet: string | null
+    walletTotalBets: number | null
+    walletWinRate: number | null
+    tradePrice: number | null
+    marketOddsAtBet: number | null
+    whaleArchetype: PolymarketWhaleBetArchetype
+    riskUsd: number | null
+    publishableAsConviction: boolean
+    publishableAsNarrative: boolean
+    classificationReason: string
+  }>
+  outcome: NarrativeOutcome
+  amountUsd: number
+}
+
+const DEFAULT_OPTIONS: WhaleBetBacktestOptions = {
+  continuationDelta: 0.03,
+  windowHours: 24,
+  topFraction: 0.3,
+  minCandidates: 10,
+  minAmountUsd: 500,
+}
+
+const mean = (values: number[]): number =>
+  values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
+
+const wilsonInterval = (hits: number, n: number, z = 1.96): { lower: number; upper: number; level: number } => {
+  if (n === 0) return { lower: 0, upper: 0, level: 0.95 }
+  const p = hits / n
+  const denom = 1 + (z * z) / n
+  const center = (p + (z * z) / (2 * n)) / denom
+  const margin = (z / denom) * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n))
+  return { lower: Math.max(0, center - margin), upper: Math.min(1, center + margin), level: 0.95 }
+}
+
+function numberOrNull(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizePrice(value: unknown): number | null {
+  const parsed = numberOrNull(value)
+  return parsed != null && parsed >= 0 && parsed <= 1 ? parsed : null
+}
+
+function inferDirection(sideRaw: unknown, outcomeRaw: unknown): Exclude<SignalDirection, 'neutral' | 'unknown'> | null {
+  const side = typeof sideRaw === 'string' ? sideRaw.toUpperCase() : ''
+  const outcome = typeof outcomeRaw === 'string' ? outcomeRaw.toUpperCase() : ''
+  if (!side) return null
+
+  const isNo = outcome === 'NO'
+  const isSell = side === 'SELL'
+
+  // Most non-YES/NO Polymarket slugs are already an outcome-specific binary market.
+  // BUY means conviction in that outcome's YES price; SELL means pressure against it.
+  if (isNo) return isSell ? 'up' : 'down'
+  return isSell ? 'down' : 'up'
+}
+
+function toClassifiedSignal(raw: LegacyWhaleBetSignal): ClassifiedSignal<Candidate['signal']['metadata']> | null {
+  const slug = raw.slug ?? raw.metadata?.slug
+  const amountUsd = numberOrNull(raw.metadata?.amount)
+  const direction = inferDirection(raw.metadata?.side, raw.metadata?.outcome)
+  const observedAt = typeof raw.metadata?.activityTimestamp === 'string' ? raw.metadata.activityTimestamp : raw.created_at
+  if (!slug || amountUsd == null || amountUsd <= 0 || !direction) return null
+
+  const walletTotalBets = numberOrNull(raw.metadata?.walletTotalBets)
+  const walletWinRate = numberOrNull(raw.metadata?.walletWinRate)
+  const tradePrice = normalizePrice(raw.metadata?.tradePrice)
+  const marketOddsAtBet = normalizePrice(raw.metadata?.marketOddsAtBet)
+  const outcome = typeof raw.metadata?.outcome === 'string' ? raw.metadata.outcome : null
+  const classificationInput = {
+    amountUsd,
+    hoursSinceObserved: 0,
+    tradePrice,
+    marketOddsAtBet,
+    outcome,
+    walletTotalBets,
+    walletWinRate,
+  }
+  const whaleClassification = classifyPolymarketWhaleBet(classificationInput)
+  const score = scorePolymarketWhaleBet(classificationInput)
+
+  return {
+    schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+    id: `classified:${raw.id}`,
+    kind: 'polymarket.large_trade',
+    source: 'polymarket',
+    featureSnapshotIds: [`legacy-signal:${raw.id}`],
+    entityRef: {
+      marketId: raw.metadata?.marketId,
+      slug,
+    },
+    direction,
+    observedAt,
+    classifiedAt: new Date().toISOString(),
+    scoringVersion: INTELLIGENCE_SCORING_VERSION,
+    ruleId: 'polymarket.whale_bet.v2',
+    score,
+    metadata: {
+      amountUsd,
+      side: typeof raw.metadata?.side === 'string' ? raw.metadata.side : null,
+      outcome,
+      wallet: typeof raw.metadata?.user === 'string' ? raw.metadata.user : null,
+      walletTotalBets,
+      walletWinRate,
+      tradePrice,
+      marketOddsAtBet,
+      whaleArchetype: whaleClassification.archetype,
+      riskUsd: whaleClassification.riskUsd,
+      publishableAsConviction: whaleClassification.publishableAsConviction,
+      publishableAsNarrative: whaleClassification.publishableAsConviction,
+      classificationReason: whaleClassification.reason,
+    },
+    trace: [
+      {
+        source: 'polymarket',
+        sourceId: raw.id,
+        fetchedAt: raw.created_at,
+      },
+    ],
+  }
+}
+
+function oddsPointsBySlug(rawOdds: LegacyOddsShiftSignal[]): Map<string, OddsPoint[]> {
+  const groups = new Map<string, OddsPoint[]>()
+  for (const row of rawOdds) {
+    const slug = row.slug ?? row.metadata?.slug
+    const price = normalizePrice(row.metadata?.shift_to ?? row.metadata?.yes_price)
+    if (!slug || price == null) continue
+    const group = groups.get(slug) ?? []
+    group.push({ observedAt: row.created_at, price })
+    groups.set(slug, group)
+  }
+  for (const group of groups.values()) {
+    group.sort((a, b) => a.observedAt.localeCompare(b.observedAt))
+  }
+  return groups
+}
+
+function evaluateCandidate(
+  signal: ClassifiedSignal<Candidate['signal']['metadata']>,
+  oddsPoints: OddsPoint[],
+  options: WhaleBetBacktestOptions
+): NarrativeOutcome {
+  const cutoff = new Date(new Date(signal.observedAt).getTime() + options.windowHours * 3_600_000).toISOString()
+  const start = oddsPoints.find((point) => point.observedAt >= signal.observedAt)
+  if (!start || start.observedAt > cutoff) {
+    return {
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: `outcome:${signal.id}`,
+      narrativeId: signal.id,
+      evaluatedAt: new Date().toISOString(),
+      criteria: [oddsMoveCriterion(signal.direction as 'up' | 'down', options.continuationDelta, options.windowHours)],
+      result: 'inconclusive',
+      measuredValues: { startPrice: null, latestPrice: null, measuredMove: null, matchedAt: null, matchedPrice: null },
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+      notes: 'No odds point found inside evaluation window at or after whale bet timestamp',
+    }
+  }
+
+  let latestInWindow: OddsPoint | undefined
+  let matched: OddsPoint | undefined
+
+  for (const point of oddsPoints) {
+    if (point.observedAt <= start.observedAt) continue
+    if (point.observedAt > cutoff) break
+    latestInWindow = point
+    const move = point.price - start.price
+    if (!matched && (signal.direction === 'up' ? move >= options.continuationDelta : move <= -options.continuationDelta)) {
+      matched = point
+    }
+  }
+
+  const measuredMove = latestInWindow ? latestInWindow.price - start.price : 0
+  return {
+    schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+    id: `outcome:${signal.id}`,
+    narrativeId: signal.id,
+    evaluatedAt: new Date().toISOString(),
+    criteria: [oddsMoveCriterion(signal.direction as 'up' | 'down', options.continuationDelta, options.windowHours)],
+    result: matched ? 'hit' : latestInWindow ? 'miss' : 'inconclusive',
+    measuredValues: {
+      startPrice: start.price,
+      latestPrice: latestInWindow?.price ?? null,
+      measuredMove,
+      matchedAt: matched?.observedAt ?? null,
+      matchedPrice: matched?.price ?? null,
+    },
+    scoringVersion: INTELLIGENCE_SCORING_VERSION,
+  }
+}
+
+
+function classifyWithBacktestOddsFallback(signal: Candidate['signal'], outcome: NarrativeOutcome): Candidate['signal'] {
+  if (signal.metadata.tradePrice != null || signal.metadata.marketOddsAtBet != null) return signal
+  const startPrice = numberOrNull(outcome.measuredValues.startPrice)
+  if (startPrice == null) return signal
+
+  const classificationInput = {
+    amountUsd: signal.metadata.amountUsd,
+    hoursSinceObserved: 0,
+    tradePrice: null,
+    marketOddsAtBet: startPrice,
+    outcome: signal.metadata.outcome,
+    walletTotalBets: signal.metadata.walletTotalBets,
+    walletWinRate: signal.metadata.walletWinRate,
+  }
+  const whaleClassification = classifyPolymarketWhaleBet(classificationInput)
+  return {
+    ...signal,
+    score: scorePolymarketWhaleBet(classificationInput),
+    metadata: {
+      ...signal.metadata,
+      marketOddsAtBet: startPrice,
+      whaleArchetype: whaleClassification.archetype,
+      riskUsd: whaleClassification.riskUsd,
+      publishableAsConviction: whaleClassification.publishableAsConviction,
+      publishableAsNarrative: whaleClassification.publishableAsConviction,
+      classificationReason: `${whaleClassification.reason} (using backtest start odds fallback)`,
+    },
+  }
+}
+
+const ARCHETYPES: PolymarketWhaleBetArchetype[] = ['penny_pickup', 'lottery', 'contrarian', 'conviction', 'noise']
+
+function buildArchetypeStats(candidates: Candidate[], selected: Candidate[]): Record<PolymarketWhaleBetArchetype, WhaleBetArchetypeBacktestStats> {
+  const selectedIds = new Set(selected.map((candidate) => candidate.signal.id))
+  return Object.fromEntries(
+    ARCHETYPES.map((archetype) => {
+      const group = candidates.filter((candidate) => candidate.signal.metadata.whaleArchetype === archetype)
+      const hits = group.filter((candidate) => candidate.outcome.result === 'hit').length
+      const misses = group.filter((candidate) => candidate.outcome.result === 'miss').length
+      const risks = group.map((candidate) => candidate.signal.metadata.riskUsd).filter((risk): risk is number => typeof risk === 'number' && Number.isFinite(risk))
+      return [archetype, {
+        archetype,
+        candidateCount: group.length,
+        selectedCount: group.filter((candidate) => selectedIds.has(candidate.signal.id)).length,
+        hitRate: group.length === 0 ? 0 : hits / group.length,
+        missRate: group.length === 0 ? 0 : misses / group.length,
+        avgRiskUsd: risks.length === 0 ? null : mean(risks),
+        avgAmountUsd: mean(group.map((candidate) => candidate.amountUsd)),
+        examples: group.slice(0, 3).map((candidate) => candidate.outcome),
+      }]
+    })
+  ) as Record<PolymarketWhaleBetArchetype, WhaleBetArchetypeBacktestStats>
+}
+
+export function runPolymarketWhaleBetBacktest(
+  rawWhales: LegacyWhaleBetSignal[],
+  rawOdds: LegacyOddsShiftSignal[],
+  partialOptions: Partial<WhaleBetBacktestOptions> = {}
+): WhaleBetBacktestResult {
+  const options = { ...DEFAULT_OPTIONS, ...partialOptions }
+  const oddsBySlug = oddsPointsBySlug(rawOdds)
+  const signals = rawWhales
+    .map(toClassifiedSignal)
+    .filter((signal): signal is ClassifiedSignal<Candidate['signal']['metadata']> => Boolean(signal))
+    .filter((signal) => signal.metadata.amountUsd >= (options.minAmountUsd ?? 0))
+    .sort((a, b) => a.observedAt.localeCompare(b.observedAt))
+
+  const candidates: Candidate[] = signals.map((signal) => {
+    const outcome = evaluateCandidate(signal, oddsBySlug.get(signal.entityRef.slug ?? '') ?? [], options)
+    const classifiedSignal = classifyWithBacktestOddsFallback(signal, outcome)
+    return {
+      signal: classifiedSignal,
+      outcome,
+      amountUsd: classifiedSignal.metadata.amountUsd,
+    }
+  })
+
+  const conclusive = candidates.filter((candidate) => candidate.outcome.result !== 'inconclusive')
+  const publishable = conclusive.filter((candidate) => candidate.signal.metadata.publishableAsNarrative)
+  const selectedCount = Math.max(options.minCandidates ?? 1, Math.ceil(publishable.length * options.topFraction))
+  const boundedSelectedCount = Math.min(selectedCount, publishable.length)
+
+  const selectedCandidates = [...publishable]
+    .sort((a, b) => b.signal.score.confidence - a.signal.score.confidence || b.signal.score.urgency - a.signal.score.urgency)
+    .slice(0, boundedSelectedCount)
+
+  const selectedSignals = selectedCandidates.map((candidate) => candidate.signal)
+  const selected = selectedCandidates.map((candidate) => candidate.outcome)
+
+  // Compare against the same publishable candidate pool we allow the scorer to select from.
+  // Otherwise the baseline can win by picking non-narratable trades (for example penny-pickup
+  // clips near 99¢) that the production classifier intentionally suppresses.
+  const baselineCandidates = [...publishable]
+    .sort((a, b) => b.amountUsd - a.amountUsd)
+    .slice(0, boundedSelectedCount)
+  const baselineSignals = baselineCandidates.map((candidate) => candidate.signal)
+  const baseline = baselineCandidates.map((candidate) => candidate.outcome)
+
+  const hitRate = mean(selected.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
+  const baselineHitRate = mean(baseline.map((outcome) => (outcome.result === 'hit' ? 1 : 0)))
+  const hits = selected.filter((outcome) => outcome.result === 'hit').length
+  const windowStart = conclusive[0]?.signal.observedAt ?? signals[0]?.observedAt ?? new Date().toISOString()
+  const windowEnd = conclusive.at(-1)?.signal.observedAt ?? signals.at(-1)?.observedAt ?? windowStart
+  const actualWindowDays = Math.max(0, (new Date(windowEnd).getTime() - new Date(windowStart).getTime()) / 86_400_000)
+
+  return {
+    summary: {
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: `backtest:polymarket.whale_bet:${Date.now()}`,
+      source: 'polymarket',
+      signalKind: 'polymarket.large_trade',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      windowStart,
+      windowEnd,
+      requestedWindowDays: options.requestedWindowDays,
+      actualWindowDays,
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+      baseline: 'largest_trade_amount',
+      candidateCount: conclusive.length,
+      hitRate,
+      baselineHitRate,
+      confidenceInterval: wilsonInterval(hits, selected.length),
+    },
+    selectedSignals,
+    selected,
+    baselineSignals,
+    baseline,
+    byArchetype: buildArchetypeStats(conclusive, selectedCandidates),
+    examples: {
+      hits: selected.filter((outcome) => outcome.result === 'hit').slice(0, 5),
+      misses: selected.filter((outcome) => outcome.result === 'miss').slice(0, 5),
+    },
+  }
+}

--- a/packages/brain/src/intelligence/schemas.test.ts
+++ b/packages/brain/src/intelligence/schemas.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { INTELLIGENCE_SCHEMA_VERSION, INTELLIGENCE_SCORING_VERSION, oddsMoveCriterion } from './contracts.js'
+import { BacktestRunSummarySchema, NarrativeOutcomeSchema, RawEventSchema } from './schemas.js'
+
+describe('intelligence runtime schemas', () => {
+  it('validates raw events at runtime', () => {
+    const parsed = RawEventSchema.parse({
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: 'raw-1',
+      source: 'polymarket',
+      kind: 'polymarket.large_trade',
+      entityRef: { slug: 'market-a' },
+      observedAt: '2026-01-01T00:00:00.000Z',
+      receivedAt: '2026-01-01T00:00:01.000Z',
+      dedupeKey: 'polymarket:trade:1',
+      trace: {
+        source: 'polymarket',
+        sourceId: 'trade-1',
+        fetchedAt: '2026-01-01T00:00:01.000Z',
+      },
+      payload: { amount: 1000 },
+    })
+
+    expect(parsed.schemaVersion).toBe(INTELLIGENCE_SCHEMA_VERSION)
+    expect(parsed.entityRef.slug).toBe('market-a')
+  })
+
+  it('rejects stale schema versions', () => {
+    const result = RawEventSchema.safeParse({ schemaVersion: 999 })
+    expect(result.success).toBe(false)
+  })
+
+  it('validates frozen outcome criteria and actual backtest windows', () => {
+    const outcome = NarrativeOutcomeSchema.parse({
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: 'outcome-1',
+      narrativeId: 'classified-1',
+      evaluatedAt: '2026-01-02T00:00:00.000Z',
+      criteria: [oddsMoveCriterion('up', 0.03, 24)],
+      result: 'hit',
+      measuredValues: { startPrice: 0.4, latestPrice: 0.45, measuredMove: 0.05 },
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+    })
+    expect(outcome.criteria[0]).toMatchObject({ kind: 'odds_move', targetDelta: 0.03 })
+
+    const summary = BacktestRunSummarySchema.parse({
+      schemaVersion: INTELLIGENCE_SCHEMA_VERSION,
+      id: 'backtest-1',
+      source: 'polymarket',
+      signalKind: 'polymarket.odds_shift',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-02T00:00:00.000Z',
+      windowStart: '2026-01-01T00:00:00.000Z',
+      windowEnd: '2026-02-05T00:00:00.000Z',
+      requestedWindowDays: 35,
+      actualWindowDays: 35,
+      scoringVersion: INTELLIGENCE_SCORING_VERSION,
+      baseline: 'largest_raw_odds_delta',
+      candidateCount: 10,
+      hitRate: 0.7,
+      baselineHitRate: 0.5,
+    })
+    expect(summary.actualWindowDays).toBe(35)
+  })
+})

--- a/packages/brain/src/intelligence/schemas.ts
+++ b/packages/brain/src/intelligence/schemas.ts
@@ -1,0 +1,283 @@
+import {
+  INTELLIGENCE_SCHEMA_VERSION,
+  type BacktestRunSummary,
+  type ClassifiedSignal,
+  type NarrativeCandidate,
+  type NarrativeOutcome,
+  type OutcomeCriterion,
+  type PublishedNarrative,
+  type RawEvent,
+} from './contracts.js'
+
+export interface RuntimeSchema<T> {
+  readonly name: string
+  parse(value: unknown): T
+  safeParse(value: unknown): { success: true; data: T } | { success: false; error: Error }
+}
+
+type Validator<T> = (value: unknown, path: string) => T
+
+function schema<T>(name: string, validate: Validator<T>): RuntimeSchema<T> {
+  return {
+    name,
+    parse(value: unknown): T {
+      return validate(value, name)
+    },
+    safeParse(value: unknown) {
+      try {
+        return { success: true, data: validate(value, name) }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error : new Error(String(error)) }
+      }
+    },
+  }
+}
+
+function fail(path: string, message: string): never {
+  throw new Error(`${path}: ${message}`)
+}
+
+function object(value: unknown, path: string): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : fail(path, 'expected object')
+}
+
+function string(value: unknown, path: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fail(path, 'expected non-empty string')
+}
+
+function number(value: unknown, path: string): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fail(path, 'expected finite number')
+}
+
+function integer(value: unknown, path: string): number {
+  const n = number(value, path)
+  return Number.isInteger(n) ? n : fail(path, 'expected integer')
+}
+
+function literal<T extends string | number | boolean>(value: unknown, expected: T, path: string): T {
+  return value === expected ? expected : fail(path, `expected ${String(expected)}`)
+}
+
+function optional<T>(value: unknown, path: string, validate: Validator<T>): T | undefined {
+  return value == null ? undefined : validate(value, path)
+}
+
+function stringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value)) fail(path, 'expected array')
+  return value.map((item, index) => string(item, `${path}[${index}]`))
+}
+
+function record(value: unknown, path: string): Record<string, unknown> {
+  return object(value, path)
+}
+
+function enumValue<T extends readonly string[]>(value: unknown, allowed: T, path: string): T[number] {
+  return typeof value === 'string' && allowed.includes(value)
+    ? value
+    : fail(path, `expected one of ${allowed.join(', ')}`)
+}
+
+function isoDate(value: unknown, path: string): string {
+  const text = string(value, path)
+  if (Number.isNaN(new Date(text).getTime())) fail(path, 'expected ISO date string')
+  return text
+}
+
+function contractVersion(value: unknown, path: string): typeof INTELLIGENCE_SCHEMA_VERSION {
+  return literal(value, INTELLIGENCE_SCHEMA_VERSION, path)
+}
+
+const sources = ['polymarket'] as const
+const rawKinds = ['polymarket.market_snapshot', 'polymarket.odds_snapshot', 'polymarket.volume_liquidity_snapshot', 'polymarket.large_trade', 'polymarket.resolution'] as const
+const signalKinds = ['polymarket.odds_shift', 'polymarket.volume_spike', 'polymarket.liquidity_expansion', 'polymarket.large_trade', 'polymarket.resolution'] as const
+const directions = ['up', 'down', 'neutral', 'unknown'] as const
+const baselines = ['random_candidate', 'largest_raw_odds_delta', 'largest_trade_amount'] as const
+
+function entityRef(value: unknown, path: string): RawEvent['entityRef'] {
+  const v = object(value, path)
+  return {
+    marketId: optional(v.marketId, `${path}.marketId`, string),
+    slug: optional(v.slug, `${path}.slug`, string),
+    conditionId: optional(v.conditionId, `${path}.conditionId`, string),
+    assetId: optional(v.assetId, `${path}.assetId`, string),
+  }
+}
+
+function traceRef(value: unknown, path: string): RawEvent['trace'] {
+  const v = object(value, path)
+  return {
+    source: enumValue(v.source, sources, `${path}.source`),
+    sourceId: string(v.sourceId, `${path}.sourceId`),
+    fetchedAt: isoDate(v.fetchedAt, `${path}.fetchedAt`),
+    url: optional(v.url, `${path}.url`, string),
+    rawSnapshotId: optional(v.rawSnapshotId, `${path}.rawSnapshotId`, string),
+  }
+}
+
+function traceArray(value: unknown, path: string): RawEvent['trace'][] {
+  if (!Array.isArray(value)) fail(path, 'expected array')
+  return value.map((item, index) => traceRef(item, `${path}[${index}]`))
+}
+
+function scoreBreakdown(value: unknown, path: string): ClassifiedSignal['score'] {
+  const v = object(value, path)
+  return {
+    confidence: number(v.confidence, `${path}.confidence`),
+    urgency: number(v.urgency, `${path}.urgency`),
+    freshness: number(v.freshness, `${path}.freshness`),
+    sourceReliability: number(v.sourceReliability, `${path}.sourceReliability`),
+    signalWeight: number(v.signalWeight, `${path}.signalWeight`),
+    dedupePriority: number(v.dedupePriority, `${path}.dedupePriority`),
+  }
+}
+
+function outcomeCriterion(value: unknown, path: string): OutcomeCriterion {
+  const v = object(value, path)
+  const kind = string(v.kind, `${path}.kind`)
+  if (kind === 'odds_move') {
+    return {
+      kind,
+      direction: enumValue(v.direction, ['up', 'down'] as const, `${path}.direction`),
+      targetDelta: number(v.targetDelta, `${path}.targetDelta`),
+      windowHours: number(v.windowHours, `${path}.windowHours`),
+    }
+  }
+  if (kind === 'market_resolution') {
+    return {
+      kind,
+      expectedOutcome: string(v.expectedOutcome, `${path}.expectedOutcome`),
+      windowHours: optional(v.windowHours, `${path}.windowHours`, number),
+    }
+  }
+  if (kind === 'volume_or_liquidity_follow_through') {
+    return {
+      kind,
+      targetMultiplier: number(v.targetMultiplier, `${path}.targetMultiplier`),
+      windowHours: number(v.windowHours, `${path}.windowHours`),
+    }
+  }
+  return fail(`${path}.kind`, 'unknown outcome criterion kind')
+}
+
+function criteria(value: unknown, path: string): OutcomeCriterion[] {
+  if (!Array.isArray(value)) fail(path, 'expected array')
+  return value.map((item, index) => outcomeCriterion(item, `${path}[${index}]`))
+}
+
+export const OutcomeCriterionSchema = schema<OutcomeCriterion>('OutcomeCriterion', outcomeCriterion)
+
+export const RawEventSchema = schema<RawEvent>('RawEvent', (value, path) => {
+  const v = object(value, path)
+  return {
+    schemaVersion: contractVersion(v.schemaVersion, `${path}.schemaVersion`),
+    id: string(v.id, `${path}.id`),
+    source: enumValue(v.source, sources, `${path}.source`),
+    kind: enumValue(v.kind, rawKinds, `${path}.kind`),
+    entityRef: entityRef(v.entityRef, `${path}.entityRef`),
+    observedAt: isoDate(v.observedAt, `${path}.observedAt`),
+    receivedAt: isoDate(v.receivedAt, `${path}.receivedAt`),
+    dedupeKey: string(v.dedupeKey, `${path}.dedupeKey`),
+    trace: traceRef(v.trace, `${path}.trace`),
+    payload: v.payload,
+  }
+})
+
+export const ClassifiedSignalSchema = schema<ClassifiedSignal>('ClassifiedSignal', (value, path) => {
+  const v = object(value, path)
+  return {
+    schemaVersion: contractVersion(v.schemaVersion, `${path}.schemaVersion`),
+    id: string(v.id, `${path}.id`),
+    kind: enumValue(v.kind, signalKinds, `${path}.kind`),
+    source: enumValue(v.source, sources, `${path}.source`),
+    featureSnapshotIds: stringArray(v.featureSnapshotIds, `${path}.featureSnapshotIds`),
+    entityRef: entityRef(v.entityRef, `${path}.entityRef`),
+    direction: enumValue(v.direction, directions, `${path}.direction`),
+    observedAt: isoDate(v.observedAt, `${path}.observedAt`),
+    classifiedAt: isoDate(v.classifiedAt, `${path}.classifiedAt`),
+    scoringVersion: integer(v.scoringVersion, `${path}.scoringVersion`) as ClassifiedSignal['scoringVersion'],
+    ruleId: string(v.ruleId, `${path}.ruleId`),
+    score: scoreBreakdown(v.score, `${path}.score`),
+    metadata: record(v.metadata, `${path}.metadata`),
+    trace: traceArray(v.trace, `${path}.trace`),
+  }
+})
+
+export const NarrativeCandidateSchema = schema<NarrativeCandidate>('NarrativeCandidate', (value, path) => {
+  const v = object(value, path)
+  return {
+    schemaVersion: contractVersion(v.schemaVersion, `${path}.schemaVersion`),
+    id: string(v.id, `${path}.id`),
+    source: enumValue(v.source, sources, `${path}.source`),
+    signalIds: stringArray(v.signalIds, `${path}.signalIds`),
+    entityRef: entityRef(v.entityRef, `${path}.entityRef`),
+    title: string(v.title, `${path}.title`),
+    thesis: string(v.thesis, `${path}.thesis`),
+    whyNow: string(v.whyNow, `${path}.whyNow`),
+    invalidation: string(v.invalidation, `${path}.invalidation`),
+    narrativeScore: number(v.narrativeScore, `${path}.narrativeScore`),
+    scoringVersion: integer(v.scoringVersion, `${path}.scoringVersion`) as NarrativeCandidate['scoringVersion'],
+    successCriteria: criteria(v.successCriteria, `${path}.successCriteria`),
+    createdAt: isoDate(v.createdAt, `${path}.createdAt`),
+  }
+})
+
+export const PublishedNarrativeSchema = schema<PublishedNarrative>('PublishedNarrative', (value, path) => {
+  const v = object(value, path)
+  return {
+    ...NarrativeCandidateSchema.parse(value),
+    publishedAt: isoDate(v.publishedAt, `${path}.publishedAt`),
+    editorVersion: integer(v.editorVersion, `${path}.editorVersion`),
+    status: literal(v.status, 'published', `${path}.status`),
+  }
+})
+
+export const NarrativeOutcomeSchema = schema<NarrativeOutcome>('NarrativeOutcome', (value, path) => {
+  const v = object(value, path)
+  return {
+    schemaVersion: contractVersion(v.schemaVersion, `${path}.schemaVersion`),
+    id: string(v.id, `${path}.id`),
+    narrativeId: string(v.narrativeId, `${path}.narrativeId`),
+    evaluatedAt: isoDate(v.evaluatedAt, `${path}.evaluatedAt`),
+    criteria: criteria(v.criteria, `${path}.criteria`),
+    result: enumValue(v.result, ['hit', 'miss', 'inconclusive'] as const, `${path}.result`),
+    measuredValues: record(v.measuredValues, `${path}.measuredValues`) as NarrativeOutcome['measuredValues'],
+    scoringVersion: integer(v.scoringVersion, `${path}.scoringVersion`) as NarrativeOutcome['scoringVersion'],
+    notes: optional(v.notes, `${path}.notes`, string),
+  }
+})
+
+export const BacktestRunSummarySchema = schema<BacktestRunSummary>('BacktestRunSummary', (value, path) => {
+  const v = object(value, path)
+  const confidenceInterval = optional(v.confidenceInterval, `${path}.confidenceInterval`, (ci, ciPath) => {
+    const c = object(ci, ciPath)
+    return {
+      lower: number(c.lower, `${ciPath}.lower`),
+      upper: number(c.upper, `${ciPath}.upper`),
+      level: number(c.level, `${ciPath}.level`),
+    }
+  })
+  return {
+    schemaVersion: contractVersion(v.schemaVersion, `${path}.schemaVersion`),
+    id: string(v.id, `${path}.id`),
+    source: enumValue(v.source, sources, `${path}.source`),
+    signalKind: enumValue(v.signalKind, signalKinds, `${path}.signalKind`),
+    startedAt: isoDate(v.startedAt, `${path}.startedAt`),
+    completedAt: optional(v.completedAt, `${path}.completedAt`, isoDate),
+    windowStart: isoDate(v.windowStart, `${path}.windowStart`),
+    windowEnd: isoDate(v.windowEnd, `${path}.windowEnd`),
+    requestedWindowDays: optional(v.requestedWindowDays, `${path}.requestedWindowDays`, number),
+    actualWindowDays: number(v.actualWindowDays, `${path}.actualWindowDays`),
+    scoringVersion: integer(v.scoringVersion, `${path}.scoringVersion`) as BacktestRunSummary['scoringVersion'],
+    baseline: enumValue(v.baseline, baselines, `${path}.baseline`),
+    candidateCount: integer(v.candidateCount, `${path}.candidateCount`),
+    hitRate: number(v.hitRate, `${path}.hitRate`),
+    baselineHitRate: number(v.baselineHitRate, `${path}.baselineHitRate`),
+    ...(confidenceInterval ? { confidenceInterval } : {}),
+  }
+})
+
+export function parseIntelligenceContract<T>(runtimeSchema: RuntimeSchema<T>, value: unknown): T {
+  return runtimeSchema.parse(value)
+}

--- a/packages/brain/src/intelligence/scoring.test.ts
+++ b/packages/brain/src/intelligence/scoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { scorePolymarketOddsShift, scoringVersion } from './scoring.js'
+import { classifyPolymarketWhaleBet, scorePolymarketOddsShift, scorePolymarketWhaleBet, scoringVersion } from './scoring.js'
 
 const expectScoreRange = (value: number) => {
   expect(value).toBeGreaterThanOrEqual(0)
@@ -32,5 +32,26 @@ describe('intelligence v2 scoring', () => {
 
     expect(large.signalWeight).toBeGreaterThan(small.signalWeight)
     expect(large.confidence).toBeGreaterThan(small.confidence)
+  })
+
+
+  it('classifies 95%+ consensus whale bets as penny pickup, not conviction', () => {
+    const classification = classifyPolymarketWhaleBet({
+      amountUsd: 100_000,
+      hoursSinceObserved: 0,
+      tradePrice: 0.99,
+    })
+
+    expect(classification.archetype).toBe('penny_pickup')
+    expect(classification.publishableAsConviction).toBe(false)
+    expect(classification.riskUsd).toBeCloseTo(1_000)
+  })
+
+  it('scores contrarian whale risk higher than same-notional penny pickup', () => {
+    const penny = scorePolymarketWhaleBet({ amountUsd: 100_000, hoursSinceObserved: 0, tradePrice: 0.99 })
+    const contrarian = scorePolymarketWhaleBet({ amountUsd: 100_000, hoursSinceObserved: 0, tradePrice: 0.20 })
+
+    expect(contrarian.signalWeight).toBeGreaterThan(penny.signalWeight)
+    expect(contrarian.confidence).toBeGreaterThan(penny.confidence)
   })
 })

--- a/packages/brain/src/intelligence/scoring.test.ts
+++ b/packages/brain/src/intelligence/scoring.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { scorePolymarketOddsShift, scoringVersion } from './scoring.js'
+
+const expectScoreRange = (value: number) => {
+  expect(value).toBeGreaterThanOrEqual(0)
+  expect(value).toBeLessThanOrEqual(1)
+}
+
+describe('intelligence v2 scoring', () => {
+  it('returns current scoring version', () => {
+    expect(scoringVersion()).toBe(1)
+  })
+
+  it('scores Polymarket odds shifts into bounded components', () => {
+    const score = scorePolymarketOddsShift({
+      oddsDelta: 0.12,
+      hoursSinceObserved: 2,
+      liquidityUsd: 50_000,
+    })
+
+    expectScoreRange(score.confidence)
+    expectScoreRange(score.urgency)
+    expectScoreRange(score.freshness)
+    expectScoreRange(score.sourceReliability)
+    expectScoreRange(score.signalWeight)
+    expectScoreRange(score.dedupePriority)
+  })
+
+  it('gives stronger odds moves higher signal weight', () => {
+    const small = scorePolymarketOddsShift({ oddsDelta: 0.02, hoursSinceObserved: 1 })
+    const large = scorePolymarketOddsShift({ oddsDelta: 0.15, hoursSinceObserved: 1 })
+
+    expect(large.signalWeight).toBeGreaterThan(small.signalWeight)
+    expect(large.confidence).toBeGreaterThan(small.confidence)
+  })
+})

--- a/packages/brain/src/intelligence/scoring.ts
+++ b/packages/brain/src/intelligence/scoring.ts
@@ -1,0 +1,31 @@
+import { INTELLIGENCE_SCORING_VERSION, type ScoreBreakdown } from './contracts.js'
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value))
+
+export interface PolymarketOddsShiftInput {
+  oddsDelta: number
+  hoursSinceObserved: number
+  liquidityUsd?: number
+  sourceReliability?: number
+}
+
+export function scorePolymarketOddsShift(input: PolymarketOddsShiftInput): ScoreBreakdown {
+  const absDelta = Math.abs(input.oddsDelta)
+  const liquidityScore = input.liquidityUsd == null ? 0.5 : clamp01(Math.log10(Math.max(input.liquidityUsd, 1)) / 6)
+  const freshness = clamp01(1 - input.hoursSinceObserved / 24)
+  const sourceReliability = clamp01(input.sourceReliability ?? 0.8)
+  const signalWeight = clamp01(absDelta / 0.2)
+
+  return {
+    confidence: clamp01(signalWeight * 0.5 + liquidityScore * 0.25 + sourceReliability * 0.25),
+    urgency: clamp01(signalWeight * 0.7 + freshness * 0.3),
+    freshness,
+    sourceReliability,
+    signalWeight,
+    dedupePriority: clamp01(signalWeight * 0.6 + freshness * 0.4),
+  }
+}
+
+export function scoringVersion(): typeof INTELLIGENCE_SCORING_VERSION {
+  return INTELLIGENCE_SCORING_VERSION
+}

--- a/packages/brain/src/intelligence/scoring.ts
+++ b/packages/brain/src/intelligence/scoring.ts
@@ -7,6 +7,7 @@ export interface PolymarketOddsShiftInput {
   hoursSinceObserved: number
   liquidityUsd?: number
   sourceReliability?: number
+  currentPrice?: number
 }
 
 export function scorePolymarketOddsShift(input: PolymarketOddsShiftInput): ScoreBreakdown {
@@ -15,9 +16,14 @@ export function scorePolymarketOddsShift(input: PolymarketOddsShiftInput): Score
   const freshness = clamp01(1 - input.hoursSinceObserved / 24)
   const sourceReliability = clamp01(input.sourceReliability ?? 0.8)
   const signalWeight = clamp01(absDelta / 0.2)
+  const directionRoom = input.currentPrice == null
+    ? 1
+    : input.oddsDelta >= 0
+      ? clamp01((1 - input.currentPrice) / 0.5)
+      : clamp01(input.currentPrice / 0.5)
 
   return {
-    confidence: clamp01(signalWeight * 0.5 + liquidityScore * 0.25 + sourceReliability * 0.25),
+    confidence: clamp01((signalWeight * 0.5 + liquidityScore * 0.25 + sourceReliability * 0.25) * directionRoom),
     urgency: clamp01(signalWeight * 0.7 + freshness * 0.3),
     freshness,
     sourceReliability,

--- a/packages/brain/src/intelligence/scoring.ts
+++ b/packages/brain/src/intelligence/scoring.ts
@@ -32,6 +32,103 @@ export function scorePolymarketOddsShift(input: PolymarketOddsShiftInput): Score
   }
 }
 
+export interface PolymarketWhaleBetInput {
+  amountUsd: number
+  hoursSinceObserved: number
+  tradePrice?: number | null
+  marketOddsAtBet?: number | null
+  outcome?: string | null
+  walletTotalBets?: number | null
+  walletWinRate?: number | null
+  sourceReliability?: number
+}
+
+export type PolymarketWhaleBetArchetype = 'penny_pickup' | 'lottery' | 'contrarian' | 'conviction' | 'noise'
+
+export interface PolymarketWhaleBetClassification {
+  archetype: PolymarketWhaleBetArchetype
+  betProbability: number | null
+  riskUsd: number | null
+  reason: string
+  publishableAsConviction: boolean
+}
+
+function normalizeProbability(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1 ? value : null
+}
+
+function probabilityForOutcome(input: Pick<PolymarketWhaleBetInput, 'tradePrice' | 'marketOddsAtBet' | 'outcome'>): number | null {
+  const tradePrice = normalizeProbability(input.tradePrice)
+  if (tradePrice != null) return tradePrice
+
+  const yesOdds = normalizeProbability(input.marketOddsAtBet)
+  if (yesOdds == null) return null
+  return input.outcome?.toUpperCase() === 'NO' ? 1 - yesOdds : yesOdds
+}
+
+export function classifyPolymarketWhaleBet(input: PolymarketWhaleBetInput): PolymarketWhaleBetClassification {
+  const betProbability = probabilityForOutcome(input)
+  const riskUsd = betProbability == null ? null : input.amountUsd * Math.min(betProbability, 1 - betProbability)
+
+  if (input.amountUsd < 500) {
+    return { archetype: 'noise', betProbability, riskUsd, reason: 'below whale-tracking amount threshold', publishableAsConviction: false }
+  }
+  if (betProbability == null) {
+    return { archetype: 'noise', betProbability, riskUsd, reason: 'missing odds at bet time; cannot risk-adjust', publishableAsConviction: false }
+  }
+  if (betProbability >= 0.95) {
+    return { archetype: 'penny_pickup', betProbability, riskUsd, reason: 'bet is with 95%+ consensus; not directional whale alpha', publishableAsConviction: false }
+  }
+  if (betProbability <= 0.05) {
+    return { archetype: 'lottery', betProbability, riskUsd, reason: 'tiny-probability longshot; classify separately from normal conviction', publishableAsConviction: true }
+  }
+  if (betProbability < 0.30) {
+    return { archetype: 'contrarian', betProbability, riskUsd, reason: 'bet is against broad market consensus', publishableAsConviction: true }
+  }
+  if (riskUsd != null && riskUsd >= 1_000) {
+    return { archetype: 'conviction', betProbability, riskUsd, reason: 'meaningful risk at non-consensus odds', publishableAsConviction: true }
+  }
+  return { archetype: 'noise', betProbability, riskUsd, reason: 'risk-adjusted exposure too small', publishableAsConviction: false }
+}
+
+export function scorePolymarketWhaleBet(input: PolymarketWhaleBetInput): ScoreBreakdown {
+  const classification = classifyPolymarketWhaleBet(input)
+  const amountScore = clamp01(Math.log10(Math.max(input.amountUsd, 1)) / 5) // $100k ~= 1.0
+  const riskAdjustedScore = classification.riskUsd == null
+    ? amountScore * 0.5
+    : clamp01(Math.log10(Math.max(classification.riskUsd, 1)) / 5)
+  const oddsQuality = classification.archetype === 'penny_pickup'
+    ? 0.1
+    : classification.archetype === 'lottery'
+      ? 0.65
+      : classification.archetype === 'contrarian'
+        ? 0.55
+        : classification.archetype === 'conviction'
+          ? 1
+          : 0.25
+  const probabilityQuality = classification.betProbability == null
+    ? 0.25
+    : classification.betProbability >= 0.2 && classification.betProbability <= 0.8
+      ? 1
+      : classification.betProbability >= 0.1 && classification.betProbability <= 0.9
+        ? 0.55
+        : 0.15
+  const experienceScore = input.walletTotalBets == null ? 0.4 : clamp01(Math.log10(Math.max(input.walletTotalBets, 1)) / 4)
+  const winRateScore = input.walletWinRate == null ? 0.5 : clamp01(input.walletWinRate)
+  const freshness = clamp01(1 - input.hoursSinceObserved / 24)
+  const sourceReliability = clamp01(input.sourceReliability ?? 0.75)
+  const signalWeight = clamp01(riskAdjustedScore * 0.45 + oddsQuality * 0.25 + probabilityQuality * 0.3)
+
+  return {
+    confidence: clamp01(signalWeight * 0.55 + experienceScore * 0.15 + winRateScore * 0.1 + sourceReliability * 0.2),
+    urgency: clamp01(signalWeight * 0.65 + freshness * 0.35),
+    freshness,
+    sourceReliability,
+    signalWeight,
+    dedupePriority: clamp01(signalWeight * 0.7 + freshness * 0.3),
+  }
+}
+
 export function scoringVersion(): typeof INTELLIGENCE_SCORING_VERSION {
   return INTELLIGENCE_SCORING_VERSION
 }

--- a/packages/brain/src/publisher-types.ts
+++ b/packages/brain/src/publisher-types.ts
@@ -1,5 +1,7 @@
 // Shared types for publisher + critic pipeline
 
+import type { OutcomeCriterion } from './intelligence/contracts.js'
+
 export type ContentType = 'fomo' | 'signal' | 'sports' | 'macro' | 'news' | 'crypto'
 
 export interface NarrativeAction {
@@ -35,6 +37,10 @@ export interface Narrative {
   slugs: string[]
   status: string
   created_at: string
+  schema_version?: number | null
+  scoring_version?: number | null
+  editor_version?: number | null
+  success_criteria?: OutcomeCriterion[] | null
 }
 
 export interface PublishedNarrative {
@@ -44,4 +50,8 @@ export interface PublishedNarrative {
   tags: string[]
   content_type: ContentType
   actions: NarrativeAction[]
+  schema_version?: number | null
+  scoring_version?: number | null
+  editor_version?: number | null
+  success_criteria?: OutcomeCriterion[] | null
 }

--- a/packages/brain/src/publisher.ts
+++ b/packages/brain/src/publisher.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config'
 import { publisherGraph } from './graphs/publisher-graph.js'
+import { INTELLIGENCE_EDITOR_VERSION, INTELLIGENCE_SCHEMA_VERSION, INTELLIGENCE_SCORING_VERSION } from './intelligence/contracts.js'
 import { callMinimax, extractText } from './minimax.js'
 import type { Narrative, PublishedOutput } from './publisher-types.js'
 
@@ -80,33 +81,53 @@ async function findExistingThread(slugs: string[]): Promise<string | null> {
 }
 
 async function insertPublishedNarrative(
-  narrativeId: string,
+  narrative: Narrative,
   output: PublishedOutput,
   threadId: string | null
 ): Promise<void> {
   const url = `${SUPABASE_URL}/rest/v1/published_narratives`
-  const res = await fetch(url, {
+  const baseRow = {
+    narrative_id: narrative.id,
+    content_small: output.content_small,
+    content_full: output.content_full,
+    reasoning: output.reasoning,
+    tags: output.tags,
+    priority: output.priority,
+    actions: output.actions ?? [],
+    content_type: output.content_type,
+    thread_id: threadId,
+  }
+  const intelligenceRow = {
+    ...baseRow,
+    schema_version: narrative.schema_version ?? INTELLIGENCE_SCHEMA_VERSION,
+    scoring_version: narrative.scoring_version ?? INTELLIGENCE_SCORING_VERSION,
+    editor_version: narrative.editor_version ?? INTELLIGENCE_EDITOR_VERSION,
+    success_criteria: narrative.success_criteria ?? null,
+  }
+
+  const insert = (row: typeof baseRow | typeof intelligenceRow) => fetch(url, {
     method: 'POST',
     headers: {
       ...supabaseHeaders(),
       Prefer: 'return=minimal',
     },
-    body: JSON.stringify({
-      narrative_id: narrativeId,
-      content_small: output.content_small,
-      content_full: output.content_full,
-      reasoning: output.reasoning,
-      tags: output.tags,
-      priority: output.priority,
-      actions: output.actions ?? [],
-      content_type: output.content_type,
-      thread_id: threadId,
-    }),
+    body: JSON.stringify(row),
   })
 
-  if (!res.ok) {
-    throw new Error(`Supabase published_narratives insert failed: ${res.status} ${await res.text()}`)
+  const res = await insert(intelligenceRow)
+  if (res.ok) return
+
+  const text = await res.text()
+  // Prod-safe bridge: code writes frozen intelligence metadata once migration 037 is applied,
+  // but older prod DBs should keep publishing instead of failing on unknown columns.
+  if (/schema_version|scoring_version|editor_version|success_criteria|column/i.test(text)) {
+    console.warn(`[publisher] published_narratives intelligence columns unavailable; retrying legacy insert: ${text}`)
+    const fallback = await insert(baseRow)
+    if (fallback.ok) return
+    throw new Error(`Supabase published_narratives legacy insert failed: ${fallback.status} ${await fallback.text()}`)
   }
+
+  throw new Error(`Supabase published_narratives insert failed: ${res.status} ${text}`)
 }
 
 async function markNarrativeStatus(narrativeId: string, status: 'published' | 'rejected'): Promise<void> {
@@ -406,7 +427,7 @@ async function run(): Promise<void> {
 
       if (draft.publisher_score >= 8) {
         const threadId = await findExistingThread(narrative.slugs ?? [])
-        await insertPublishedNarrative(narrative.id, draft, threadId)
+        await insertPublishedNarrative(narrative, draft, threadId)
         await markNarrativeStatus(narrative.id, 'published')
         published.push({ narrative, output: draft })
         console.log(`[publisher] Published: "${narrative.cluster}" (publisher_score ${draft.publisher_score}, priority ${draft.priority}, content_type ${draft.content_type})`)

--- a/packages/brain/src/run-polymarket-odds-backtest.ts
+++ b/packages/brain/src/run-polymarket-odds-backtest.ts
@@ -1,0 +1,61 @@
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '../../.env' })
+loadEnv({ path: '.env' })
+loadEnv()
+import { createClient } from '@supabase/supabase-js'
+import { runPolymarketOddsShiftBacktest, type LegacyOddsShiftSignal } from './intelligence/polymarket-backtest.js'
+
+const days = Number(process.env.POLYMARKET_BACKTEST_DAYS ?? 30)
+const continuationDelta = Number(process.env.POLYMARKET_BACKTEST_CONTINUATION_DELTA ?? 0.03)
+const windowHours = Number(process.env.POLYMARKET_BACKTEST_WINDOW_HOURS ?? 24)
+const topFraction = Number(process.env.POLYMARKET_BACKTEST_TOP_FRACTION ?? 0.3)
+const maxRows = Number(process.env.POLYMARKET_BACKTEST_MAX_ROWS ?? 5000)
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required')
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey)
+const since = new Date(Date.now() - days * 24 * 3_600_000).toISOString()
+
+const rows: LegacyOddsShiftSignal[] = []
+const pageSize = 1000
+
+for (let from = 0; from < maxRows; from += pageSize) {
+  const to = Math.min(from + pageSize - 1, maxRows - 1)
+  const { data, error } = await supabase
+    .from('signals')
+    .select('id, topic, slug, created_at, metadata')
+    .eq('source', 'POLYMARKET')
+    .eq('type', 'ODDS_SHIFT')
+    .gte('created_at', since)
+    .order('created_at', { ascending: true })
+    .range(from, to)
+
+  if (error) throw error
+  rows.push(...((data ?? []) as LegacyOddsShiftSignal[]))
+  if (!data || data.length < pageSize) break
+}
+
+const result = runPolymarketOddsShiftBacktest(rows, {
+  continuationDelta,
+  windowHours,
+  topFraction,
+})
+
+console.log(JSON.stringify({
+  params: {
+    days,
+    continuationDelta,
+    windowHours,
+    topFraction,
+    rawSignals: rows.length,
+    maxRows,
+  },
+  summary: result.summary,
+  examples: result.examples,
+}, null, 2))

--- a/packages/brain/src/run-polymarket-odds-backtest.ts
+++ b/packages/brain/src/run-polymarket-odds-backtest.ts
@@ -4,6 +4,7 @@ loadEnv({ path: '../../.env' })
 loadEnv({ path: '.env' })
 loadEnv()
 import { createClient } from '@supabase/supabase-js'
+import { writeBacktestArtifact } from './intelligence/backtest-artifacts.js'
 import { runPolymarketOddsShiftBacktest, type LegacyOddsShiftSignal } from './intelligence/polymarket-backtest.js'
 
 const days = Number(process.env.POLYMARKET_BACKTEST_DAYS ?? 30)
@@ -11,6 +12,7 @@ const continuationDelta = Number(process.env.POLYMARKET_BACKTEST_CONTINUATION_DE
 const windowHours = Number(process.env.POLYMARKET_BACKTEST_WINDOW_HOURS ?? 24)
 const topFraction = Number(process.env.POLYMARKET_BACKTEST_TOP_FRACTION ?? 0.3)
 const maxRows = Number(process.env.POLYMARKET_BACKTEST_MAX_ROWS ?? 5000)
+const outputPath = process.env.POLYMARKET_BACKTEST_OUTPUT
 
 const supabaseUrl = process.env.SUPABASE_URL
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -41,21 +43,39 @@ for (let from = 0; from < maxRows; from += pageSize) {
   if (!data || data.length < pageSize) break
 }
 
+const params = {
+  days,
+  continuationDelta,
+  windowHours,
+  topFraction,
+  rawSignals: rows.length,
+  maxRows,
+}
+
 const result = runPolymarketOddsShiftBacktest(rows, {
   continuationDelta,
   windowHours,
   topFraction,
+  requestedWindowDays: days,
 })
 
+const artifact = {
+  params,
+  summary: result.summary,
+  selected: result.selected,
+  baseline: result.baseline,
+  examples: result.examples,
+}
+
+const artifactPath = await writeBacktestArtifact(artifact, outputPath)
+
+if (result.summary.actualWindowDays < Math.min(days, 30)) {
+  console.warn(`[polymarket-backtest] Requested ${days}d but conclusive candidate window is ${result.summary.actualWindowDays.toFixed(2)}d. Increase POLYMARKET_BACKTEST_DAYS/MAX_ROWS for >=30d acceptance evidence.`)
+}
+
 console.log(JSON.stringify({
-  params: {
-    days,
-    continuationDelta,
-    windowHours,
-    topFraction,
-    rawSignals: rows.length,
-    maxRows,
-  },
+  params,
   summary: result.summary,
   examples: result.examples,
+  artifactPath,
 }, null, 2))

--- a/packages/brain/src/run-polymarket-whale-backtest.ts
+++ b/packages/brain/src/run-polymarket-whale-backtest.ts
@@ -1,0 +1,108 @@
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '../../.env' })
+loadEnv({ path: '.env' })
+loadEnv()
+import { createClient } from '@supabase/supabase-js'
+import { writeBacktestArtifact } from './intelligence/backtest-artifacts.js'
+import { type LegacyOddsShiftSignal } from './intelligence/polymarket-backtest.js'
+import { runPolymarketWhaleBetBacktest, type LegacyWhaleBetSignal } from './intelligence/polymarket-whale-backtest.js'
+
+const days = Number(process.env.POLYMARKET_BACKTEST_DAYS ?? 30)
+const continuationDelta = Number(process.env.POLYMARKET_BACKTEST_CONTINUATION_DELTA ?? 0.03)
+const windowHours = Number(process.env.POLYMARKET_BACKTEST_WINDOW_HOURS ?? 24)
+const topFraction = Number(process.env.POLYMARKET_BACKTEST_TOP_FRACTION ?? 0.3)
+const minAmountUsd = Number(process.env.POLYMARKET_WHALE_BACKTEST_MIN_AMOUNT ?? 500)
+const maxWhaleRows = Number(process.env.POLYMARKET_WHALE_BACKTEST_MAX_ROWS ?? 50000)
+const maxOddsRows = Number(process.env.POLYMARKET_BACKTEST_MAX_ODDS_ROWS ?? 50000)
+const outputPath = process.env.POLYMARKET_BACKTEST_OUTPUT
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required')
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey)
+const since = new Date(Date.now() - days * 24 * 3_600_000).toISOString()
+// Do not backtest whale bets whose full evaluation window has not elapsed yet.
+const evaluationCutoff = new Date(Date.now() - windowHours * 3_600_000).toISOString()
+const pageSize = 1000
+
+async function fetchSignals<T>(type: string, maxRows: number): Promise<T[]> {
+  const rows: T[] = []
+  for (let from = 0; from < maxRows; from += pageSize) {
+    const to = Math.min(from + pageSize - 1, maxRows - 1)
+    let query = supabase
+      .from('signals')
+      .select('id, topic, slug, created_at, weight, metadata')
+      .eq('source', 'POLYMARKET')
+      .eq('type', type)
+      .gte('created_at', since)
+
+    if (type === 'WHALE_BET') {
+      query = query.lte('created_at', evaluationCutoff)
+    }
+
+    const { data, error } = await query
+      .order('created_at', { ascending: true })
+      .range(from, to)
+
+    if (error) throw error
+    rows.push(...((data ?? []) as T[]))
+    if (!data || data.length < pageSize) break
+  }
+  return rows
+}
+
+const [whaleRows, oddsRows] = await Promise.all([
+  fetchSignals<LegacyWhaleBetSignal>('WHALE_BET', maxWhaleRows),
+  fetchSignals<LegacyOddsShiftSignal>('ODDS_SHIFT', maxOddsRows),
+])
+
+const params = {
+  days,
+  continuationDelta,
+  windowHours,
+  topFraction,
+  minAmountUsd,
+  evaluationCutoff,
+  rawWhaleSignals: whaleRows.length,
+  rawOddsSignals: oddsRows.length,
+  maxWhaleRows,
+  maxOddsRows,
+}
+
+const result = runPolymarketWhaleBetBacktest(whaleRows, oddsRows, {
+  continuationDelta,
+  windowHours,
+  topFraction,
+  minAmountUsd,
+  requestedWindowDays: days,
+})
+
+const artifact = {
+  params,
+  summary: result.summary,
+  selectedSignals: result.selectedSignals,
+  selected: result.selected,
+  baselineSignals: result.baselineSignals,
+  baseline: result.baseline,
+  byArchetype: result.byArchetype,
+  examples: result.examples,
+}
+
+const artifactPath = await writeBacktestArtifact(artifact, outputPath)
+
+if (result.summary.actualWindowDays < Math.min(days, 30)) {
+  console.warn(`[polymarket-whale-backtest] Requested ${days}d but conclusive candidate window is ${result.summary.actualWindowDays.toFixed(2)}d. Increase POLYMARKET_BACKTEST_DAYS/MAX_ROWS for >=30d acceptance evidence.`)
+}
+
+console.log(JSON.stringify({
+  params,
+  summary: result.summary,
+  byArchetype: result.byArchetype,
+  examples: result.examples,
+  artifactPath,
+}, null, 2))

--- a/packages/collectors/src/polymarket/match-watcher.ts
+++ b/packages/collectors/src/polymarket/match-watcher.ts
@@ -39,6 +39,9 @@ interface PolyTrade {
   outcome?: string
   size?: number
   amount?: number
+  price?: number
+  tradePrice?: number
+  marketPrice?: number
   conditionId?: string
   asset?: string
   title?: string
@@ -91,6 +94,25 @@ async function resolveConditionId(slug: string): Promise<string | null> {
   }
 }
 
+
+const oddsCache = new Map<string, number | null>()
+
+async function fetchMarketOddsAtBet(slug: string): Promise<number | null> {
+  if (oddsCache.has(slug)) return oddsCache.get(slug)!
+  try {
+    const res = await fetch(`https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(slug)}`)
+    if (!res.ok) return null
+    const data = await res.json() as Array<{ outcomePrices?: string[] }>
+    const price = Number(data[0]?.outcomePrices?.[0])
+    const normalized = Number.isFinite(price) && price >= 0 && price <= 1 ? price : null
+    oddsCache.set(slug, normalized)
+    return normalized
+  } catch {
+    oddsCache.set(slug, null)
+    return null
+  }
+}
+
 function betWeight(amount?: number): number {
   if (!amount || amount < MIN_BET_AMOUNT) return 0
   if (amount < 2000) return 6
@@ -134,6 +156,9 @@ async function pollMatchTrades(
     const weight = betWeight(amount)
     if (weight === 0) continue
 
+    const tradePrice = trade.tradePrice ?? trade.price ?? trade.marketPrice ?? null
+    const marketOddsAtBet = await fetchMarketOddsAtBet(slug)
+
     const signal: Signal = {
       source: 'POLYMARKET',
       type: 'WHALE_BET',
@@ -147,6 +172,9 @@ async function pollMatchTrades(
         outcome: trade.outcome,
         marketId: conditionId,
         slug,
+        activityTimestamp: trade.timestamp,
+        tradePrice,
+        marketOddsAtBet,
         source: 'match-watcher',   // distinguishes from user-tracker signals
       },
     }

--- a/packages/collectors/src/polymarket/match-watcher.ts
+++ b/packages/collectors/src/polymarket/match-watcher.ts
@@ -95,20 +95,20 @@ async function resolveConditionId(slug: string): Promise<string | null> {
 }
 
 
-const oddsCache = new Map<string, number | null>()
+function normalizeOdds(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+    ? value
+    : null
+}
 
 async function fetchMarketOddsAtBet(slug: string): Promise<number | null> {
-  if (oddsCache.has(slug)) return oddsCache.get(slug)!
   try {
     const res = await fetch(`https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(slug)}`)
     if (!res.ok) return null
     const data = await res.json() as Array<{ outcomePrices?: string[] }>
     const price = Number(data[0]?.outcomePrices?.[0])
-    const normalized = Number.isFinite(price) && price >= 0 && price <= 1 ? price : null
-    oddsCache.set(slug, normalized)
-    return normalized
+    return normalizeOdds(price)
   } catch {
-    oddsCache.set(slug, null)
     return null
   }
 }
@@ -156,8 +156,8 @@ async function pollMatchTrades(
     const weight = betWeight(amount)
     if (weight === 0) continue
 
-    const tradePrice = trade.tradePrice ?? trade.price ?? trade.marketPrice ?? null
-    const marketOddsAtBet = await fetchMarketOddsAtBet(slug)
+    const tradePrice = normalizeOdds(trade.tradePrice ?? trade.price ?? trade.marketPrice ?? null)
+    const marketOddsAtBet = tradePrice ?? await fetchMarketOddsAtBet(slug)
 
     const signal: Signal = {
       source: 'POLYMARKET',

--- a/packages/collectors/src/polymarket/user-tracker.ts
+++ b/packages/collectors/src/polymarket/user-tracker.ts
@@ -14,6 +14,9 @@ interface PolyActivity {
   proxyWallet: string
   size?: number
   amount?: number
+  price?: number
+  tradePrice?: number
+  marketPrice?: number
   side?: string
   outcome?: string
   title?: string
@@ -49,6 +52,25 @@ function betWeight(amount?: number): number {
 
 // Cache conditionId -> { title, slug } to avoid repeated lookups
 const marketCache = new Map<string, { title: string; slug: string | null }>()
+
+const oddsCache = new Map<string, number | null>()
+
+async function fetchMarketOddsAtBet(slug: string): Promise<number | null> {
+  if (oddsCache.has(slug)) return oddsCache.get(slug)!
+  try {
+    const res = await fetch(`https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(slug)}`)
+    if (!res.ok) return null
+    const data = await res.json() as Array<{ outcomePrices?: string[] }>
+    const price = Number(data[0]?.outcomePrices?.[0])
+    const normalized = Number.isFinite(price) && price >= 0 && price <= 1 ? price : null
+    oddsCache.set(slug, normalized)
+    return normalized
+  } catch {
+    oddsCache.set(slug, null)
+    return null
+  }
+}
+
 
 async function resolveMarket(conditionId: string): Promise<{ title: string; slug: string | null }> {
   if (!conditionId) return { title: 'Unknown market', slug: null }
@@ -180,6 +202,9 @@ async function pollUser(address: string): Promise<void> {
       continue
     }
 
+    const tradePrice = activity.tradePrice ?? activity.price ?? activity.marketPrice ?? null
+    const marketOddsAtBet = await fetchMarketOddsAtBet(slug)
+
     // Determine wallet label and upsert stats
     const isTracked = (trackedUsers as string[]).includes(address)
     const walletLabel = isTracked ? 'tracked-whale' : 'unknown'
@@ -198,9 +223,12 @@ async function pollUser(address: string): Promise<void> {
         outcome: activity.outcome,
         marketId: conditionId,
         slug, // keep in metadata for backwards compat
+        activityTimestamp: activity.timestamp,
         walletTotalBets: walletStats.total_bets,
         walletWinRate: walletStats.win_rate,
         walletLabel: walletStats.label,
+        tradePrice,
+        marketOddsAtBet,
       },
     }
 

--- a/packages/collectors/src/polymarket/user-tracker.ts
+++ b/packages/collectors/src/polymarket/user-tracker.ts
@@ -53,20 +53,20 @@ function betWeight(amount?: number): number {
 // Cache conditionId -> { title, slug } to avoid repeated lookups
 const marketCache = new Map<string, { title: string; slug: string | null }>()
 
-const oddsCache = new Map<string, number | null>()
+function normalizeOdds(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+    ? value
+    : null
+}
 
 async function fetchMarketOddsAtBet(slug: string): Promise<number | null> {
-  if (oddsCache.has(slug)) return oddsCache.get(slug)!
   try {
     const res = await fetch(`https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(slug)}`)
     if (!res.ok) return null
     const data = await res.json() as Array<{ outcomePrices?: string[] }>
     const price = Number(data[0]?.outcomePrices?.[0])
-    const normalized = Number.isFinite(price) && price >= 0 && price <= 1 ? price : null
-    oddsCache.set(slug, normalized)
-    return normalized
+    return normalizeOdds(price)
   } catch {
-    oddsCache.set(slug, null)
     return null
   }
 }
@@ -202,8 +202,8 @@ async function pollUser(address: string): Promise<void> {
       continue
     }
 
-    const tradePrice = activity.tradePrice ?? activity.price ?? activity.marketPrice ?? null
-    const marketOddsAtBet = await fetchMarketOddsAtBet(slug)
+    const tradePrice = normalizeOdds(activity.tradePrice ?? activity.price ?? activity.marketPrice ?? null)
+    const marketOddsAtBet = tradePrice ?? await fetchMarketOddsAtBet(slug)
 
     // Determine wallet label and upsert stats
     const isTracked = (trackedUsers as string[]).includes(address)


### PR DESCRIPTION
## Summary

Completes the Intelligence Engine v2 Polymarket validation slice for #123.

This PR moves the issue from architecture/proxy work into a reviewable implementation pass with:

- versioned runtime contract validation
- frozen success criteria copied into outcomes
- persisted backtest artifacts with schema validation
- measured actual backtest windows, not assumed requested windows
- Polymarket ODDS_SHIFT and WHALE_BET ≥30d baseline evidence
- publisher-mode ADR and concrete realtime semantics docs
- prod-safe publisher metadata bridge for the new intelligence fields

## What changed

### Contracts and validation

- Added runtime schemas in `packages/brain/src/intelligence/schemas.ts` for core intelligence contracts.
- Added helpers for frozen criteria, e.g. `oddsMoveCriterion(...)`.
- Exported schema/outcome helpers from the intelligence module.
- Backtest artifacts now validate summaries/outcomes before writing JSON.

### Backtests and evidence

- Added `actualWindowDays` and `requestedWindowDays` to backtest summaries.
- Added WHALE_BET backtest path and tests.
- Added `activityTimestamp` precedence test so historical/user-tracker timing does not silently fall back to DB insert time when true activity time exists.
- Added persisted artifacts for both acceptance runs.

### Outcomes and publisher bridge

- Added `packages/brain/src/intelligence/outcomes.ts` for durable `NarrativeOutcome` row mapping.
- Added migration `docs/db-migrations/037-intelligence-v2-metadata.sql`:
  - intelligence metadata columns on `published_narratives`
  - `narrative_outcomes` table
- Updated publisher insert path to write:
  - `schema_version`
  - `scoring_version`
  - `editor_version`
  - `success_criteria`
- The publisher bridge is prod-safe: if those DB columns are not applied yet, it logs and falls back to the legacy insert instead of breaking publishing.

### Docs / ADR / realtime semantics

- Accepted ADR 0001: Intelligence Engine v2 starts in publisher mode.
- Explicitly excludes executor/signing/custody from this validation slice.
- Added concrete Polymarket v1 realtime semantics:
  - polling/streaming behavior
  - acceptable lag
  - ordering key
  - dedupe direction
  - retry/backpressure behavior
  - stale/cursor caveats
- Updated docs with the latest ≥30d backtest evidence and current proxy-mode caveats.

## Validation

Targeted intelligence test gate:

```bash
pnpm --filter @myboon/brain test -- --run \
  packages/brain/src/intelligence/scoring.test.ts \
  packages/brain/src/intelligence/polymarket-backtest.test.ts \
  packages/brain/src/intelligence/polymarket-whale-backtest.test.ts \
  packages/brain/src/intelligence/backtest-artifacts.test.ts \
  packages/brain/src/intelligence/schemas.test.ts \
  packages/brain/src/intelligence/outcomes.test.ts
```

Result:

- 34 passed
- 10 skipped

## Acceptance backtests

### ODDS_SHIFT

Command:

```bash
POLYMARKET_BACKTEST_DAYS=35 POLYMARKET_BACKTEST_MAX_ROWS=100000 \
  pnpm --filter @myboon/brain intelligence:polymarket:backtest
```

Result:

- raw rows: 50,908
- conclusive candidates: 50,423
- actual conclusive window: 32.80d
- selected hit rate: 68.47%
- baseline hit rate: 50.33%
- Wilson 95% CI: 67.72%-69.20%
- artifact: `packages/brain/artifacts/intelligence-backtests/backtest-polymarket.odds_shift-1777891475535.json`

### WHALE_BET proxy

Command:

```bash
POLYMARKET_BACKTEST_DAYS=35 POLYMARKET_WHALE_BACKTEST_MAX_ROWS=50000 POLYMARKET_BACKTEST_MAX_ODDS_ROWS=100000 \
  pnpm --filter @myboon/brain intelligence:polymarket:whale-backtest
```

Result:

- whale rows: 50,000
- odds rows: 50,923
- conclusive candidates: 1,293
- actual conclusive window: 30.02d
- selected hit rate: 66.67%
- baseline hit rate: 55.56%
- Wilson 95% CI: 53.36%-77.76%
- artifact: `packages/brain/artifacts/intelligence-backtests/backtest-polymarket.whale_bet-1777891560255.json`

## Known caveat

Full package typecheck is still blocked by pre-existing workspace issues outside this PR area:

- missing `@myboon/entity-memory`
- missing `@myboon/tx-parser`
- shared Polymarket profile query typing errors

The targeted Intelligence Engine tests pass, and this PR avoids prod service restarts/deploy changes.

## Reviewer focus

Please review especially:

1. `packages/brain/src/intelligence/schemas.ts` — runtime validation shape and strictness.
2. `packages/brain/src/intelligence/polymarket-*.ts` — criteria freezing and window measurement.
3. `packages/brain/src/publisher.ts` — prod-safe metadata insert fallback.
4. `docs/db-migrations/037-intelligence-v2-metadata.sql` — DB shape for published metadata/outcomes.
5. `docs/INTELLIGENCE-ENGINE-V2.md` and ADR 0001 — whether proxy-mode caveats are clear enough.

Closes #123.
