### PR TITLE
Fix Predict redeemables and editable withdrawal wallet

### DIFF
--- a/apps/hybrid-expo/components/predict/WithdrawModal.tsx
+++ b/apps/hybrid-expo/components/predict/WithdrawModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -35,16 +35,31 @@ export function WithdrawModal({
   const [state, setState] = useState<WithdrawState>('input');
   const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [recipientAddress, setRecipientAddress] = useState(solanaAddress);
 
   const parsedAmount = parseFloat(amount);
   const MIN_WITHDRAW = 1; // $1 minimum — dust amounts would fail on bridge
-  const isValid = parsedAmount >= MIN_WITHDRAW && (cashBalance === null || parsedAmount <= cashBalance);
+  const trimmedRecipientAddress = recipientAddress.trim();
+  const isRecipientValid = useMemo(() => {
+    // Solana base58 addresses are usually 32-44 chars. Keep this client-side check light;
+    // the bridge/server remains the source of truth.
+    return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(trimmedRecipientAddress);
+  }, [trimmedRecipientAddress]);
+  const isValid =
+    parsedAmount >= MIN_WITHDRAW &&
+    (cashBalance === null || parsedAmount <= cashBalance) &&
+    isRecipientValid;
+
+  useEffect(() => {
+    if (isOpen) setRecipientAddress(solanaAddress);
+  }, [isOpen, solanaAddress]);
 
   const handleClose = () => {
     setAmount('');
     setState('input');
     setTxHash(null);
     setError(null);
+    setRecipientAddress(solanaAddress);
     onClose();
   };
 
@@ -60,7 +75,7 @@ export function WithdrawModal({
       const result = await withdrawFromPolymarket({
         polygonAddress,
         amount: parsedAmount,
-        solanaAddress,
+        solanaAddress: trimmedRecipientAddress,
       });
       if (result.ok) {
         setTxHash(result.txHash ?? null);
@@ -98,7 +113,7 @@ export function WithdrawModal({
           {state === 'input' && (
             <>
               <Text style={styles.subtitle}>
-                Withdraw USDC from Polymarket to your Solana wallet.
+                Withdraw USDC from Polymarket to a Solana wallet. Your connected wallet is prefilled, but you can change it.
               </Text>
 
               {/* Balance row */}
@@ -127,12 +142,27 @@ export function WithdrawModal({
               </View>
 
               {/* Destination */}
-              <View style={styles.destRow}>
-                <MaterialIcons name="arrow-forward" size={10} color={semantic.text.faint} />
-                <Text style={styles.destLabel}>To Solana:</Text>
-                <Text style={styles.destAddr} numberOfLines={1}>
-                  {solanaAddress.slice(0, 8)}...{solanaAddress.slice(-6)}
-                </Text>
+              <View style={styles.destinationWrap}>
+                <View style={styles.destRow}>
+                  <MaterialIcons name="arrow-forward" size={10} color={semantic.text.faint} />
+                  <Text style={styles.destLabel}>To Solana wallet</Text>
+                  <Pressable onPress={() => setRecipientAddress(solanaAddress)}>
+                    <Text style={styles.useConnectedText}>USE CONNECTED</Text>
+                  </Pressable>
+                </View>
+                <TextInput
+                  style={[styles.addressInput, recipientAddress.length > 0 && !isRecipientValid && styles.inputError]}
+                  value={recipientAddress}
+                  onChangeText={setRecipientAddress}
+                  placeholder="Solana wallet address"
+                  placeholderTextColor={semantic.text.faint}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  spellCheck={false}
+                />
+                {recipientAddress.length > 0 && !isRecipientValid && (
+                  <Text style={styles.errorHint}>Enter a valid Solana wallet address.</Text>
+                )}
               </View>
 
               <Pressable
@@ -161,7 +191,7 @@ export function WithdrawModal({
                 <View style={styles.confirmRow}>
                   <Text style={styles.confirmLabel}>To</Text>
                   <Text style={styles.confirmValue}>
-                    {solanaAddress.slice(0, 8)}...{solanaAddress.slice(-6)}
+                    {trimmedRecipientAddress.slice(0, 8)}...{trimmedRecipientAddress.slice(-6)}
                   </Text>
                 </View>
                 <View style={styles.confirmRow}>
@@ -194,7 +224,7 @@ export function WithdrawModal({
               <MaterialIcons name="check-circle" size={32} color={tokens.colors.viridian} />
               <Text style={styles.statusText}>Withdraw submitted!</Text>
               <Text style={styles.statusSubtext}>
-                ${parsedAmount.toFixed(2)} USDC bridging to your Solana wallet.{'\n'}
+                ${parsedAmount.toFixed(2)} USDC bridging to {trimmedRecipientAddress.slice(0, 8)}...{trimmedRecipientAddress.slice(-6)}.{'\n'}
                 May take a few minutes to arrive.
               </Text>
               {txHash && (
@@ -330,18 +360,43 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
+    marginBottom: 6,
+  },
+  destinationWrap: {
     marginBottom: 16,
   },
   destLabel: {
     fontFamily: 'monospace',
     fontSize: 8,
     color: semantic.text.dim,
-  },
-  destAddr: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    color: semantic.text.accent,
     flex: 1,
+  },
+  useConnectedText: {
+    fontFamily: 'monospace',
+    fontSize: 7,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    color: tokens.colors.primary,
+  },
+  addressInput: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    color: semantic.text.primary,
+    backgroundColor: semantic.background.lift,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 9,
+  },
+  inputError: {
+    borderColor: tokens.colors.vermillion,
+  },
+  errorHint: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: tokens.colors.vermillion,
+    marginTop: 5,
   },
   withdrawBtn: {
     backgroundColor: tokens.colors.primary,

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -586,7 +586,9 @@ export async function fetchPortfolio(polygonAddress: string): Promise<PortfolioD
     address: typeof p.address === 'string' ? p.address : polygonAddress,
     portfolioValue: toNumber(p.portfolioValue),
     positions: Array.isArray(p.positions) ? (p.positions as PortfolioPosition[]) : [],
-    redeemablePositions: Array.isArray(p.redeemablePositions) ? (p.redeemablePositions as PortfolioPosition[]) : [],
+    redeemablePositions: Array.isArray(p.redeemablePositions)
+      ? (p.redeemablePositions as PortfolioPosition[]).filter((position) => (position.currentValue ?? 0) >= 0.01)
+      : [],
     profile: p.profile as PortfolioData['profile'] ?? null,
     summary: (p.summary as PortfolioData['summary']) ?? { openPositions: 0, totalPnl: 0 },
   };

--- a/apps/hybrid-expo/features/predict/profile/RedeemableSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/RedeemableSection.tsx
@@ -11,9 +11,10 @@ interface RedeemableSectionProps {
 }
 
 export function RedeemableSection({ positions, polygonAddress, onRedeemed }: RedeemableSectionProps) {
-  if (positions.length === 0) return null;
+  const visiblePositions = positions.filter((position) => (position.currentValue ?? 0) >= 0.01);
+  if (visiblePositions.length === 0) return null;
 
-  const totalRedeemable = positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
+  const totalRedeemable = visiblePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
 
   return (
     <View style={styles.section}>
@@ -22,7 +23,7 @@ export function RedeemableSection({ positions, polygonAddress, onRedeemed }: Red
         <Text style={styles.total}>${totalRedeemable.toFixed(2)}</Text>
       </View>
 
-      {positions.map((p, i) => (
+      {visiblePositions.map((p, i) => (
         <RedeemRow
           key={`${p.conditionId}-${p.outcomeIndex}-${i}`}
           position={p}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -187,7 +187,7 @@ function parseNullableNumber(input: unknown): number | null {
 function isPositivePositionValue(position: unknown): boolean {
   if (!position || typeof position !== 'object') return false
   const value = parseNullableNumber((position as Record<string, unknown>).currentValue) ?? 0
-  return value > 0
+  return value >= 0.01
 }
 
 // --- dome fallback wrapper ---

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -184,6 +184,12 @@ function parseNullableNumber(input: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+function isPositivePositionValue(position: unknown): boolean {
+  if (!position || typeof position !== 'object') return false
+  const value = parseNullableNumber((position as Record<string, unknown>).currentValue) ?? 0
+  return value > 0
+}
+
 // --- dome fallback wrapper ---
 
 async function withDomeFallback<T>(
@@ -972,10 +978,10 @@ app.get('/predict/portfolio/:address', async (c) => {
   if (!address?.trim()) return c.json({ error: 'Bad request' }, 400)
 
   try {
-    // Fetch value, positions, redeemable positions, and profile in parallel
+    // Fetch value, active positions, positive-payout redeemables, and profile in parallel
     const [valueRes, posRes, redeemableRes, profileRes] = await Promise.allSettled([
       dataApiFetch(`value?user=${encodeURIComponent(address)}`),
-      dataApiFetch(`positions?user=${encodeURIComponent(address)}&limit=100&sortBy=CURRENT&sortDirection=DESC`),
+      dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=false&limit=100&sortBy=CURRENT&sortDirection=DESC`),
       dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=true&limit=50&sortBy=CURRENT&sortDirection=DESC`),
       gammaFetch(`public-profile?proxyWallet=${encodeURIComponent(address)}`),
     ])
@@ -1003,7 +1009,7 @@ app.get('/predict/portfolio/:address', async (c) => {
     let redeemablePositions: unknown[] = []
     if (redeemableRes.status === 'fulfilled' && redeemableRes.value.ok) {
       const body = await redeemableRes.value.json() as unknown
-      redeemablePositions = Array.isArray(body) ? body : []
+      redeemablePositions = Array.isArray(body) ? body.filter(isPositivePositionValue) : []
     }
 
     // Parse profile
@@ -1174,7 +1180,7 @@ app.get('/predict/positions/:address/market/:slug', async (c) => {
 
   try {
     const res = await dataApiFetch(
-      `positions?user=${encodeURIComponent(address)}&sizeThreshold=0.1&limit=100&sortBy=CURRENT&sortDirection=DESC`
+      `positions?user=${encodeURIComponent(address)}&redeemable=false&sizeThreshold=0.1&limit=100&sortBy=CURRENT&sortDirection=DESC`
     )
     if (!res.ok) {
       console.error(`[api] data-api /positions error ${res.status}`)


### PR DESCRIPTION
## Summary
- allow users to edit the prefilled Solana withdrawal recipient wallet
- filter zero/dust redeemable positions from Predict portfolio API responses
- add mobile client-side guard so stale/dust redeemables do not render as Redeem $0.00

## Validation
- pnpm --filter @myboon/api exec tsx --check src/index.ts
- git diff --check
- rebuilt release APK earlier for the withdrawal modal change
- verified VPS API returns redeemablePositions: [] for 0xec3c577fbb37213c9865ae6ede66e7d3ac302f9f
