### PR TITLE
[codex] Align predict profile lifecycle UX

### DIFF
--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -16,7 +16,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
 import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, cancelOrder } from '@/features/predict/predict.api';
-import type { OpenOrder, PortfolioData } from '@/features/predict/predict.api';
+import type { ActivityItem, OpenOrder, PortfolioData } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useDrawer } from '@/components/drawer/DrawerProvider';
@@ -40,6 +40,29 @@ function getOrderCost(order: OpenOrder): number {
   const size = Number.parseFloat(order.original_size) || 0;
   const price = Number.parseFloat(order.price) || 0;
   return size * price;
+}
+
+function formatActivityTime(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'just now';
+  const then = timestamp > 10_000_000_000 ? timestamp : timestamp * 1000;
+  const diffMs = Date.now() - then;
+  if (diffMs < 60_000) return 'just now';
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function activityVerb(item: ActivityItem): string {
+  if (item.type === 'TRADE') return item.side === 'SELL' ? 'Sold' : 'Bought';
+  if (item.type === 'REDEEM') return 'Redeemed';
+  if (item.type === 'MERGE') return 'Merged';
+  if (item.type === 'SPLIT') return 'Split';
+  if (item.type === 'CONVERSION') return 'Converted';
+  return item.type ? item.type.toLowerCase().replace(/_/g, ' ') : 'Activity';
 }
 
 export default function PredictProfileScreen() {
@@ -202,9 +225,10 @@ export default function PredictProfileScreen() {
   const positions = portfolio?.positions ?? [];
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
   const closedPositions = portfolio?.closedPositions ?? [];
+  const activity = portfolio?.activity ?? [];
   const portfolioValue = portfolio?.portfolioValue ?? null;
-  const cashOutNow = positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
-  const readyToCollect = redeemablePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
+  const cashOutNow = portfolio?.summary.cashOutNow ?? positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
+  const readyToCollect = portfolio?.summary.readyToCollect ?? redeemablePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
   const waitingPickValue = openOrders.reduce((sum, order) => sum + getOrderCost(order), 0);
   const activePickCount = positions.length + openOrders.length;
   const hasAnyPicks = activePickCount + redeemablePositions.length + closedPositions.length > 0;
@@ -392,7 +416,12 @@ export default function PredictProfileScreen() {
               onRedeemed={() => void loadPortfolio()}
             />
 
-            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0 && (
+            <RecentActivitySection
+              activity={activity}
+              onMarketPress={handleOpenMarket}
+            />
+
+            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0 && activity.length === 0 && (
               <View style={styles.positionsSection}>
                 <EmptyPortfolio
                   mode={(cashBalance ?? 0) > 0 ? 'no-picks' : 'no-balance'}
@@ -424,6 +453,56 @@ export default function PredictProfileScreen() {
           onSuccess={loadPortfolio}
         />
       )}
+    </View>
+  );
+}
+
+function RecentActivitySection({
+  activity,
+  onMarketPress,
+}: {
+  activity: ActivityItem[];
+  onMarketPress: (slug: string) => void;
+}) {
+  if (activity.length === 0) return null;
+  const visible = activity.slice(0, 6);
+
+  return (
+    <View style={styles.activitySection}>
+      <View style={styles.activityHeader}>
+        <Text style={styles.activityTitle}>Recent Activity</Text>
+        <Text style={styles.activityCount}>{activity.length} events</Text>
+      </View>
+      {visible.map((item, index) => {
+        const isPositive = item.type === 'REDEEM' || item.side === 'SELL';
+        const amount = Number.isFinite(item.usdcSize) ? item.usdcSize : 0;
+        return (
+          <Pressable
+            key={`${item.timestamp}-${item.slug}-${item.side}-${index}`}
+            style={styles.activityRow}
+            onPress={() => item.slug ? onMarketPress(item.slug) : undefined}
+          >
+            <View style={[styles.activityIcon, isPositive ? styles.activityIconPositive : styles.activityIconNegative]}>
+              <MaterialIcons
+                name={isPositive ? 'arrow-upward' : 'arrow-downward'}
+                size={12}
+                color={isPositive ? tokens.colors.viridian : tokens.colors.vermillion}
+              />
+            </View>
+            <View style={styles.activityInfo}>
+              <Text style={styles.activityRowTitle} numberOfLines={1}>
+                {activityVerb(item)} {item.outcome || 'pick'}
+              </Text>
+              <Text style={styles.activityMeta} numberOfLines={1}>
+                {item.title || item.slug || 'Predict market'} · {formatActivityTime(item.timestamp)}
+              </Text>
+            </View>
+            <Text style={[styles.activityAmount, isPositive ? styles.posText : styles.negText]}>
+              {isPositive ? '+' : '-'}{formatUsd(amount)}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
@@ -806,6 +885,82 @@ const styles = StyleSheet.create({
     fontSize: 9,
     color: semantic.text.faint,
     letterSpacing: 0.5,
+  },
+
+  activitySection: {
+    marginHorizontal: tokens.spacing.lg,
+    marginTop: 14,
+  },
+  activityHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  activityTitle: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  activityCount: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+  },
+  activityRow: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 11,
+    marginBottom: 7,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+  },
+  activityIcon: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  activityIconPositive: {
+    borderColor: 'rgba(74,140,111,0.28)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
+  },
+  activityIconNegative: {
+    borderColor: 'rgba(244,88,78,0.24)',
+    backgroundColor: 'rgba(244,88,78,0.08)',
+  },
+  activityInfo: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  activityRowTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: semantic.text.primary,
+    lineHeight: 15,
+  },
+  activityMeta: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+  },
+  activityAmount: {
+    width: 58,
+    textAlign: 'right',
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '700',
   },
 
 

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -36,9 +36,10 @@ function formatUsd(value: number | null): string {
   return `${prefix}$${abs.toFixed(2)}`;
 }
 
-function formatPnl(value: number): string {
-  const prefix = value >= 0 ? '+$' : '-$';
-  return `${prefix}${Math.abs(value).toFixed(2)}`;
+function getOrderCost(order: OpenOrder): number {
+  const size = Number.parseFloat(order.original_size) || 0;
+  const price = Number.parseFloat(order.price) || 0;
+  return size * price;
 }
 
 export default function PredictProfileScreen() {
@@ -155,12 +156,11 @@ export default function PredictProfileScreen() {
     }
 
     Alert.alert(
-      'Connect Predict Account',
-      'Sign once to restore or set up the prediction account linked to this wallet.\n\n' +
+        'Connect Predict Account',
+        'Sign once to restore or set up the prediction account linked to this wallet.\n\n' +
         '• Sign a message to verify ownership (no transaction)\n' +
-        '• Your trading address is derived deterministically\n' +
         '• No extra seed phrases or wallets to manage\n' +
-        '• Deposit & trade on prediction markets — gasless',
+        '• Deposit and make picks without gas',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -201,10 +201,17 @@ export default function PredictProfileScreen() {
 
   const positions = portfolio?.positions ?? [];
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
+  const closedPositions = portfolio?.closedPositions ?? [];
   const portfolioValue = portfolio?.portfolioValue ?? null;
-  const totalPnl = portfolio?.summary.totalPnl ?? 0;
   const cashOutNow = positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
   const readyToCollect = redeemablePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
+  const waitingPickValue = openOrders.reduce((sum, order) => sum + getOrderCost(order), 0);
+  const activePickCount = positions.length + openOrders.length;
+  const hasAnyPicks = activePickCount + redeemablePositions.length + closedPositions.length > 0;
+  const hasActiveOrReadyPicks = activePickCount + redeemablePositions.length > 0;
+  const activePicksValue = cashOutNow + waitingPickValue;
+  const collectedValue = portfolio?.summary.totalCollected ?? 0;
+  const collectedDisplay = hasAnyPicks || (cashBalance ?? 0) > 0 ? formatUsd(collectedValue) : '--';
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>
@@ -257,14 +264,8 @@ export default function PredictProfileScreen() {
           </View>
           <View style={styles.identityInfo}>
             <Text style={styles.handle}>
-              {portfolio?.profile?.name ?? (poly.polygonAddress ? truncate(poly.polygonAddress) : '—')}
+              {portfolio?.profile?.name ?? (solanaAddress ? truncate(solanaAddress) : poly.polygonAddress ? truncate(poly.polygonAddress) : '—')}
             </Text>
-            <View style={styles.addrRow}>
-              <Text style={styles.addrText}>
-                {solanaAddress ? truncate(solanaAddress) : '—'}
-              </Text>
-              <MaterialIcons name="content-copy" size={10} color={semantic.text.faint} />
-            </View>
             {connected && (
               <View style={styles.connectedChip}>
                 <View style={styles.connectedDot} />
@@ -282,19 +283,6 @@ export default function PredictProfileScreen() {
             >
               <MaterialIcons name="login" size={14} color={tokens.colors.backgroundDark} />
               <Text style={styles.passkeyCtaText}>Sign In</Text>
-            </Pressable>
-          )}
-          {!isEnabled && !poly.isLoading && connected && (
-            <Pressable
-              onPress={handleConnectPredictAccount}
-              disabled={busy}
-              style={[styles.passkeyCta, busy && styles.btnDisabled]}
-            >
-              {busy ? (
-                <ActivityIndicator color={tokens.colors.backgroundDark} size="small" />
-              ) : (
-                <Text style={styles.passkeyCtaText}>Connect Predict</Text>
-              )}
             </Pressable>
           )}
           {isEnabled && (
@@ -325,7 +313,7 @@ export default function PredictProfileScreen() {
             <EmptyPortfolio
               mode="no-account"
               onPrimaryAction={!connected ? openDrawer : handleConnectPredictAccount}
-              primaryLabel={!connected ? 'Sign In' : 'Connect Predict'}
+              primaryLabel={!connected ? 'Sign In' : 'Open Prediction Account'}
             />
           </View>
         )}
@@ -352,37 +340,44 @@ export default function PredictProfileScreen() {
                   </Text>
                 </View>
                 <View style={[styles.eqItem, styles.eqItemRight]}>
-                  <Text style={styles.eqLabel}>Ready</Text>
+                  <Text style={styles.eqLabel}>
+                    {!hasActiveOrReadyPicks ? 'Collected' : readyToCollect > 0 ? 'Ready' : 'Active picks'}
+                  </Text>
                   <Text style={[styles.eqVal, readyToCollect > 0 && styles.posText]}>
-                    {formatUsd(readyToCollect)}
+                    {!hasActiveOrReadyPicks
+                      ? collectedDisplay
+                      : readyToCollect > 0
+                        ? formatUsd(readyToCollect)
+                        : formatUsd(activePicksValue)}
                   </Text>
                 </View>
               </View>
-              <View style={styles.equityRow}>
-                <View style={styles.eqItem}>
-                  <Text style={styles.eqLabel}>Cash out now</Text>
-                  <Text style={styles.eqVal}>{formatUsd(cashOutNow)}</Text>
+              {hasActiveOrReadyPicks && (
+                <View style={[styles.equityRow, styles.equityRowSecond]}>
+                  <View style={styles.eqItem}>
+                    <Text style={styles.eqLabel}>Cash out now</Text>
+                    <Text style={styles.eqVal}>{formatUsd(cashOutNow)}</Text>
+                  </View>
+                  <View style={[styles.eqItem, styles.eqItemCenter]}>
+                    <Text style={styles.eqLabel}>Active picks</Text>
+                    <Text style={styles.eqVal}>{activePickCount}</Text>
+                  </View>
+                  <View style={[styles.eqItem, styles.eqItemRight]}>
+                    <Text style={styles.eqLabel}>Collected</Text>
+                    <Text style={styles.eqVal}>{collectedDisplay}</Text>
+                  </View>
                 </View>
-                <View style={[styles.eqItem, styles.eqItemCenter]}>
-                  <Text style={styles.eqLabel}>Active picks</Text>
-                  <Text style={styles.eqVal}>{positions.length + openOrders.length}</Text>
-                </View>
-                <View style={[styles.eqItem, styles.eqItemRight]}>
-                  <Text style={styles.eqLabel}>P&L</Text>
-                  <Text style={[styles.eqVal, totalPnl >= 0 ? styles.posText : styles.negText]}>
-                    {formatPnl(totalPnl)}
-                  </Text>
-                </View>
-              </View>
+              )}
             </View>
 
             <YourPicksSection
               positions={positions}
               openOrders={openOrders}
               redeemablePositions={redeemablePositions}
+              closedPositions={closedPositions}
               polygonAddress={poly.polygonAddress}
               cancellingOrderId={cancellingId}
-              onPositionPress={(p) =>
+              onCashOutPress={(p) =>
                 router.push({
                   pathname: '/predict-position/[conditionId]',
                   params: {
@@ -397,7 +392,7 @@ export default function PredictProfileScreen() {
               onRedeemed={() => void loadPortfolio()}
             />
 
-            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && (
+            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0 && (
               <View style={styles.positionsSection}>
                 <EmptyPortfolio
                   mode={(cashBalance ?? 0) > 0 ? 'no-picks' : 'no-balance'}
@@ -535,17 +530,6 @@ const styles = StyleSheet.create({
     color: semantic.text.primary,
     marginBottom: 3,
   },
-  addrRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  addrText: {
-    fontFamily: 'monospace',
-    fontSize: 9,
-    color: semantic.text.dim,
-    letterSpacing: 0.3,
-  },
   connectedChip: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -647,6 +631,9 @@ const styles = StyleSheet.create({
   },
   equityRow: {
     flexDirection: 'row',
+  },
+  equityRowSecond: {
+    marginTop: 14,
   },
   eqItem: { flex: 1, gap: 3 },
   eqItemCenter: { alignItems: 'center' },

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -15,15 +15,13 @@ import { useRouter, useNavigation } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
-import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity, cancelOrder } from '@/features/predict/predict.api';
-import type { ActivityItem, PortfolioData, PortfolioPosition, OpenOrder } from '@/features/predict/predict.api';
+import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity } from '@/features/predict/predict.api';
+import type { ActivityItem, PortfolioData } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
-import { usePrivyWallet } from '@/hooks/usePrivyWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useDrawer } from '@/components/drawer/DrawerProvider';
-import { PerfStrip } from '@/features/predict/profile/PerfStrip';
-import { RedeemableSection } from '@/features/predict/profile/RedeemableSection';
 import { EmptyPortfolio } from '@/features/predict/profile/EmptyPortfolio';
+import { YourPicksSection } from '@/features/predict/profile/YourPicksSection';
 import { semantic, tokens } from '@/theme';
 
 function truncate(addr: string, start = 6, end = 4): string {
@@ -47,7 +45,6 @@ export default function PredictProfileScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { connected, address: solanaAddress, source } = useWallet();
-  const privy = usePrivyWallet();
   const poly = usePolymarketWallet();
   const { open: openDrawer } = useDrawer();
   const [busy, setBusy] = useState(false);
@@ -63,26 +60,7 @@ export default function PredictProfileScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
 
-  const [cancellingId, setCancellingId] = useState<string | null>(null);
-
   const isEnabled = poly.isReady && poly.polygonAddress;
-
-  const handleCancel = useCallback(async (orderId: string) => {
-    if (!poly.polygonAddress) return;
-    setCancellingId(orderId);
-    try {
-      const result = await cancelOrder(poly.polygonAddress, orderId);
-      if (result.ok) {
-        setOpenOrders((prev) => prev.filter((o) => o.id !== orderId));
-      } else {
-        Alert.alert('Cancel failed', result.error ?? 'Unknown error');
-      }
-    } catch {
-      Alert.alert('Cancel failed', 'Network error');
-    } finally {
-      setCancellingId(null);
-    }
-  }, [poly.polygonAddress]);
 
   const loadPortfolio = useCallback(async () => {
     if (!poly.polygonAddress) return;
@@ -343,134 +321,30 @@ export default function PredictProfileScreen() {
               </View>
             </View>
 
-            {/* Open Orders */}
-            {openOrders.length > 0 && (
-              <View style={styles.positionsSection}>
-                <View style={styles.posHeader}>
-                  <Text style={styles.posTitle}>Open Orders</Text>
-                  <Text style={styles.posCount}>{openOrders.length} pending</Text>
-                </View>
-                {openOrders.map((o: OpenOrder) => {
-                  const sizeNum = parseFloat(o.original_size) || 0;
-                  const matched = parseFloat(o.size_matched) || 0;
-                  const priceNum = parseFloat(o.price) || 0;
-                  const cost = sizeNum * priceNum;
-                  const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
-                  return (
-                    <View key={o.id} style={styles.orderCard}>
-                      <View style={styles.orderCardTop}>
-                        <View style={[styles.sideBadge, o.side === 'BUY' ? styles.sideBadgeYes : styles.sideBadgeNo]}>
-                          <Text style={[styles.sideBadgeText, o.side === 'BUY' ? styles.posText : styles.negText]}>
-                            {o.side}
-                          </Text>
-                        </View>
-                        <Text style={styles.orderOutcome} numberOfLines={1}>{o.outcome || '--'}</Text>
-                        <Text style={styles.orderStatus}>{o.status}</Text>
-                      </View>
-                      <View style={styles.orderCardStats}>
-                        <View>
-                          <Text style={styles.orderStatLabel}>Price</Text>
-                          <Text style={styles.orderStatVal}>{Math.round(priceNum * 100)}¢</Text>
-                        </View>
-                        <View>
-                          <Text style={styles.orderStatLabel}>Shares</Text>
-                          <Text style={styles.orderStatVal}>{sizeNum.toFixed(2)}</Text>
-                        </View>
-                        <View>
-                          <Text style={styles.orderStatLabel}>Cost</Text>
-                          <Text style={styles.orderStatVal}>${cost.toFixed(2)}</Text>
-                        </View>
-                        <View style={{ alignItems: 'flex-end' }}>
-                          <Text style={styles.orderStatLabel}>Filled</Text>
-                          <Text style={styles.orderStatVal}>{fillPct}%</Text>
-                        </View>
-                      </View>
-                      <Pressable
-                        style={styles.cancelBtn}
-                        disabled={cancellingId === o.id}
-                        onPress={() => handleCancel(o.id)}
-                      >
-                        {cancellingId === o.id ? (
-                          <ActivityIndicator size="small" color={semantic.sentiment.negative} />
-                        ) : (
-                          <Text style={styles.cancelBtnText}>Cancel</Text>
-                        )}
-                      </Pressable>
-                    </View>
-                  );
-                })}
-              </View>
-            )}
+            <YourPicksSection
+              positions={positions}
+              openOrders={openOrders}
+              redeemablePositions={redeemablePositions}
+              onPositionPress={(p) =>
+                router.push({
+                  pathname: '/predict-position/[conditionId]',
+                  params: {
+                    conditionId: p.conditionId,
+                    slug: p.slug,
+                    outcomeIndex: String(p.outcomeIndex),
+                  },
+                })
+              }
+            />
 
-            {/* Open positions */}
-            <View style={styles.positionsSection}>
-              <View style={styles.posHeader}>
-                <Text style={styles.posTitle}>Positions</Text>
-                <Text style={styles.posCount}>{positions.length} active</Text>
-              </View>
-              {positions.length === 0 && openOrders.length === 0 && (
+            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && (
+              <View style={styles.positionsSection}>
                 <EmptyPortfolio
                   hasBalance={(cashBalance ?? 0) > 0}
                   onDeposit={() => setDepositOpen(true)}
                 />
-              )}
-              {positions.map((p: PortfolioPosition, i: number) => {
-                const pnl = p.cashPnl ?? 0;
-                const isUp = pnl >= 0;
-                return (
-                  <Pressable
-                    key={`${p.conditionId}-${p.outcomeIndex}-${i}`}
-                    style={styles.posRow}
-                    onPress={() =>
-                      router.push({
-                        pathname: '/predict-position/[conditionId]',
-                        params: {
-                          conditionId: p.conditionId,
-                          slug: p.slug,
-                          outcomeIndex: String(p.outcomeIndex),
-                        },
-                      })
-                    }
-                    accessibilityLabel={`View position: ${p.title}`}
-                  >
-                    <View
-                      style={[
-                        styles.sideBadge,
-                        p.outcome === 'No' ? styles.sideBadgeNo : styles.sideBadgeYes,
-                      ]}
-                    >
-                      <Text
-                        style={[
-                          styles.sideBadgeText,
-                          p.outcome === 'No' ? styles.negText : styles.posText,
-                        ]}
-                      >
-                        {p.outcome?.toUpperCase() ?? 'YES'}
-                      </Text>
-                    </View>
-                    <Text style={styles.posQuestion} numberOfLines={1}>
-                      {p.title || p.slug || '—'}
-                    </Text>
-                    <View style={styles.posPnlWrap}>
-                      <Text style={[styles.posPnl, isUp ? styles.posText : styles.negText]}>
-                        {formatPnl(pnl)}
-                      </Text>
-                      <Text style={styles.posEntry}>
-                        {p.avgPrice?.toFixed(2) ?? '--'}→{p.curPrice?.toFixed(2) ?? '--'}
-                      </Text>
-                    </View>
-                    <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
-                  </Pressable>
-                );
-              })}
-            </View>
-
-            {/* Redeemable Positions */}
-            <RedeemableSection
-              positions={redeemablePositions}
-              polygonAddress={poly.polygonAddress}
-              onRedeemed={() => void loadPortfolio()}
-            />
+              </View>
+            )}
 
             {/* Trade History */}
             {tradeHistory.length > 0 && (

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -15,7 +15,7 @@ import { useRouter, useNavigation } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
-import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity } from '@/features/predict/predict.api';
+import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity, cancelOrder } from '@/features/predict/predict.api';
 import type { ActivityItem, PortfolioData } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
@@ -60,7 +60,26 @@ export default function PredictProfileScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
 
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+
   const isEnabled = poly.isReady && poly.polygonAddress;
+
+  const handleCancel = useCallback(async (orderId: string) => {
+    if (!poly.polygonAddress) return;
+    setCancellingId(orderId);
+    try {
+      const result = await cancelOrder(poly.polygonAddress, orderId);
+      if (result.ok) {
+        setOpenOrders((prev) => prev.filter((o) => o.id !== orderId));
+      } else {
+        Alert.alert('Cancel failed', result.error ?? 'Unknown error');
+      }
+    } catch {
+      Alert.alert('Cancel failed', 'Network error');
+    } finally {
+      setCancellingId(null);
+    }
+  }, [poly.polygonAddress]);
 
   const loadPortfolio = useCallback(async () => {
     if (!poly.polygonAddress) return;
@@ -171,6 +190,17 @@ export default function PredictProfileScreen() {
     }
   }, [connected, poly, loadPortfolio]);
 
+  const handleOpenMarket = useCallback((slug: string) => {
+    const sportMatch = slug.match(/^cric(epl|ucl|ipl)-/);
+    if (sportMatch) {
+      router.push({
+        pathname: '/predict-sport/[sport]/[slug]',
+        params: { sport: sportMatch[1], slug },
+      });
+    } else {
+      router.push(`/predict-market/${encodeURIComponent(slug)}`);
+    }
+  }, [router]);
 
   const positions = portfolio?.positions ?? [];
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
@@ -325,6 +355,8 @@ export default function PredictProfileScreen() {
               positions={positions}
               openOrders={openOrders}
               redeemablePositions={redeemablePositions}
+              polygonAddress={poly.polygonAddress}
+              cancellingOrderId={cancellingId}
               onPositionPress={(p) =>
                 router.push({
                   pathname: '/predict-position/[conditionId]',
@@ -335,6 +367,9 @@ export default function PredictProfileScreen() {
                   },
                 })
               }
+              onMarketPress={handleOpenMarket}
+              onCancelOrder={(orderId) => void handleCancel(orderId)}
+              onRedeemed={() => void loadPortfolio()}
             />
 
             {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && (

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -31,7 +31,7 @@ function truncate(addr: string, start = 6, end = 4): string {
 function formatUsd(value: number | null): string {
   if (value === null || !Number.isFinite(value)) return '--';
   const abs = Math.abs(value);
-  const prefix = value < 0 ? '-' : value > 0 ? '+' : '';
+  const prefix = value < 0 ? '-' : '';
   if (abs >= 1000) return `${prefix}$${(abs / 1000).toFixed(1)}K`;
   return `${prefix}$${abs.toFixed(2)}`;
 }
@@ -203,6 +203,8 @@ export default function PredictProfileScreen() {
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
   const portfolioValue = portfolio?.portfolioValue ?? null;
   const totalPnl = portfolio?.summary.totalPnl ?? 0;
+  const cashOutNow = positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
+  const readyToCollect = redeemablePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>
@@ -338,7 +340,7 @@ export default function PredictProfileScreen() {
             <View style={styles.equityCard}>
               <View style={styles.equityRow}>
                 <View style={styles.eqItem}>
-                  <Text style={styles.eqLabel}>Portfolio</Text>
+                  <Text style={styles.eqLabel}>Predict value</Text>
                   <Text style={styles.eqVal}>
                     {portfolioValue !== null ? formatUsd(portfolioValue) : '--'}
                   </Text>
@@ -348,6 +350,22 @@ export default function PredictProfileScreen() {
                   <Text style={styles.eqVal}>
                     {cashBalance !== null ? `$${cashBalance.toFixed(2)}` : '--'}
                   </Text>
+                </View>
+                <View style={[styles.eqItem, styles.eqItemRight]}>
+                  <Text style={styles.eqLabel}>Ready</Text>
+                  <Text style={[styles.eqVal, readyToCollect > 0 && styles.posText]}>
+                    {formatUsd(readyToCollect)}
+                  </Text>
+                </View>
+              </View>
+              <View style={styles.equityRow}>
+                <View style={styles.eqItem}>
+                  <Text style={styles.eqLabel}>Cash out now</Text>
+                  <Text style={styles.eqVal}>{formatUsd(cashOutNow)}</Text>
+                </View>
+                <View style={[styles.eqItem, styles.eqItemCenter]}>
+                  <Text style={styles.eqLabel}>Active picks</Text>
+                  <Text style={styles.eqVal}>{positions.length + openOrders.length}</Text>
                 </View>
                 <View style={[styles.eqItem, styles.eqItemRight]}>
                   <Text style={styles.eqLabel}>P&L</Text>

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -16,7 +16,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
 import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity, cancelOrder } from '@/features/predict/predict.api';
-import type { ActivityItem, PortfolioData } from '@/features/predict/predict.api';
+import type { ActivityItem, OpenOrder, PortfolioData } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useDrawer } from '@/components/drawer/DrawerProvider';
@@ -204,7 +204,7 @@ export default function PredictProfileScreen() {
 
   const positions = portfolio?.positions ?? [];
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
-  const portfolioValue = portfolio?.portfolioValue;
+  const portfolioValue = portfolio?.portfolioValue ?? null;
   const totalPnl = portfolio?.summary.totalPnl ?? 0;
 
   return (
@@ -321,6 +321,16 @@ export default function PredictProfileScreen() {
           </Pressable>
         )}
 
+        {!isEnabled && !poly.isLoading && (
+          <View style={styles.positionsSection}>
+            <EmptyPortfolio
+              mode="no-account"
+              onPrimaryAction={!connected ? openDrawer : handleConnectPredictAccount}
+              primaryLabel={!connected ? 'Sign In' : 'Connect Predict'}
+            />
+          </View>
+        )}
+
         {/* ── Enabled: real portfolio ── */}
         {isEnabled && !portfolioLoading && (
           <>
@@ -375,8 +385,9 @@ export default function PredictProfileScreen() {
             {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && (
               <View style={styles.positionsSection}>
                 <EmptyPortfolio
-                  hasBalance={(cashBalance ?? 0) > 0}
-                  onDeposit={() => setDepositOpen(true)}
+                  mode={(cashBalance ?? 0) > 0 ? 'no-picks' : 'no-balance'}
+                  onPrimaryAction={(cashBalance ?? 0) > 0 ? () => router.push('/predict') : () => setDepositOpen(true)}
+                  primaryLabel={(cashBalance ?? 0) > 0 ? 'Browse Markets' : 'Deposit'}
                 />
               </View>
             )}

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -15,8 +15,8 @@ import { useRouter, useNavigation } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
-import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, fetchActivity, cancelOrder } from '@/features/predict/predict.api';
-import type { ActivityItem, OpenOrder, PortfolioData } from '@/features/predict/predict.api';
+import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, cancelOrder } from '@/features/predict/predict.api';
+import type { OpenOrder, PortfolioData } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useDrawer } from '@/components/drawer/DrawerProvider';
@@ -55,7 +55,6 @@ export default function PredictProfileScreen() {
   const [portfolio, setPortfolio] = useState<PortfolioData | null>(null);
   const [cashBalance, setCashBalance] = useState<number | null>(null);
   const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
-  const [tradeHistory, setTradeHistory] = useState<ActivityItem[]>([]);
   const [portfolioLoading, setPortfolioLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
@@ -86,15 +85,13 @@ export default function PredictProfileScreen() {
     // Gamma data-api tracks by trading wallet address (where funds/positions live)
     // CLOB operations use EOA (polygonAddress) for session auth
     const gammaAddr = poly.tradingAddress ?? poly.polygonAddress;
-    const [portfolioData, balanceData, ordersData, activityData] = await Promise.all([
+    const [portfolioData, balanceData, ordersData] = await Promise.all([
       fetchPortfolio(gammaAddr).catch(() => null),
       fetchClobBalance(poly.polygonAddress),
       fetchOpenOrders(poly.polygonAddress).catch(() => []),
-      fetchActivity(gammaAddr).catch(() => []),
     ]);
     if (portfolioData) setPortfolio(portfolioData);
     setOpenOrders(ordersData);
-    setTradeHistory(activityData);
     if (balanceData) {
       setCashBalance(balanceData.balance);
       setSessionExpired(false);
@@ -389,37 +386,6 @@ export default function PredictProfileScreen() {
                   onPrimaryAction={(cashBalance ?? 0) > 0 ? () => router.push('/predict') : () => setDepositOpen(true)}
                   primaryLabel={(cashBalance ?? 0) > 0 ? 'Browse Markets' : 'Deposit'}
                 />
-              </View>
-            )}
-
-            {/* Trade History */}
-            {tradeHistory.length > 0 && (
-              <View style={styles.positionsSection}>
-                <View style={styles.posHeader}>
-                  <Text style={styles.posTitle}>Trade History</Text>
-                  <Text style={styles.posCount}>{tradeHistory.length} trades</Text>
-                </View>
-                {tradeHistory.slice(0, 20).map((t, i) => {
-                  const isBuy = t.side === 'BUY';
-                  const date = new Date(t.timestamp * 1000);
-                  const timeStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}`;
-                  return (
-                    <View key={`${t.timestamp}-${i}`} style={styles.posRow}>
-                      <View style={[styles.sideBadge, isBuy ? styles.sideBadgeYes : styles.sideBadgeNo]}>
-                        <Text style={[styles.sideBadgeText, isBuy ? styles.posText : styles.negText]}>
-                          {t.side}
-                        </Text>
-                      </View>
-                      <View style={styles.tradeInfoWrap}>
-                        <Text style={styles.posQuestion} numberOfLines={1}>{t.title || t.slug}</Text>
-                        <Text style={styles.tradeTime}>{timeStr}</Text>
-                      </View>
-                      <Text style={[styles.posPnl, isBuy ? styles.posText : styles.negText]}>
-                        ${t.usdcSize.toFixed(2)}
-                      </Text>
-                    </View>
-                  );
-                })}
               </View>
             )}
 

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -16,12 +16,13 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
 import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, cancelOrder } from '@/features/predict/predict.api';
-import type { ActivityItem, OpenOrder, PortfolioData } from '@/features/predict/predict.api';
+import type { OpenOrder, PortfolioData, PortfolioPosition } from '@/features/predict/predict.api';
 import { useWallet } from '@/hooks/useWallet';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useDrawer } from '@/components/drawer/DrawerProvider';
 import { EmptyPortfolio } from '@/features/predict/profile/EmptyPortfolio';
 import { YourPicksSection } from '@/features/predict/profile/YourPicksSection';
+import { CashOutConfirmModal } from '@/features/predict/components/CashOutConfirmModal';
 import { semantic, tokens } from '@/theme';
 
 function truncate(addr: string, start = 6, end = 4): string {
@@ -42,29 +43,6 @@ function getOrderCost(order: OpenOrder): number {
   return size * price;
 }
 
-function formatActivityTime(timestamp: number): string {
-  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'just now';
-  const then = timestamp > 10_000_000_000 ? timestamp : timestamp * 1000;
-  const diffMs = Date.now() - then;
-  if (diffMs < 60_000) return 'just now';
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(then).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
-
-function activityVerb(item: ActivityItem): string {
-  if (item.type === 'TRADE') return item.side === 'SELL' ? 'Sold' : 'Bought';
-  if (item.type === 'REDEEM') return 'Redeemed';
-  if (item.type === 'MERGE') return 'Merged';
-  if (item.type === 'SPLIT') return 'Split';
-  if (item.type === 'CONVERSION') return 'Converted';
-  return item.type ? item.type.toLowerCase().replace(/_/g, ' ') : 'Activity';
-}
-
 export default function PredictProfileScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -82,6 +60,7 @@ export default function PredictProfileScreen() {
   const [portfolioLoading, setPortfolioLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
+  const [cashOutPosition, setCashOutPosition] = useState<PortfolioPosition | null>(null);
 
   const [cancellingId, setCancellingId] = useState<string | null>(null);
 
@@ -222,10 +201,13 @@ export default function PredictProfileScreen() {
     }
   }, [router]);
 
+  const handleCashOut = useCallback((position: PortfolioPosition) => {
+    setCashOutPosition(position);
+  }, []);
+
   const positions = portfolio?.positions ?? [];
   const redeemablePositions = portfolio?.redeemablePositions ?? [];
   const closedPositions = portfolio?.closedPositions ?? [];
-  const activity = portfolio?.activity ?? [];
   const portfolioValue = portfolio?.portfolioValue ?? null;
   const cashOutNow = portfolio?.summary.cashOutNow ?? positions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
   const readyToCollect = portfolio?.summary.readyToCollect ?? redeemablePositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0);
@@ -401,27 +383,13 @@ export default function PredictProfileScreen() {
               closedPositions={closedPositions}
               polygonAddress={poly.polygonAddress}
               cancellingOrderId={cancellingId}
-              onCashOutPress={(p) =>
-                router.push({
-                  pathname: '/predict-position/[conditionId]',
-                  params: {
-                    conditionId: p.conditionId,
-                    slug: p.slug,
-                    outcomeIndex: String(p.outcomeIndex),
-                  },
-                })
-              }
+              onCashOutPress={handleCashOut}
               onMarketPress={handleOpenMarket}
               onCancelOrder={(orderId) => void handleCancel(orderId)}
               onRedeemed={() => void loadPortfolio()}
             />
 
-            <RecentActivitySection
-              activity={activity}
-              onMarketPress={handleOpenMarket}
-            />
-
-            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0 && activity.length === 0 && (
+            {positions.length === 0 && openOrders.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0 && (
               <View style={styles.positionsSection}>
                 <EmptyPortfolio
                   mode={(cashBalance ?? 0) > 0 ? 'no-picks' : 'no-balance'}
@@ -453,56 +421,12 @@ export default function PredictProfileScreen() {
           onSuccess={loadPortfolio}
         />
       )}
-    </View>
-  );
-}
 
-function RecentActivitySection({
-  activity,
-  onMarketPress,
-}: {
-  activity: ActivityItem[];
-  onMarketPress: (slug: string) => void;
-}) {
-  if (activity.length === 0) return null;
-  const visible = activity.slice(0, 6);
-
-  return (
-    <View style={styles.activitySection}>
-      <View style={styles.activityHeader}>
-        <Text style={styles.activityTitle}>Recent Activity</Text>
-        <Text style={styles.activityCount}>{activity.length} events</Text>
-      </View>
-      {visible.map((item, index) => {
-        const isPositive = item.type === 'REDEEM' || item.side === 'SELL';
-        const amount = Number.isFinite(item.usdcSize) ? item.usdcSize : 0;
-        return (
-          <Pressable
-            key={`${item.timestamp}-${item.slug}-${item.side}-${index}`}
-            style={styles.activityRow}
-            onPress={() => item.slug ? onMarketPress(item.slug) : undefined}
-          >
-            <View style={[styles.activityIcon, isPositive ? styles.activityIconPositive : styles.activityIconNegative]}>
-              <MaterialIcons
-                name={isPositive ? 'arrow-upward' : 'arrow-downward'}
-                size={12}
-                color={isPositive ? tokens.colors.viridian : tokens.colors.vermillion}
-              />
-            </View>
-            <View style={styles.activityInfo}>
-              <Text style={styles.activityRowTitle} numberOfLines={1}>
-                {activityVerb(item)} {item.outcome || 'pick'}
-              </Text>
-              <Text style={styles.activityMeta} numberOfLines={1}>
-                {item.title || item.slug || 'Predict market'} · {formatActivityTime(item.timestamp)}
-              </Text>
-            </View>
-            <Text style={[styles.activityAmount, isPositive ? styles.posText : styles.negText]}>
-              {isPositive ? '+' : '-'}{formatUsd(amount)}
-            </Text>
-          </Pressable>
-        );
-      })}
+      <CashOutConfirmModal
+        visible={cashOutPosition !== null}
+        position={cashOutPosition}
+        onClose={() => setCashOutPosition(null)}
+      />
     </View>
   );
 }
@@ -886,83 +810,6 @@ const styles = StyleSheet.create({
     color: semantic.text.faint,
     letterSpacing: 0.5,
   },
-
-  activitySection: {
-    marginHorizontal: tokens.spacing.lg,
-    marginTop: 14,
-  },
-  activityHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 8,
-  },
-  activityTitle: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    letterSpacing: 2,
-    textTransform: 'uppercase',
-    color: semantic.text.primary,
-    fontWeight: '700',
-  },
-  activityCount: {
-    fontFamily: 'monospace',
-    fontSize: 7.5,
-    color: semantic.text.faint,
-  },
-  activityRow: {
-    minHeight: 56,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingVertical: 10,
-    paddingHorizontal: 11,
-    marginBottom: 7,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: semantic.border.muted,
-    backgroundColor: semantic.background.surface,
-  },
-  activityIcon: {
-    width: 26,
-    height: 26,
-    borderRadius: 13,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 1,
-  },
-  activityIconPositive: {
-    borderColor: 'rgba(74,140,111,0.28)',
-    backgroundColor: 'rgba(74,140,111,0.10)',
-  },
-  activityIconNegative: {
-    borderColor: 'rgba(244,88,78,0.24)',
-    backgroundColor: 'rgba(244,88,78,0.08)',
-  },
-  activityInfo: {
-    flex: 1,
-    minWidth: 0,
-    gap: 2,
-  },
-  activityRowTitle: {
-    fontSize: 11,
-    fontWeight: '700',
-    color: semantic.text.primary,
-    lineHeight: 15,
-  },
-  activityMeta: {
-    fontFamily: 'monospace',
-    fontSize: 7.5,
-    color: semantic.text.faint,
-  },
-  activityAmount: {
-    width: 58,
-    textAlign: 'right',
-    fontFamily: 'monospace',
-    fontSize: 9,
-    fontWeight: '700',
-  },
-
 
   // Color helpers
   posText: { color: tokens.colors.viridian },

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -31,7 +31,7 @@ interface PredictMarketDetailScreenProps {
 }
 
 type Interval = '5m' | '1h' | '1d';
-type ActiveView = 'chart' | 'orderbook';
+type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
 
 const SOFT_COLLAPSED = 230; // handle + stats + odds
 const SOFT_EXPANDED = 680;  // + numpad
@@ -44,6 +44,22 @@ function formatDeadline(endDate: string | null, active: boolean | null): string 
   const month = date.toLocaleString('en-US', { month: 'short' });
   const day = date.getDate();
   return `${active === false ? 'Ended' : 'Ends'} ${month} ${day}`;
+}
+
+function DisplayTab({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable style={[styles.displayTab, active && styles.displayTabActive]} onPress={onPress}>
+      <Text style={[styles.displayTabText, active && styles.displayTabTextActive]}>{label}</Text>
+    </Pressable>
+  );
 }
 
 export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenProps) {
@@ -288,8 +304,12 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
         <View style={styles.body}>
           {/* ══ DARK ZONE ══ */}
           <View style={[styles.darkZone, { paddingBottom: SOFT_COLLAPSED }]}>
-            {/* Range chips + view toggle */}
-            <View style={styles.chipRow}>
+            <View style={styles.displayRow}>
+              <View style={styles.displayTabGroup}>
+                <DisplayTab label="Your Picks" active={activeView === 'picks'} onPress={() => setActiveView('picks')} />
+                <DisplayTab label="Stats" active={activeView === 'stats'} onPress={() => setActiveView('stats')} />
+              </View>
+              <View style={styles.displayTabGroup}>
               {activeView === 'chart' && (['5m', '1h', '1d'] as Interval[]).map((iv) => (
                 <Pressable
                   key={iv}
@@ -300,23 +320,38 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                   </Text>
                 </Pressable>
               ))}
-              <View style={styles.toggleIcons}>
-                <Pressable
-                  style={[styles.toggleBtn, activeView === 'chart' && styles.toggleBtnActive]}
-                  onPress={() => setActiveView('chart')}>
-                  <MaterialIcons name="show-chart" size={14} color={activeView === 'chart' ? semantic.text.primary : semantic.text.faint} />
-                </Pressable>
-                <Pressable
-                  style={[styles.toggleBtn, activeView === 'orderbook' && styles.toggleBtnActive]}
-                  onPress={() => setActiveView('orderbook')}>
-                  <MaterialIcons name="view-list" size={14} color={activeView === 'orderbook' ? semantic.text.primary : semantic.text.faint} />
-                </Pressable>
+                <DisplayTab label="Chart" active={activeView === 'chart'} onPress={() => setActiveView('chart')} />
+                <DisplayTab label="Book" active={activeView === 'orderbook'} onPress={() => setActiveView('orderbook')} />
               </View>
             </View>
 
             {/* Chart or Orderbook */}
             <View style={styles.viewContainer}>
-              {activeView === 'chart' ? (
+              {activeView === 'picks' ? (
+                <View style={styles.picksView}>
+                  <View style={styles.picksHeading}>
+                    <Text style={styles.picksTitle}>Your Picks</Text>
+                    <Text style={styles.picksSubtitle}>This market</Text>
+                  </View>
+                  <View style={styles.picksEmptyCard}>
+                    <Text style={styles.picksEmptyTitle}>No picks here yet</Text>
+                    <Text style={styles.picksEmptyText}>Pick YES or NO below. Once it is live, this panel shows cash out, back more, or collect actions.</Text>
+                  </View>
+                </View>
+              ) : activeView === 'stats' ? (
+                <View style={styles.statsView}>
+                  <View style={styles.picksHeading}>
+                    <Text style={styles.picksTitle}>Stats</Text>
+                    <Text style={styles.picksSubtitle}>Market health</Text>
+                  </View>
+                  <View style={styles.statsGrid}>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Volume</Text><Text style={styles.statsValue}>{formatUsdCompact(detail.volume24h)}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Liquidity</Text><Text style={styles.statsValue}>{formatUsdCompact(detail.liquidity)}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>No chance</Text><Text style={styles.statsValue}>{noPrice !== null ? `${Math.round(noPrice * 100)}%` : '--'}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Resolves</Text><Text style={styles.statsValue}>{formatDeadline(detail.endDate, detail.active)}</Text></View>
+                  </View>
+                </View>
+              ) : activeView === 'chart' ? (
                 historyLoading ? (
                   <View style={styles.chartSkeleton}>
                     <ActivityIndicator size="small" color={semantic.text.faint} />
@@ -483,6 +518,40 @@ const styles = StyleSheet.create({
     gap: 4,
     paddingVertical: 10,
   },
+  displayRow: {
+    minHeight: 38,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  displayTabGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    flexShrink: 1,
+  },
+  displayTab: {
+    height: 28,
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  displayTabActive: {
+    backgroundColor: tokens.colors.surface,
+  },
+  displayTabText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 0.7,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  displayTabTextActive: {
+    color: semantic.text.primary,
+  },
   rangeChip: {
     paddingHorizontal: 14,
     paddingVertical: 8,
@@ -526,6 +595,79 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  picksView: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  picksHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  picksTitle: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: 'uppercase',
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  picksSubtitle: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  picksEmptyCard: {
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 14,
+  },
+  picksEmptyTitle: {
+    color: semantic.text.primary,
+    fontSize: 12,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  picksEmptyText: {
+    color: semantic.text.dim,
+    fontSize: 10,
+    lineHeight: 15,
+  },
+  statsView: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  statsCard: {
+    width: '48%',
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 10,
+  },
+  statsLabel: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 1,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  statsValue: {
+    marginTop: 4,
+    fontFamily: 'monospace',
+    fontSize: 15,
+    fontWeight: '800',
+    color: semantic.text.primary,
   },
 
   // ── Soft zone ──

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -13,7 +13,8 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { fetchCuratedMarketDetail, fetchMarketPrice, fetchPriceHistory, fetchOrderbook, placeBet } from '@/features/predict/predict.api';
+import { cancelOrder, fetchCuratedMarketDetail, fetchMarketPrice, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, placeBet } from '@/features/predict/predict.api';
+import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import type { GeopoliticsMarketDetail, LivePrice, Orderbook, PricePoint } from '@/features/predict/predict.types';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { usePrivyWallet } from '@/hooks/usePrivyWallet';
@@ -25,6 +26,7 @@ import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
 import { StatsStrip } from '@/features/predict/components/StatsStrip';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
+import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
 
 interface PredictMarketDetailScreenProps {
   slug: string;
@@ -62,6 +64,17 @@ function DisplayTab({
   );
 }
 
+function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-sport/[sport]/[slug]'; params: { sport: string; slug: string } } {
+  const sportMatch = rowSlug.match(/^cric(epl|ucl|ipl)-/);
+  if (sportMatch) {
+    return {
+      pathname: '/predict-sport/[sport]/[slug]',
+      params: { sport: sportMatch[1], slug: rowSlug },
+    };
+  }
+  return `/predict-market/${encodeURIComponent(rowSlug)}`;
+}
+
 export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenProps) {
   const router = useRouter();
   const poly = usePolymarketWallet();
@@ -91,6 +104,13 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
+  const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
+  const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
+  const [redeemablePositions, setRedeemablePositions] = useState<PortfolioPosition[]>([]);
+  const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
+  const [picksLoading, setPicksLoading] = useState(false);
+  const [cancellingOrderId, setCancellingOrderId] = useState<string | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -157,6 +177,44 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
     }
   }
 
+  async function loadPicks() {
+    const gammaAddr = poly.tradingAddress ?? poly.polygonAddress;
+    if (!gammaAddr) {
+      setMarketPositions([]);
+      setAllPositions([]);
+      setRedeemablePositions([]);
+      setOpenOrders([]);
+      return;
+    }
+    setPicksLoading(true);
+    try {
+      const [market, portfolio, orders] = await Promise.all([
+        fetchMarketPositions(gammaAddr, slug).catch(() => []),
+        fetchPortfolio(gammaAddr).catch(() => null),
+        poly.polygonAddress ? fetchOpenOrders(poly.polygonAddress).catch(() => []) : Promise.resolve([]),
+      ]);
+      setMarketPositions(market);
+      setAllPositions(portfolio?.positions ?? []);
+      setRedeemablePositions(portfolio?.redeemablePositions ?? []);
+      setOpenOrders(orders);
+    } finally {
+      setPicksLoading(false);
+    }
+  }
+
+  async function handleCancelOrder(orderId: string) {
+    if (!poly.polygonAddress || cancellingOrderId) return;
+    setCancellingOrderId(orderId);
+    try {
+      const result = await cancelOrder(poly.polygonAddress, orderId);
+      if (result.ok) {
+        setOpenOrders((prev) => prev.filter((order) => order.id !== orderId));
+      }
+    } finally {
+      setCancellingOrderId(null);
+    }
+  }
+
   async function refreshPrice() {
     try {
       setLivePrice(await fetchMarketPrice(slug));
@@ -179,6 +237,10 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   useEffect(() => {
     if (activeView === 'orderbook' && detail) void loadOrderbook();
   }, [activeView, detail]);
+
+  useEffect(() => {
+    if (activeView === 'picks') void loadPicks();
+  }, [activeView, slug, poly.polygonAddress, poly.tradingAddress]);
 
   // Animate soft zone
   useEffect(() => {
@@ -328,16 +390,32 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
             {/* Chart or Orderbook */}
             <View style={styles.viewContainer}>
               {activeView === 'picks' ? (
-                <View style={styles.picksView}>
-                  <View style={styles.picksHeading}>
-                    <Text style={styles.picksTitle}>Your Picks</Text>
-                    <Text style={styles.picksSubtitle}>This market</Text>
-                  </View>
-                  <View style={styles.picksEmptyCard}>
-                    <Text style={styles.picksEmptyTitle}>No picks here yet</Text>
-                    <Text style={styles.picksEmptyText}>Pick YES or NO below. Once it is live, this panel shows cash out, back more, or collect actions.</Text>
-                  </View>
-                </View>
+                <DetailPicksPanel
+                  scope={pickScope}
+                  loading={picksLoading}
+                  marketPositions={marketPositions}
+                  allPositions={allPositions}
+                  redeemablePositions={redeemablePositions}
+                  openOrders={openOrders}
+                  cancellingOrderId={cancellingOrderId}
+                  onScopeChange={setPickScope}
+                  onCashOut={(position) => router.push({
+                    pathname: '/predict-position/[conditionId]',
+                    params: {
+                      conditionId: position.conditionId,
+                      slug: position.slug,
+                      outcomeIndex: String(position.outcomeIndex),
+                    },
+                  })}
+                  onBackMore={(position) => {
+                    if (position.slug && position.slug !== slug) {
+                      router.push(marketHrefForSlug(position.slug));
+                      return;
+                    }
+                    tapOdd(position.outcome === 'No' ? 'no' : 'yes');
+                  }}
+                  onCancelOrder={(orderId) => void handleCancelOrder(orderId)}
+                />
               ) : activeView === 'stats' ? (
                 <View style={styles.statsView}>
                   <View style={styles.picksHeading}>

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -360,6 +360,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
             {/* Odds format toggle + Binary odds buttons */}
             <View style={styles.oddsSection}>
               <View style={styles.oddsHeader}>
+                <Text style={styles.oddsTitle}>{"What's your pick?"}</Text>
                 <OddsFormatToggle format={format} onFormatChange={setFormat} />
               </View>
               <View style={styles.binaryBtns}>
@@ -367,13 +368,13 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                   style={[styles.bnBtn, styles.bnBtnYes, selectedSide === 'yes' && styles.bnBtnYesSelected]}
                   onPress={() => tapOdd('yes')}>
                   <Text style={styles.bnBtnYesPrice}>{yesPrice !== null ? formatOdds(yesPrice) : '--'}</Text>
-                  <Text style={styles.bnBtnYesLabel}>Yes</Text>
+                  <Text style={styles.bnBtnYesLabel}>Back YES</Text>
                 </Pressable>
                 <Pressable
                   style={[styles.bnBtn, styles.bnBtnNo, selectedSide === 'no' && styles.bnBtnNoSelected]}
                   onPress={() => tapOdd('no')}>
                   <Text style={styles.bnBtnNoPrice}>{noPrice !== null ? formatOdds(noPrice) : '--'}</Text>
-                  <Text style={styles.bnBtnNoLabel}>No</Text>
+                  <Text style={styles.bnBtnNoLabel}>Back NO</Text>
                 </Pressable>
               </View>
             </View>
@@ -382,6 +383,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
             <InlineNumpad
               visible={numpadOpen}
               side={selectedSide ?? 'yes'}
+              pickLabel={selectedSide === 'no' ? 'NO' : 'YES'}
               price={selectedSide === 'no' ? (noPrice ?? 0.5) : (yesPrice ?? 0.5)}
               amount={numpadAmount}
               onAmountChange={setNumpadAmount}
@@ -555,8 +557,15 @@ const styles = StyleSheet.create({
   },
   oddsHeader: {
     flexDirection: 'row',
-    justifyContent: 'flex-end',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     marginBottom: 8,
+  },
+  oddsTitle: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    fontWeight: '700',
+    color: semantic.text.primary,
   },
   binaryBtns: {
     flexDirection: 'row',

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -509,7 +509,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                     setPickScope('market');
                     void loadPicks();
                   }}>
-                    <Text style={styles.successSecondaryActionText}>Cash Out</Text>
+                    <Text style={styles.successSecondaryActionText}>Manage</Text>
                   </Pressable>
                   <Pressable style={styles.successSecondaryAction} onPress={() => tapOdd(livePick.label === 'NO' ? 'no' : 'yes')}>
                     <Text style={styles.successSecondaryActionText}>Add More</Text>

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -13,7 +13,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { cancelOrder, fetchCuratedMarketDetail, fetchMarketPrice, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, placeBet } from '@/features/predict/predict.api';
+import { cancelOrder, fetchClobBalance, fetchCuratedMarketDetail, fetchMarketPrice, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, placeBet } from '@/features/predict/predict.api';
 import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import type { GeopoliticsMarketDetail, LivePrice, Orderbook, PricePoint } from '@/features/predict/predict.types';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
@@ -26,6 +26,8 @@ import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
 import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
+import { CashOutConfirmModal } from '@/features/predict/components/CashOutConfirmModal';
+import { truncateUsd } from '@/features/predict/formatPredictMoney';
 
 interface PredictMarketDetailScreenProps {
   slug: string;
@@ -33,11 +35,6 @@ interface PredictMarketDetailScreenProps {
 
 type Interval = '5m' | '1h' | '1d';
 type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
-type LivePick = {
-  label: string;
-  amount: number;
-  price: number;
-};
 
 const SOFT_COLLAPSED = 230; // handle + stats + odds
 const SOFT_EXPANDED = 680;  // + numpad
@@ -110,7 +107,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const [selectedSide, setSelectedSide] = useState<'yes' | 'no' | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
-  const [livePick, setLivePick] = useState<LivePick | null>(null);
   const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
   const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
   const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
@@ -118,6 +114,8 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
   const [picksLoading, setPicksLoading] = useState(false);
   const [cancellingOrderId, setCancellingOrderId] = useState<string | null>(null);
+  const [cashBalance, setCashBalance] = useState<number | null>(null);
+  const [cashOutPosition, setCashOutPosition] = useState<PortfolioPosition | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -249,6 +247,20 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
     if (activeView === 'picks') void loadPicks();
   }, [activeView, slug, poly.polygonAddress, poly.tradingAddress]);
 
+  useEffect(() => {
+    let cancelled = false;
+    async function loadCashBalance() {
+      if (!poly.polygonAddress) {
+        setCashBalance(null);
+        return;
+      }
+      const balance = await fetchClobBalance(poly.polygonAddress).catch(() => null);
+      if (!cancelled) setCashBalance(balance?.balance ?? null);
+    }
+    void loadCashBalance();
+    return () => { cancelled = true; };
+  }, [poly.polygonAddress]);
+
   // Animate soft zone
   useEffect(() => {
     Animated.timing(softZoneAnim, {
@@ -261,7 +273,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const yesPrice = livePrice?.yesPrice ?? (detail?.outcomePrices[0] ?? null);
   const noPrice = livePrice?.noPrice ?? (detail?.outcomePrices[1] ?? null);
   function tapOdd(side: 'yes' | 'no') {
-    setLivePick(null);
     if (numpadOpen && selectedSide === side) {
       // same tap — collapse
       setNumpadOpen(false);
@@ -282,6 +293,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
     if (!detail || !selectedSide || submitting) return;
     const amount = parseFloat(numpadAmount);
     if (!amount || amount <= 0) return;
+    if (cashBalance !== null && amount > cashBalance + 0.000001) return;
 
     // Resolve token ID: yes = clobTokenIds[0], no = clobTokenIds[1]
     const tokenID = selectedSide === 'yes' ? detail.clobTokenIds[0] : detail.clobTokenIds[1];
@@ -326,17 +338,20 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      setLivePick({
-        label: selectedSide.toUpperCase(),
-        amount,
-        price,
-      });
       collapseNumpad();
+      setActiveView('picks');
+      setPickScope('market');
+      void loadPicks();
+      void fetchClobBalance(polygonAddress).then((balance) => setCashBalance(balance?.balance ?? null)).catch(() => undefined);
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function handleCashOut(position: PortfolioPosition) {
+    setCashOutPosition(position);
   }
 
   const chartWidth = screenWidth - 40;
@@ -354,9 +369,10 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
             {detail?.question ?? 'Loading...'}
           </Text>
         </View>
-        <Text style={styles.headerEnd}>
-          {detail ? formatDeadline(detail.endDate, detail.active) : ''}
-        </Text>
+        <View style={styles.cashPill}>
+          <Text style={styles.cashPillLabel}>Cash</Text>
+          <Text style={styles.cashPillValue}>{truncateUsd(cashBalance)}</Text>
+        </View>
       </View>
 
       {/* ── LOADING / ERROR ── */}
@@ -412,14 +428,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                   cancellingOrderId={cancellingOrderId}
                   polygonAddress={poly.polygonAddress}
                   onScopeChange={setPickScope}
-                  onCashOut={(position) => router.push({
-                    pathname: '/predict-position/[conditionId]',
-                    params: {
-                      conditionId: position.conditionId,
-                      slug: position.slug,
-                      outcomeIndex: String(position.outcomeIndex),
-                    },
-                  })}
+                  onCashOut={handleCashOut}
                   onBackMore={(position) => {
                     if (position.slug && position.slug !== slug) {
                       router.push(marketHrefForSlug(position.slug));
@@ -473,56 +482,13 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
               </Pressable>
             </View>
 
-            {livePick && (
-              <View style={styles.successPanel}>
-                <View style={styles.successPanelTop}>
-                  <MaterialIcons name="check-circle" size={16} color={tokens.colors.viridian} />
-                  <View style={styles.successPanelCopy}>
-                    <Text style={styles.successTitle}>Your pick is live</Text>
-                    <Text style={styles.successSub}>{livePick.label} at {Math.round(livePick.price * 100)}%</Text>
-                  </View>
-                </View>
-                <View style={styles.successStats}>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Put in</Text>
-                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
-                  </View>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Worth now</Text>
-                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
-                  </View>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Possible win</Text>
-                    <Text style={styles.successStatValue}>${(livePick.amount / livePick.price).toFixed(2)}</Text>
-                  </View>
-                </View>
-                <View style={styles.successActions}>
-                  <Pressable style={styles.successPrimaryAction} onPress={() => {
-                    setActiveView('picks');
-                    setPickScope('market');
-                    void loadPicks();
-                  }}>
-                    <Text style={styles.successPrimaryActionText}>View My Picks</Text>
-                  </Pressable>
-                  <Pressable style={styles.successSecondaryAction} onPress={() => {
-                    setActiveView('picks');
-                    setPickScope('market');
-                    void loadPicks();
-                  }}>
-                    <Text style={styles.successSecondaryActionText}>Manage</Text>
-                  </Pressable>
-                  <Pressable style={styles.successSecondaryAction} onPress={() => tapOdd(livePick.label === 'NO' ? 'no' : 'yes')}>
-                    <Text style={styles.successSecondaryActionText}>Add More</Text>
-                  </Pressable>
-                </View>
-              </View>
-            )}
-
             {/* Odds format toggle + Binary odds buttons */}
             <View style={styles.oddsSection}>
               <View style={styles.oddsHeader}>
                 <Text style={styles.oddsTitle}>{"What's your pick?"}</Text>
+                {/*
                 <OddsFormatToggle format={format} onFormatChange={setFormat} />
+                */}
               </View>
               <View style={styles.binaryBtns}>
                 <Pressable
@@ -547,6 +513,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
               pickLabel={selectedSide === 'no' ? 'NO' : 'YES'}
               price={selectedSide === 'no' ? (noPrice ?? 0.5) : (yesPrice ?? 0.5)}
               amount={numpadAmount}
+              availableCash={cashBalance}
               onAmountChange={setNumpadAmount}
               onConfirm={() => { void submitOrder(); }}
               submitting={submitting}
@@ -555,6 +522,11 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
           </Animated.View>
         </View>
       ) : null}
+      <CashOutConfirmModal
+        visible={cashOutPosition !== null}
+        position={cashOutPosition}
+        onClose={() => setCashOutPosition(null)}
+      />
     </View>
   );
 }
@@ -592,6 +564,31 @@ const styles = StyleSheet.create({
     fontSize: 8,
     color: semantic.text.faint,
     flexShrink: 0,
+  },
+  cashPill: {
+    minHeight: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: semantic.background.lift,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    flexShrink: 0,
+  },
+  cashPillLabel: {
+    fontFamily: 'monospace',
+    fontSize: 6,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  cashPillValue: {
+    fontFamily: 'monospace',
+    fontSize: 9.5,
+    fontWeight: '800',
+    color: semantic.text.primary,
   },
 
   // ── States ──
@@ -817,117 +814,6 @@ const styles = StyleSheet.create({
     backgroundColor: semantic.predict.rowBorderSoft,
     marginHorizontal: 20,
   },
-  successBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginHorizontal: 20,
-    marginTop: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 12,
-    backgroundColor: 'rgba(74,140,111,0.12)',
-    borderWidth: 1,
-    borderColor: 'rgba(74,140,111,0.24)',
-  },
-  successText: {
-    flex: 1,
-    fontFamily: 'monospace',
-    fontSize: 9,
-    lineHeight: 13,
-    color: semantic.text.primary,
-  },
-  successPanel: {
-    marginHorizontal: 20,
-    marginTop: 10,
-    padding: 12,
-    borderRadius: 14,
-    backgroundColor: 'rgba(74,140,111,0.12)',
-    borderWidth: 1,
-    borderColor: 'rgba(74,140,111,0.24)',
-    gap: 10,
-  },
-  successPanelTop: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  successPanelCopy: {
-    flex: 1,
-  },
-  successTitle: {
-    fontSize: 13,
-    fontWeight: '800',
-    color: semantic.text.primary,
-  },
-  successSub: {
-    marginTop: 2,
-    fontFamily: 'monospace',
-    fontSize: 8,
-    color: semantic.text.dim,
-    textTransform: 'uppercase',
-  },
-  successStats: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  successStat: {
-    flex: 1,
-    borderRadius: 10,
-    backgroundColor: 'rgba(0,0,0,0.12)',
-    padding: 8,
-  },
-  successStatLabel: {
-    fontFamily: 'monospace',
-    fontSize: 7,
-    color: semantic.text.faint,
-    textTransform: 'uppercase',
-  },
-  successStatValue: {
-    marginTop: 2,
-    fontFamily: 'monospace',
-    fontSize: 10,
-    fontWeight: '800',
-    color: semantic.text.primary,
-  },
-  successActions: {
-    flexDirection: 'row',
-    gap: 6,
-  },
-  successPrimaryAction: {
-    flex: 1.3,
-    minHeight: 34,
-    borderRadius: 9,
-    backgroundColor: tokens.colors.viridian,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 8,
-  },
-  successPrimaryActionText: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    fontWeight: '800',
-    color: tokens.colors.backgroundDark,
-    textTransform: 'uppercase',
-  },
-  successSecondaryAction: {
-    flex: 1,
-    minHeight: 34,
-    borderRadius: 9,
-    borderWidth: 1,
-    borderColor: semantic.border.muted,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 7,
-  },
-  successSecondaryActionText: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    fontWeight: '800',
-    color: semantic.text.primary,
-    textTransform: 'uppercase',
-  },
-
   // ── Binary odds ──
   oddsSection: {
     paddingHorizontal: 20,

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -1,6 +1,6 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'expo-router';
+import { useRouter, type Href } from 'expo-router';
 import {
   ActivityIndicator,
   Alert,
@@ -33,6 +33,11 @@ interface PredictMarketDetailScreenProps {
 
 type Interval = '5m' | '1h' | '1d';
 type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
+type LivePick = {
+  label: string;
+  amount: number;
+  price: number;
+};
 
 const SOFT_COLLAPSED = 230; // handle + stats + odds
 const SOFT_EXPANDED = 680;  // + numpad
@@ -63,7 +68,7 @@ function DisplayTab({
   );
 }
 
-function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-sport/[sport]/[slug]'; params: { sport: string; slug: string } } {
+function marketHrefForSlug(rowSlug: string): Href {
   const sportMatch = rowSlug.match(/^cric(epl|ucl|ipl)-/);
   if (sportMatch) {
     return {
@@ -71,7 +76,10 @@ function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-spor
       params: { sport: sportMatch[1], slug: rowSlug },
     };
   }
-  return `/predict-market/${encodeURIComponent(rowSlug)}`;
+  return {
+    pathname: '/predict-market/[slug]',
+    params: { slug: rowSlug },
+  };
 }
 
 export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenProps) {
@@ -102,7 +110,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const [selectedSide, setSelectedSide] = useState<'yes' | 'no' | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [livePick, setLivePick] = useState<LivePick | null>(null);
   const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
   const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
   const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
@@ -253,7 +261,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const yesPrice = livePrice?.yesPrice ?? (detail?.outcomePrices[0] ?? null);
   const noPrice = livePrice?.noPrice ?? (detail?.outcomePrices[1] ?? null);
   function tapOdd(side: 'yes' | 'no') {
-    setSuccessMessage(null);
+    setLivePick(null);
     if (numpadOpen && selectedSide === side) {
       // same tap — collapse
       setNumpadOpen(false);
@@ -318,7 +326,11 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      setSuccessMessage(`${selectedSide.toUpperCase()} is live with $${amount}. Follow it in Your Picks.`);
+      setLivePick({
+        label: selectedSide.toUpperCase(),
+        amount,
+        price,
+      });
       collapseNumpad();
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
@@ -398,6 +410,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                   redeemablePositions={redeemablePositions}
                   openOrders={openOrders}
                   cancellingOrderId={cancellingOrderId}
+                  polygonAddress={poly.polygonAddress}
                   onScopeChange={setPickScope}
                   onCashOut={(position) => router.push({
                     pathname: '/predict-position/[conditionId]',
@@ -415,6 +428,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                     tapOdd(position.outcome === 'No' ? 'no' : 'yes');
                   }}
                   onCancelOrder={(orderId) => void handleCancelOrder(orderId)}
+                  onRedeemed={() => void loadPicks()}
                 />
               ) : activeView === 'stats' ? (
                 <View style={styles.statsView}>
@@ -459,10 +473,48 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
               </Pressable>
             </View>
 
-            {successMessage && (
-              <View style={styles.successBanner}>
-                <MaterialIcons name="check-circle" size={14} color={tokens.colors.viridian} />
-                <Text style={styles.successText}>{successMessage}</Text>
+            {livePick && (
+              <View style={styles.successPanel}>
+                <View style={styles.successPanelTop}>
+                  <MaterialIcons name="check-circle" size={16} color={tokens.colors.viridian} />
+                  <View style={styles.successPanelCopy}>
+                    <Text style={styles.successTitle}>Your pick is live</Text>
+                    <Text style={styles.successSub}>{livePick.label} at {Math.round(livePick.price * 100)}%</Text>
+                  </View>
+                </View>
+                <View style={styles.successStats}>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Put in</Text>
+                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
+                  </View>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Worth now</Text>
+                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
+                  </View>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Possible win</Text>
+                    <Text style={styles.successStatValue}>${(livePick.amount / livePick.price).toFixed(2)}</Text>
+                  </View>
+                </View>
+                <View style={styles.successActions}>
+                  <Pressable style={styles.successPrimaryAction} onPress={() => {
+                    setActiveView('picks');
+                    setPickScope('market');
+                    void loadPicks();
+                  }}>
+                    <Text style={styles.successPrimaryActionText}>View My Picks</Text>
+                  </Pressable>
+                  <Pressable style={styles.successSecondaryAction} onPress={() => {
+                    setActiveView('picks');
+                    setPickScope('market');
+                    void loadPicks();
+                  }}>
+                    <Text style={styles.successSecondaryActionText}>Cash Out</Text>
+                  </Pressable>
+                  <Pressable style={styles.successSecondaryAction} onPress={() => tapOdd(livePick.label === 'NO' ? 'no' : 'yes')}>
+                    <Text style={styles.successSecondaryActionText}>Add More</Text>
+                  </Pressable>
+                </View>
               </View>
             )}
 
@@ -784,6 +836,96 @@ const styles = StyleSheet.create({
     fontSize: 9,
     lineHeight: 13,
     color: semantic.text.primary,
+  },
+  successPanel: {
+    marginHorizontal: 20,
+    marginTop: 10,
+    padding: 12,
+    borderRadius: 14,
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.24)',
+    gap: 10,
+  },
+  successPanelTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  successPanelCopy: {
+    flex: 1,
+  },
+  successTitle: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  successSub: {
+    marginTop: 2,
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.dim,
+    textTransform: 'uppercase',
+  },
+  successStats: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  successStat: {
+    flex: 1,
+    borderRadius: 10,
+    backgroundColor: 'rgba(0,0,0,0.12)',
+    padding: 8,
+  },
+  successStatLabel: {
+    fontFamily: 'monospace',
+    fontSize: 7,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  successStatValue: {
+    marginTop: 2,
+    fontFamily: 'monospace',
+    fontSize: 10,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  successActions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  successPrimaryAction: {
+    flex: 1.3,
+    minHeight: 34,
+    borderRadius: 9,
+    backgroundColor: tokens.colors.viridian,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  successPrimaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '800',
+    color: tokens.colors.backgroundDark,
+    textTransform: 'uppercase',
+  },
+  successSecondaryAction: {
+    flex: 1,
+    minHeight: 34,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 7,
+  },
+  successSecondaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '800',
+    color: semantic.text.primary,
+    textTransform: 'uppercase',
   },
 
   // ── Binary odds ──

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -24,7 +24,6 @@ import { useOddsFormat } from '@/hooks/useOddsFormat';
 import { OddsFormatToggle } from '@/features/predict/components/OddsFormatToggle';
 import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
-import { StatsStrip } from '@/features/predict/components/StatsStrip';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
 import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
 
@@ -392,6 +391,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
               {activeView === 'picks' ? (
                 <DetailPicksPanel
                   scope={pickScope}
+                  marketSlug={slug}
                   loading={picksLoading}
                   marketPositions={marketPositions}
                   allPositions={allPositions}
@@ -458,16 +458,6 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
                 <View style={styles.dragHandlePill} />
               </Pressable>
             </View>
-
-            {/* Stats strip */}
-            <StatsStrip stats={[
-              { value: formatUsdCompact(detail.volume24h), label: 'Volume' },
-              { value: formatUsdCompact(detail.liquidity), label: 'Liquidity' },
-              { value: '--', label: 'Traders' },
-            ]} />
-
-            {/* Separator */}
-            <View style={styles.separator} />
 
             {successMessage && (
               <View style={styles.successBanner}>

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -1,5 +1,5 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'expo-router';
 import {
   ActivityIndicator,
@@ -74,6 +74,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
   const [selectedSide, setSelectedSide] = useState<'yes' | 'no' | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -174,10 +175,8 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
   const yesPrice = livePrice?.yesPrice ?? (detail?.outcomePrices[0] ?? null);
   const noPrice = livePrice?.noPrice ?? (detail?.outcomePrices[1] ?? null);
-  const yesPct = yesPrice !== null ? Math.round(yesPrice * 100) : null;
-  const noPct = noPrice !== null ? Math.round(noPrice * 100) : null;
-
   function tapOdd(side: 'yes' | 'no') {
+    setSuccessMessage(null);
     if (numpadOpen && selectedSide === side) {
       // same tap — collapse
       setNumpadOpen(false);
@@ -242,7 +241,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      Alert.alert('Order placed', `${selectedSide.toUpperCase()} $${amount} @ ${Math.round(price * 100)}\u00A2`);
+      setSuccessMessage(`${selectedSide.toUpperCase()} is live with $${amount}. Follow it in Your Picks.`);
       collapseNumpad();
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
@@ -356,6 +355,13 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
             {/* Separator */}
             <View style={styles.separator} />
+
+            {successMessage && (
+              <View style={styles.successBanner}>
+                <MaterialIcons name="check-circle" size={14} color={tokens.colors.viridian} />
+                <Text style={styles.successText}>{successMessage}</Text>
+              </View>
+            )}
 
             {/* Odds format toggle + Binary odds buttons */}
             <View style={styles.oddsSection}>
@@ -548,6 +554,26 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: semantic.predict.rowBorderSoft,
     marginHorizontal: 20,
+  },
+  successBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 20,
+    marginTop: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.24)',
+  },
+  successText: {
+    flex: 1,
+    fontFamily: 'monospace',
+    fontSize: 9,
+    lineHeight: 13,
+    color: semantic.text.primary,
   },
 
   // ── Binary odds ──

--- a/apps/hybrid-expo/features/predict/PredictScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictScreen.tsx
@@ -15,10 +15,12 @@ import {
 import Svg, { Path } from 'react-native-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AvatarTrigger } from '@/components/drawer/AvatarTrigger';
-import { fetchPredictFeed } from '@/features/predict/predict.api';
+import { fetchClobBalance, fetchPredictFeed } from '@/features/predict/predict.api';
 import type { FeedItem, FeedItemBinary, FeedItemMatch, FeedResponse } from '@/features/predict/predict.types';
+import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { useOddsFormat } from '@/hooks/useOddsFormat';
 import { OddsFormatToggle } from '@/features/predict/components/OddsFormatToggle';
+import { truncateUsd } from '@/features/predict/formatPredictMoney';
 import { semantic, tokens } from '@/theme';
 import { formatUsdCompact } from '@/lib/format';
 
@@ -331,6 +333,7 @@ function SectionHeader({ label, count, onPress, isLive }: { label: string; count
 export default function PredictScreen() {
   const router = useRouter();
   const { format, setFormat, formatOdds } = useOddsFormat();
+  const poly = usePolymarketWallet();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
 
@@ -339,6 +342,7 @@ export default function PredictScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [activeCategory, setActiveCategory] = useState('All');
+  const [cashBalance, setCashBalance] = useState<number | null>(null);
 
   async function loadFeed() {
     setLoading(true);
@@ -358,6 +362,20 @@ export default function PredictScreen() {
   useEffect(() => {
     void loadFeed();
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadCashBalance() {
+      if (!poly.polygonAddress) {
+        setCashBalance(null);
+        return;
+      }
+      const balance = await fetchClobBalance(poly.polygonAddress).catch(() => null);
+      if (!cancelled) setCashBalance(balance?.balance ?? null);
+    }
+    void loadCashBalance();
+    return () => { cancelled = true; };
+  }, [poly.polygonAddress]);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -463,7 +481,13 @@ export default function PredictScreen() {
       <View style={styles.predictHeader}>
         <AvatarTrigger />
         <Text style={styles.predictTitle}>Predict</Text>
+        {/*
         <OddsFormatToggle format={format} onFormatChange={setFormat} />
+        */}
+        <View style={styles.cashPill}>
+          <Text style={styles.cashPillLabel}>Cash</Text>
+          <Text style={styles.cashPillValue}>{truncateUsd(cashBalance)}</Text>
+        </View>
       </View>
 
       {/* feed scroll */}
@@ -492,6 +516,7 @@ export default function PredictScreen() {
           </View>
         ) : null}
 
+        {/*
         {!loading && !errorMessage && featuredItems.length > 0 ? (
           <>
             <View style={styles.featuredHeader}>
@@ -525,6 +550,7 @@ export default function PredictScreen() {
             </ScrollView>
           </>
         ) : null}
+        */}
 
         {!loading && !errorMessage ? (
           <View style={styles.filterStripShell}>
@@ -649,6 +675,31 @@ const styles = StyleSheet.create({
     letterSpacing: 2.5,
     textTransform: 'uppercase',
     fontFamily: 'monospace',
+  },
+  cashPill: {
+    minHeight: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: semantic.background.lift,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    flexShrink: 0,
+  },
+  cashPillLabel: {
+    fontFamily: 'monospace',
+    fontSize: 6,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  cashPillValue: {
+    fontFamily: 'monospace',
+    fontSize: 9.5,
+    fontWeight: '800',
+    color: semantic.text.primary,
   },
   // ─── filter strip ───
   filterStripShell: {

--- a/apps/hybrid-expo/features/predict/PredictScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictScreen.tsx
@@ -141,7 +141,6 @@ function BinaryCard({ item, onPress, formatOdds }: { item: FeedItemBinary; onPre
         <Text style={styles.volBadge}>{formatUsdCompact(item.volume)} vol</Text>
         <Text style={styles.pctNo}>{formatOdds(1 - item.price)}</Text>
       </View>
-      <Text style={styles.cardActionHint}>Make Pick</Text>
     </Pressable>
   );
 }
@@ -194,12 +193,9 @@ function FeaturedCard({
           </View>
         </View>
 
-        <View style={styles.featuredActionRow}>
-          <Text style={styles.featuredActionPrimary}>Make Pick</Text>
-          <Text style={styles.featuredActionSecondary}>
-            {drawOutcome ? `Draw ${formatOdds(drawOutcome.price)}` : 'View chances'}
-          </Text>
-        </View>
+        {drawOutcome ? (
+          <Text style={styles.featuredContextText}>Draw {formatOdds(drawOutcome.price)}</Text>
+        ) : null}
       </Pressable>
     );
   }
@@ -228,10 +224,7 @@ function FeaturedCard({
         </View>
       </View>
 
-      <View style={styles.featuredActionRow}>
-        <Text style={styles.featuredActionPrimary}>Make Pick</Text>
-        <Text style={styles.featuredActionSecondary}>No {formatOdds(1 - item.price)}</Text>
-      </View>
+      <Text style={styles.featuredContextText}>No {formatOdds(1 - item.price)}</Text>
     </Pressable>
   );
 }
@@ -307,7 +300,6 @@ function MatchCard({ item, onPress, formatOdds }: { item: FeedItemMatch; onPress
         )}
         <Text style={[styles.oddsPct, styles.oddsPctNeg]}>{formatOdds(teamBPrice)}</Text>
       </View>
-      <Text style={styles.cardActionHint}>Make Pick</Text>
     </Pressable>
   );
 }
@@ -847,37 +839,11 @@ const styles = StyleSheet.create({
   featuredOddNeg: {
     color: tokens.colors.vermillion,
   },
-  featuredActionRow: {
-    flexDirection: 'row',
-    gap: tokens.spacing.sm,
-  },
-  featuredActionPrimary: {
-    flex: 1,
-    height: 32,
-    borderRadius: 10,
-    backgroundColor: tokens.colors.accent,
-    color: semantic.background.screen,
-    textAlign: 'center',
-    textAlignVertical: 'center',
-    fontSize: 12,
-    fontWeight: '800',
-    overflow: 'hidden',
-    paddingTop: 8,
-  },
-  featuredActionSecondary: {
-    flex: 1,
-    height: 32,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: semantic.border.muted,
-    backgroundColor: semantic.background.lift,
-    color: semantic.text.primary,
-    textAlign: 'center',
-    textAlignVertical: 'center',
+  featuredContextText: {
+    fontFamily: 'monospace',
     fontSize: 12,
     fontWeight: '700',
-    overflow: 'hidden',
-    paddingTop: 8,
+    color: semantic.text.dim,
   },
   featuredBinaryMain: {
     flexDirection: 'row',
@@ -1081,21 +1047,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 2,
     borderRadius: 3,
-  },
-  cardActionHint: {
-    marginTop: 9,
-    alignSelf: 'flex-start',
-    fontFamily: 'monospace',
-    fontSize: 9,
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-    color: semantic.background.screen,
-    backgroundColor: tokens.colors.accent,
-    borderRadius: 7,
-    overflow: 'hidden',
-    paddingHorizontal: 9,
-    paddingVertical: 5,
-    fontWeight: '800',
   },
   // ─── sport card (mockup: sport-card) ───
   sportCard: {

--- a/apps/hybrid-expo/features/predict/PredictScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictScreen.tsx
@@ -110,7 +110,6 @@ function CategoryBadge({ category }: { category: string }) {
 
 function BinaryCard({ item, onPress, formatOdds }: { item: FeedItemBinary; onPress: () => void; formatOdds: (p: number | null) => string }) {
   const yesPct = Math.round(item.price * 100);
-  const noPct = 100 - yesPct;
 
   return (
     <Pressable onPress={onPress} style={({ pressed }) => [styles.binaryCard, pressed && styles.cardPressed]}>
@@ -142,6 +141,7 @@ function BinaryCard({ item, onPress, formatOdds }: { item: FeedItemBinary; onPre
         <Text style={styles.volBadge}>{formatUsdCompact(item.volume)} vol</Text>
         <Text style={styles.pctNo}>{formatOdds(1 - item.price)}</Text>
       </View>
+      <Text style={styles.cardActionHint}>Make Pick</Text>
     </Pressable>
   );
 }
@@ -195,9 +195,9 @@ function FeaturedCard({
         </View>
 
         <View style={styles.featuredActionRow}>
-          <Text style={styles.featuredActionPrimary}>Trade {shortTeamName(teamA?.label ?? 'Yes')}</Text>
+          <Text style={styles.featuredActionPrimary}>Make Pick</Text>
           <Text style={styles.featuredActionSecondary}>
-            {drawOutcome ? `Draw ${formatOdds(drawOutcome.price)}` : 'Open market'}
+            {drawOutcome ? `Draw ${formatOdds(drawOutcome.price)}` : 'View chances'}
           </Text>
         </View>
       </Pressable>
@@ -229,7 +229,7 @@ function FeaturedCard({
       </View>
 
       <View style={styles.featuredActionRow}>
-        <Text style={styles.featuredActionPrimary}>Trade Yes</Text>
+        <Text style={styles.featuredActionPrimary}>Make Pick</Text>
         <Text style={styles.featuredActionSecondary}>No {formatOdds(1 - item.price)}</Text>
       </View>
     </Pressable>
@@ -307,6 +307,7 @@ function MatchCard({ item, onPress, formatOdds }: { item: FeedItemMatch; onPress
         )}
         <Text style={[styles.oddsPct, styles.oddsPctNeg]}>{formatOdds(teamBPrice)}</Text>
       </View>
+      <Text style={styles.cardActionHint}>Make Pick</Text>
     </Pressable>
   );
 }
@@ -1080,6 +1081,21 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 2,
     borderRadius: 3,
+  },
+  cardActionHint: {
+    marginTop: 9,
+    alignSelf: 'flex-start',
+    fontFamily: 'monospace',
+    fontSize: 9,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: semantic.background.screen,
+    backgroundColor: tokens.colors.accent,
+    borderRadius: 7,
+    overflow: 'hidden',
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    fontWeight: '800',
   },
   // ─── sport card (mockup: sport-card) ───
   sportCard: {

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -31,7 +31,7 @@ interface PredictSportDetailScreenProps {
 }
 
 type Interval = '5m' | '1h' | '1d';
-type ActiveView = 'chart' | 'orderbook';
+type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
 
 const SOFT_COLLAPSED = 280; // handle + stats + ~3 selection rows
 const SOFT_EXPANDED = 720;
@@ -43,6 +43,22 @@ function outcomeColor(outcome: SportOutcomeDetail, isLead: boolean): string {
 
 function sportOutcomeLabel(outcome: SportOutcomeDetail): string {
   return outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label;
+}
+
+function DisplayTab({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable style={[styles.displayTab, active && styles.displayTabActive]} onPress={onPress}>
+      <Text style={[styles.displayTabText, active && styles.displayTabTextActive]}>{label}</Text>
+    </Pressable>
+  );
 }
 
 export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScreenProps) {
@@ -61,7 +77,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [interval, setInterval] = useState<Interval>('1h');
   const [seriesData, setSeriesData] = useState<PricePoint[][]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
-  const [activeView, setActiveView] = useState<ActiveView>('chart');
+  const [activeView, setActiveView] = useState<ActiveView>('picks');
   const [orderbook, setOrderbook] = useState<Orderbook | null>(null);
   const [orderbookLoading, setOrderbookLoading] = useState(false);
   const [obOutcomeIdx, setObOutcomeIdx] = useState(0);
@@ -311,8 +327,12 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
         <View style={styles.body}>
           {/* ══ DARK ZONE ══ */}
           <View style={[styles.darkZone, { paddingBottom: SOFT_COLLAPSED }]}>
-            {/* Range chips + view toggle */}
-            <View style={styles.chipRow}>
+            <View style={styles.displayRow}>
+              <View style={styles.displayTabGroup}>
+                <DisplayTab label="Your Picks" active={activeView === 'picks'} onPress={() => setActiveView('picks')} />
+                <DisplayTab label="Stats" active={activeView === 'stats'} onPress={() => setActiveView('stats')} />
+              </View>
+              <View style={styles.displayTabGroup}>
               {activeView === 'chart' && (['5m', '1h', '1d'] as Interval[]).map((iv) => (
                 <Pressable
                   key={iv}
@@ -323,23 +343,38 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                   </Text>
                 </Pressable>
               ))}
-              <View style={styles.toggleIcons}>
-                <Pressable
-                  style={[styles.toggleBtn, activeView === 'chart' && styles.toggleBtnActive]}
-                  onPress={() => setActiveView('chart')}>
-                  <MaterialIcons name="show-chart" size={14} color={activeView === 'chart' ? semantic.text.primary : semantic.text.faint} />
-                </Pressable>
-                <Pressable
-                  style={[styles.toggleBtn, activeView === 'orderbook' && styles.toggleBtnActive]}
-                  onPress={() => setActiveView('orderbook')}>
-                  <MaterialIcons name="view-list" size={14} color={activeView === 'orderbook' ? semantic.text.primary : semantic.text.faint} />
-                </Pressable>
+                <DisplayTab label="Chart" active={activeView === 'chart'} onPress={() => setActiveView('chart')} />
+                <DisplayTab label="Book" active={activeView === 'orderbook'} onPress={() => setActiveView('orderbook')} />
               </View>
             </View>
 
             {/* Chart or Orderbook */}
             <View style={styles.viewContainer}>
-              {activeView === 'chart' ? (
+              {activeView === 'picks' ? (
+                <View style={styles.picksView}>
+                  <View style={styles.picksHeading}>
+                    <Text style={styles.picksTitle}>Your Picks</Text>
+                    <Text style={styles.picksSubtitle}>This match</Text>
+                  </View>
+                  <View style={styles.picksEmptyCard}>
+                    <Text style={styles.picksEmptyTitle}>No picks here yet</Text>
+                    <Text style={styles.picksEmptyText}>Back Liverpool, Draw, or Crystal Palace below. Live picks show cash out, back more, or collect actions here.</Text>
+                  </View>
+                </View>
+              ) : activeView === 'stats' ? (
+                <View style={styles.statsView}>
+                  <View style={styles.picksHeading}>
+                    <Text style={styles.picksTitle}>Stats</Text>
+                    <Text style={styles.picksSubtitle}>Live market</Text>
+                  </View>
+                  <View style={styles.statsGrid}>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Volume</Text><Text style={styles.statsValue}>{formatUsdCompact(detail.volume24h)}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Liquidity</Text><Text style={styles.statsValue}>{formatUsdCompact(detail.liquidity)}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Leader</Text><Text style={styles.statsValue}>{sortedOutcomes[0] ? sportOutcomeLabel(sortedOutcomes[0]) : '--'}</Text></View>
+                    <View style={styles.statsCard}><Text style={styles.statsLabel}>Chance</Text><Text style={styles.statsValue}>{leadPrice !== null ? `${Math.round(leadPrice * 100)}%` : '--'}</Text></View>
+                  </View>
+                </View>
+              ) : activeView === 'chart' ? (
                 historyLoading ? (
                   <View style={styles.chartSkeleton}>
                     <ActivityIndicator size="small" color={semantic.text.faint} />
@@ -541,6 +576,40 @@ const styles = StyleSheet.create({
     gap: 4,
     paddingVertical: 10,
   },
+  displayRow: {
+    minHeight: 38,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  displayTabGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    flexShrink: 1,
+  },
+  displayTab: {
+    height: 28,
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  displayTabActive: {
+    backgroundColor: tokens.colors.surface,
+  },
+  displayTabText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 0.7,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  displayTabTextActive: {
+    color: semantic.text.primary,
+  },
   rangeChip: {
     paddingHorizontal: 14,
     paddingVertical: 8,
@@ -572,6 +641,79 @@ const styles = StyleSheet.create({
   toggleBtnActive: { backgroundColor: tokens.colors.surface },
   viewContainer: { flex: 1, minHeight: 0 },
   chartSkeleton: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  picksView: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  picksHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  picksTitle: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: 'uppercase',
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  picksSubtitle: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  picksEmptyCard: {
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 14,
+  },
+  picksEmptyTitle: {
+    color: semantic.text.primary,
+    fontSize: 12,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  picksEmptyText: {
+    color: semantic.text.dim,
+    fontSize: 10,
+    lineHeight: 15,
+  },
+  statsView: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  statsCard: {
+    width: '48%',
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 10,
+  },
+  statsLabel: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 1,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  statsValue: {
+    marginTop: 4,
+    fontFamily: 'monospace',
+    fontSize: 15,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
 
   // ── Orderbook wrapper ──
   obWrap: { flex: 1 },

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -23,7 +23,6 @@ import { useOddsFormat } from '@/hooks/useOddsFormat';
 import { OddsFormatToggle } from '@/features/predict/components/OddsFormatToggle';
 import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
-import { StatsStrip } from '@/features/predict/components/StatsStrip';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
 import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
 
@@ -436,6 +435,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
               {activeView === 'picks' ? (
                 <DetailPicksPanel
                   scope={pickScope}
+                  marketSlug={slug}
                   loading={picksLoading}
                   marketPositions={marketPositions}
                   allPositions={allPositions}
@@ -511,16 +511,6 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                 <View style={styles.dragHandlePill} />
               </Pressable>
             </View>
-
-            {/* Stats strip */}
-            <StatsStrip stats={[
-              { value: formatUsdCompact(detail.volume24h), label: 'Volume' },
-              { value: formatUsdCompact(detail.liquidity), label: 'Liquidity' },
-              { value: '--', label: 'Traders' },
-            ]} />
-
-            {/* Separator */}
-            <View style={styles.separator} />
 
             {successMessage && (
               <View style={styles.successBanner}>

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -562,7 +562,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                     setPickScope('market');
                     void loadPicks();
                   }}>
-                    <Text style={styles.successSecondaryActionText}>Cash Out</Text>
+                    <Text style={styles.successSecondaryActionText}>Manage</Text>
                   </Pressable>
                   <Pressable style={styles.successSecondaryAction} onPress={() => {
                     const index = sortedOutcomes.findIndex((outcome) => sportOutcomeLabel(outcome) === livePick.label);

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -1,5 +1,5 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'expo-router';
 import {
   ActivityIndicator,
@@ -36,17 +36,6 @@ type ActiveView = 'chart' | 'orderbook';
 const SOFT_COLLAPSED = 280; // handle + stats + ~3 selection rows
 const SOFT_EXPANDED = 720;
 
-function formatKickoff(isoDate: string | null): string {
-  if (!isoDate) return 'TBD';
-  const time = Date.parse(isoDate);
-  if (Number.isNaN(time)) return 'TBD';
-  const date = new Date(time);
-  const month = date.toLocaleString('en-US', { month: 'short' });
-  const day = date.getDate();
-  const clock = date.toLocaleString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
-  return `${month} ${day} \u00B7 ${clock}`;
-}
-
 function outcomeColor(outcome: SportOutcomeDetail, isLead: boolean): string {
   if (outcome.label.toLowerCase().includes('draw')) return semantic.text.accent;
   return isLead ? semantic.sentiment.positive : semantic.sentiment.negative;
@@ -82,6 +71,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [selectedOutcomeIdx, setSelectedOutcomeIdx] = useState<number | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -199,6 +189,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   });
 
   function tapOdd(outcomeIdx: number) {
+    setSuccessMessage(null);
     if (numpadOpen && selectedOutcomeIdx === outcomeIdx) {
       setNumpadOpen(false);
       setSelectedOutcomeIdx(null);
@@ -261,7 +252,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      Alert.alert('Order placed', `${sportOutcomeLabel(outcome)} $${amount} @ ${Math.round(price * 100)}\u00A2`);
+      setSuccessMessage(`${sportOutcomeLabel(outcome)} is live with $${amount}. Follow it in Your Picks.`);
       collapseNumpad();
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
@@ -402,6 +393,13 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
 
             {/* Separator */}
             <View style={styles.separator} />
+
+            {successMessage && (
+              <View style={styles.successBanner}>
+                <MaterialIcons name="check-circle" size={14} color={tokens.colors.viridian} />
+                <Text style={styles.successText}>{successMessage}</Text>
+              </View>
+            )}
 
             {/* Selection rows */}
             <View style={styles.oddsSection}>
@@ -624,6 +622,26 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: semantic.predict.rowBorderSoft,
     marginHorizontal: 20,
+  },
+  successBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 20,
+    marginTop: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.24)',
+  },
+  successText: {
+    flex: 1,
+    fontFamily: 'monospace',
+    fontSize: 9,
+    lineHeight: 13,
+    color: semantic.text.primary,
   },
 
   // ── Selection rows ──

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -13,7 +13,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { cancelOrder, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, fetchSportMarketDetail, placeBet } from '@/features/predict/predict.api';
+import { cancelOrder, fetchClobBalance, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, fetchSportMarketDetail, placeBet } from '@/features/predict/predict.api';
 import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import type { PredictSport, PricePoint, SportMarketDetail, SportOutcomeDetail, Orderbook } from '@/features/predict/predict.types';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
@@ -25,6 +25,9 @@ import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
 import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
+import { CashOutConfirmModal } from '@/features/predict/components/CashOutConfirmModal';
+import { formatPredictTitle } from '@/features/predict/formatPredictTitle';
+import { truncateUsd } from '@/features/predict/formatPredictMoney';
 
 interface PredictSportDetailScreenProps {
   sport: PredictSport;
@@ -33,11 +36,6 @@ interface PredictSportDetailScreenProps {
 
 type Interval = '5m' | '1h' | '1d';
 type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
-type LivePick = {
-  label: string;
-  amount: number;
-  price: number;
-};
 
 const SOFT_COLLAPSED = 280; // handle + stats + ~3 selection rows
 const SOFT_EXPANDED = 720;
@@ -49,6 +47,30 @@ function outcomeColor(outcome: SportOutcomeDetail, isLead: boolean): string {
 
 function sportOutcomeLabel(outcome: SportOutcomeDetail): string {
   return outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label;
+}
+
+function outcomeTone(outcome: SportOutcomeDetail, index: number): 'lead' | 'draw' | 'trail' {
+  if (outcome.label.toLowerCase().includes('draw')) return 'draw';
+  return index === 0 ? 'lead' : 'trail';
+}
+
+function sortSportOutcomes(outcomes: SportOutcomeDetail[]): SportOutcomeDetail[] {
+  const list = [...outcomes];
+  const byPriceDesc = (a: SportOutcomeDetail, b: SportOutcomeDetail) => (b.price ?? -1) - (a.price ?? -1);
+  const draw = list.find((outcome) => outcome.label.toLowerCase().includes('draw'));
+
+  if (list.length === 3 && draw) {
+    const teams = list.filter((outcome) => outcome !== draw).sort(byPriceDesc);
+    if (teams.length === 2) return [teams[0], draw, teams[1]];
+  }
+
+  return list.sort((a, b) => {
+    const aIsDraw = a.label.toLowerCase().includes('draw');
+    const bIsDraw = b.label.toLowerCase().includes('draw');
+    if (aIsDraw && !bIsDraw) return 1;
+    if (!aIsDraw && bIsDraw) return -1;
+    return byPriceDesc(a, b);
+  });
 }
 
 function formatPositionOutcome(outcome: string | null | undefined): string {
@@ -112,7 +134,6 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [selectedOutcomeIdx, setSelectedOutcomeIdx] = useState<number | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
-  const [livePick, setLivePick] = useState<LivePick | null>(null);
   const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
   const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
   const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
@@ -120,6 +141,8 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
   const [picksLoading, setPicksLoading] = useState(false);
   const [cancellingOrderId, setCancellingOrderId] = useState<string | null>(null);
+  const [cashBalance, setCashBalance] = useState<number | null>(null);
+  const [cashOutPosition, setCashOutPosition] = useState<PortfolioPosition | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -138,16 +161,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   // Live badge pulse
   const livePulse = useRef(new Animated.Value(1)).current;
 
-  // Sort outcomes: lead first, draw in middle
-  const sortedOutcomes = detail
-    ? [...detail.outcomes].sort((a, b) => {
-        const aIsDraw = a.label.toLowerCase().includes('draw');
-        const bIsDraw = b.label.toLowerCase().includes('draw');
-        if (aIsDraw && !bIsDraw) return 1;
-        if (!aIsDraw && bIsDraw) return -1;
-        return (b.price ?? -1) - (a.price ?? -1);
-      })
-    : [];
+  const sortedOutcomes = detail ? sortSportOutcomes(detail.outcomes) : [];
   const leadPrice = sortedOutcomes[0]?.price ?? null;
 
   async function loadDetail() {
@@ -246,6 +260,20 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
     if (activeView === 'picks') void loadPicks();
   }, [activeView, slug, poly.polygonAddress, poly.tradingAddress]);
 
+  useEffect(() => {
+    let cancelled = false;
+    async function loadCashBalance() {
+      if (!poly.polygonAddress) {
+        setCashBalance(null);
+        return;
+      }
+      const balance = await fetchClobBalance(poly.polygonAddress).catch(() => null);
+      if (!cancelled) setCashBalance(balance?.balance ?? null);
+    }
+    void loadCashBalance();
+    return () => { cancelled = true; };
+  }, [poly.polygonAddress]);
+
   // LIVE pulse
   useEffect(() => {
     if (detail?.status !== 'live') return;
@@ -279,7 +307,6 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   });
 
   function tapOdd(outcomeIdx: number) {
-    setLivePick(null);
     if (numpadOpen && selectedOutcomeIdx === outcomeIdx) {
       setNumpadOpen(false);
       setSelectedOutcomeIdx(null);
@@ -315,6 +342,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
     if (!detail || selectedOutcomeIdx === null || submitting) return;
     const amount = parseFloat(numpadAmount);
     if (!amount || amount <= 0) return;
+    if (cashBalance !== null && amount > cashBalance + 0.000001) return;
 
     const outcome = sortedOutcomes[selectedOutcomeIdx];
     if (!outcome) return;
@@ -358,17 +386,20 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      setLivePick({
-        label: sportOutcomeLabel(outcome),
-        amount,
-        price,
-      });
       collapseNumpad();
+      setActiveView('picks');
+      setPickScope('market');
+      void loadPicks();
+      void fetchClobBalance(polygonAddress).then((balance) => setCashBalance(balance?.balance ?? null)).catch(() => undefined);
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function handleCashOut(position: PortfolioPosition) {
+    setCashOutPosition(position);
   }
 
   const numpadPrice = (() => {
@@ -379,6 +410,13 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   })();
   const selectedOutcome = selectedOutcomeIdx !== null ? sortedOutcomes[selectedOutcomeIdx] : null;
   const selectedOutcomeLabel = selectedOutcome ? sportOutcomeLabel(selectedOutcome) : undefined;
+  const displayTitle = detail
+    ? formatPredictTitle({
+        title: detail.title,
+        slug: detail.slug,
+        outcomes: detail.outcomes.map((outcome) => outcome.label),
+      })
+    : 'Loading...';
 
   const chartWidth = screenWidth - 40;
   const chartHeight = 180;
@@ -392,15 +430,21 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
         </Pressable>
         <View style={styles.headerCenter}>
           <Text style={styles.headerTitle} numberOfLines={1}>
-            {detail?.title ?? 'Loading...'}
+            {displayTitle}
           </Text>
         </View>
-        {detail?.status === 'live' && (
-          <View style={styles.liveBadge}>
-            <Animated.View style={[styles.liveDot, { opacity: livePulse }]} />
-            <Text style={styles.liveText}>LIVE</Text>
+        <View style={styles.headerRight}>
+          {detail?.status === 'live' && (
+            <View style={styles.liveBadge}>
+              <Animated.View style={[styles.liveDot, { opacity: livePulse }]} />
+              <Text style={styles.liveText}>LIVE</Text>
+            </View>
+          )}
+          <View style={styles.cashPill}>
+            <Text style={styles.cashPillLabel}>Cash</Text>
+            <Text style={styles.cashPillValue}>{truncateUsd(cashBalance)}</Text>
           </View>
-        )}
+        </View>
       </View>
 
       {/* ── LOADING / ERROR ── */}
@@ -456,14 +500,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                   cancellingOrderId={cancellingOrderId}
                   polygonAddress={poly.polygonAddress}
                   onScopeChange={setPickScope}
-                  onCashOut={(position) => router.push({
-                    pathname: '/predict-position/[conditionId]',
-                    params: {
-                      conditionId: position.conditionId,
-                      slug: position.slug,
-                      outcomeIndex: String(position.outcomeIndex),
-                    },
-                  })}
+                  onCashOut={handleCashOut}
                   onBackMore={backMorePosition}
                   onCancelOrder={(orderId) => void handleCancelOrder(orderId)}
                   onRedeemed={() => void loadPicks()}
@@ -526,63 +563,18 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
               </Pressable>
             </View>
 
-            {livePick && (
-              <View style={styles.successPanel}>
-                <View style={styles.successPanelTop}>
-                  <MaterialIcons name="check-circle" size={16} color={tokens.colors.viridian} />
-                  <View style={styles.successPanelCopy}>
-                    <Text style={styles.successTitle}>Your pick is live</Text>
-                    <Text style={styles.successSub}>{livePick.label} at {Math.round(livePick.price * 100)}%</Text>
-                  </View>
-                </View>
-                <View style={styles.successStats}>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Put in</Text>
-                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
-                  </View>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Worth now</Text>
-                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
-                  </View>
-                  <View style={styles.successStat}>
-                    <Text style={styles.successStatLabel}>Possible win</Text>
-                    <Text style={styles.successStatValue}>${(livePick.amount / livePick.price).toFixed(2)}</Text>
-                  </View>
-                </View>
-                <View style={styles.successActions}>
-                  <Pressable style={styles.successPrimaryAction} onPress={() => {
-                    setActiveView('picks');
-                    setPickScope('market');
-                    void loadPicks();
-                  }}>
-                    <Text style={styles.successPrimaryActionText}>View My Picks</Text>
-                  </Pressable>
-                  <Pressable style={styles.successSecondaryAction} onPress={() => {
-                    setActiveView('picks');
-                    setPickScope('market');
-                    void loadPicks();
-                  }}>
-                    <Text style={styles.successSecondaryActionText}>Manage</Text>
-                  </Pressable>
-                  <Pressable style={styles.successSecondaryAction} onPress={() => {
-                    const index = sortedOutcomes.findIndex((outcome) => sportOutcomeLabel(outcome) === livePick.label);
-                    tapOdd(index >= 0 ? index : 0);
-                  }}>
-                    <Text style={styles.successSecondaryActionText}>Add More</Text>
-                  </Pressable>
-                </View>
-              </View>
-            )}
-
             {/* Selection rows */}
             <View style={styles.oddsSection}>
               <View style={styles.selHeader}>
                 <Text style={styles.selHeaderLabel}>{"What's your pick?"}</Text>
+                {/*
                 <OddsFormatToggle format={format} onFormatChange={setFormat} />
+                */}
               </View>
               {sortedOutcomes.map((outcome, i) => {
                 const label = sportOutcomeLabel(outcome);
                 const isSelected = selectedOutcomeIdx === i;
+                const tone = outcomeTone(outcome, i);
                 return (
                   <View key={`${outcome.conditionId ?? outcome.label}-${i}`} style={[styles.selRow, i > 0 && styles.selRowBorder]}>
                     <View style={styles.selInfo}>
@@ -591,10 +583,18 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                     </View>
                     <View style={styles.selBtns}>
                       <Pressable
-                        style={[styles.selBtn, isSelected && styles.selBtnSelected]}
+                        style={[
+                          styles.selBtn,
+                          tone === 'lead' ? styles.selBtnLead : tone === 'draw' ? styles.selBtnDraw : styles.selBtnTrail,
+                          isSelected && (tone === 'lead' ? styles.selBtnLeadSelected : tone === 'draw' ? styles.selBtnDrawSelected : styles.selBtnTrailSelected),
+                        ]}
                         onPress={() => tapOdd(i)}>
-                        <Text style={styles.selBtnPct}>{outcome.price !== null ? formatOdds(outcome.price) : '--'}</Text>
-                        <Text style={styles.selBtnLabel} numberOfLines={1}>Back {label}</Text>
+                        <Text style={[
+                          styles.selBtnPct,
+                          tone === 'lead' ? styles.selBtnPctLead : tone === 'draw' ? styles.selBtnPctDraw : styles.selBtnPctTrail,
+                        ]}>
+                          {outcome.price !== null ? formatOdds(outcome.price) : '--'}
+                        </Text>
                       </Pressable>
                     </View>
                   </View>
@@ -609,6 +609,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
               pickLabel={selectedOutcomeLabel}
               price={numpadPrice}
               amount={numpadAmount}
+              availableCash={cashBalance}
               onAmountChange={setNumpadAmount}
               onConfirm={() => { void submitOrder(); }}
               submitting={submitting}
@@ -617,6 +618,11 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
           </Animated.View>
         </View>
       ) : null}
+      <CashOutConfirmModal
+        visible={cashOutPosition !== null}
+        position={cashOutPosition}
+        onClose={() => setCashOutPosition(null)}
+      />
     </View>
   );
 }
@@ -649,6 +655,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     fontFamily: 'monospace',
   },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 7,
+    flexShrink: 0,
+  },
   liveBadge: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -668,6 +680,31 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     textTransform: 'uppercase',
     color: semantic.sentiment.negative,
+  },
+  cashPill: {
+    minHeight: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: semantic.background.lift,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    flexShrink: 0,
+  },
+  cashPillLabel: {
+    fontFamily: 'monospace',
+    fontSize: 6,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  cashPillValue: {
+    fontFamily: 'monospace',
+    fontSize: 9.5,
+    fontWeight: '800',
+    color: semantic.text.primary,
   },
 
   // ── States ──
@@ -903,117 +940,6 @@ const styles = StyleSheet.create({
     backgroundColor: semantic.predict.rowBorderSoft,
     marginHorizontal: 20,
   },
-  successBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginHorizontal: 20,
-    marginTop: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 12,
-    backgroundColor: 'rgba(74,140,111,0.12)',
-    borderWidth: 1,
-    borderColor: 'rgba(74,140,111,0.24)',
-  },
-  successText: {
-    flex: 1,
-    fontFamily: 'monospace',
-    fontSize: 9,
-    lineHeight: 13,
-    color: semantic.text.primary,
-  },
-  successPanel: {
-    marginHorizontal: 20,
-    marginTop: 10,
-    padding: 12,
-    borderRadius: 14,
-    backgroundColor: 'rgba(74,140,111,0.12)',
-    borderWidth: 1,
-    borderColor: 'rgba(74,140,111,0.24)',
-    gap: 10,
-  },
-  successPanelTop: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  successPanelCopy: {
-    flex: 1,
-  },
-  successTitle: {
-    fontSize: 13,
-    fontWeight: '800',
-    color: semantic.text.primary,
-  },
-  successSub: {
-    marginTop: 2,
-    fontFamily: 'monospace',
-    fontSize: 8,
-    color: semantic.text.dim,
-    textTransform: 'uppercase',
-  },
-  successStats: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  successStat: {
-    flex: 1,
-    borderRadius: 10,
-    backgroundColor: 'rgba(0,0,0,0.12)',
-    padding: 8,
-  },
-  successStatLabel: {
-    fontFamily: 'monospace',
-    fontSize: 7,
-    color: semantic.text.faint,
-    textTransform: 'uppercase',
-  },
-  successStatValue: {
-    marginTop: 2,
-    fontFamily: 'monospace',
-    fontSize: 10,
-    fontWeight: '800',
-    color: semantic.text.primary,
-  },
-  successActions: {
-    flexDirection: 'row',
-    gap: 6,
-  },
-  successPrimaryAction: {
-    flex: 1.3,
-    minHeight: 34,
-    borderRadius: 9,
-    backgroundColor: tokens.colors.viridian,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 8,
-  },
-  successPrimaryActionText: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    fontWeight: '800',
-    color: tokens.colors.backgroundDark,
-    textTransform: 'uppercase',
-  },
-  successSecondaryAction: {
-    flex: 1,
-    minHeight: 34,
-    borderRadius: 9,
-    borderWidth: 1,
-    borderColor: semantic.border.muted,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 7,
-  },
-  successSecondaryActionText: {
-    fontFamily: 'monospace',
-    fontSize: 8,
-    fontWeight: '800',
-    color: semantic.text.primary,
-    textTransform: 'uppercase',
-  },
-
   // ── Selection rows ──
   oddsSection: {
     paddingHorizontal: 20,
@@ -1056,30 +982,48 @@ const styles = StyleSheet.create({
   selBtns: { flexDirection: 'row', gap: 8, flexShrink: 0 },
   selBtn: {
     width: 92,
-    height: 42,
+    height: 38,
     borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 1,
+  },
+  selBtnLead: {
     backgroundColor: semantic.predict.outcomeYesBg,
   },
-  selBtnSelected: {
+  selBtnDraw: {
+    backgroundColor: semantic.predict.outcomeDrawBg,
+  },
+  selBtnTrail: {
+    backgroundColor: semantic.predict.outcomeNoBg,
+  },
+  selBtnLeadSelected: {
     backgroundColor: 'rgba(74,140,111,0.25)',
     borderWidth: 1,
     borderColor: 'rgba(74,140,111,0.35)',
   },
+  selBtnDrawSelected: {
+    backgroundColor: 'rgba(199,183,112,0.22)',
+    borderWidth: 1,
+    borderColor: 'rgba(199,183,112,0.35)',
+  },
+  selBtnTrailSelected: {
+    backgroundColor: 'rgba(217,83,79,0.20)',
+    borderWidth: 1,
+    borderColor: 'rgba(217,83,79,0.35)',
+  },
   selBtnPct: {
     fontFamily: 'monospace',
-    fontSize: 12,
+    fontSize: 15,
     fontWeight: '700',
-    color: semantic.sentiment.positive,
-    lineHeight: 14,
+    lineHeight: 18,
   },
-  selBtnLabel: {
-    fontFamily: 'monospace',
-    fontSize: 6.5,
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-    color: 'rgba(74,140,111,0.55)',
+  selBtnPctLead: {
+    color: semantic.sentiment.positive,
+  },
+  selBtnPctDraw: {
+    color: semantic.text.accent,
+  },
+  selBtnPctTrail: {
+    color: semantic.sentiment.negative,
   },
 });

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -52,6 +52,10 @@ function outcomeColor(outcome: SportOutcomeDetail, isLead: boolean): string {
   return isLead ? semantic.sentiment.positive : semantic.sentiment.negative;
 }
 
+function sportOutcomeLabel(outcome: SportOutcomeDetail): string {
+  return outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label;
+}
+
 export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScreenProps) {
   const router = useRouter();
   const poly = usePolymarketWallet();
@@ -76,7 +80,6 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   // Numpad state
   const [numpadOpen, setNumpadOpen] = useState(false);
   const [selectedOutcomeIdx, setSelectedOutcomeIdx] = useState<number | null>(null);
-  const [selectedSide, setSelectedSide] = useState<'yes' | 'no' | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
 
@@ -191,19 +194,17 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
     return {
       points: seriesData[i] ?? [],
       color: outcomeColor(outcome, isLead),
-      label: outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label,
+      label: sportOutcomeLabel(outcome),
     };
   });
 
-  function tapOdd(outcomeIdx: number, side: 'yes' | 'no') {
-    if (numpadOpen && selectedOutcomeIdx === outcomeIdx && selectedSide === side) {
+  function tapOdd(outcomeIdx: number) {
+    if (numpadOpen && selectedOutcomeIdx === outcomeIdx) {
       setNumpadOpen(false);
       setSelectedOutcomeIdx(null);
-      setSelectedSide(null);
       return;
     }
     setSelectedOutcomeIdx(outcomeIdx);
-    setSelectedSide(side);
     setNumpadAmount('50');
     setNumpadOpen(true);
   }
@@ -211,25 +212,23 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   function collapseNumpad() {
     setNumpadOpen(false);
     setSelectedOutcomeIdx(null);
-    setSelectedSide(null);
   }
 
   async function submitOrder() {
-    if (!detail || selectedOutcomeIdx === null || !selectedSide || submitting) return;
+    if (!detail || selectedOutcomeIdx === null || submitting) return;
     const amount = parseFloat(numpadAmount);
     if (!amount || amount <= 0) return;
 
     const outcome = sortedOutcomes[selectedOutcomeIdx];
     if (!outcome) return;
 
-    // For "yes" buy the yes token (clobTokenIds[0]), for "no" buy the no token (clobTokenIds[1])
-    const tokenID = selectedSide === 'yes' ? outcome.clobTokenIds[0] : outcome.clobTokenIds[1];
+    const tokenID = outcome.clobTokenIds[0];
     if (!tokenID) {
       Alert.alert('Error', 'No token ID for this outcome');
       return;
     }
 
-    const price = selectedSide === 'yes' ? outcome.price : (outcome.price !== null ? 1 - outcome.price : null);
+    const price = outcome.price;
     if (!price || price <= 0 || price >= 1) {
       Alert.alert('Error', 'Invalid price');
       return;
@@ -262,8 +261,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      const label = outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label;
-      Alert.alert('Order placed', `${selectedSide.toUpperCase()} ${label} $${amount} @ ${Math.round(price * 100)}\u00A2`);
+      Alert.alert('Order placed', `${sportOutcomeLabel(outcome)} $${amount} @ ${Math.round(price * 100)}\u00A2`);
       collapseNumpad();
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
@@ -273,11 +271,13 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   }
 
   const numpadPrice = (() => {
-    if (selectedOutcomeIdx === null || selectedSide === null) return 0.5;
+    if (selectedOutcomeIdx === null) return 0.5;
     const outcome = sortedOutcomes[selectedOutcomeIdx];
     if (!outcome?.price) return 0.5;
-    return selectedSide === 'yes' ? outcome.price : 1 - outcome.price;
+    return outcome.price;
   })();
+  const selectedOutcome = selectedOutcomeIdx !== null ? sortedOutcomes[selectedOutcomeIdx] : null;
+  const selectedOutcomeLabel = selectedOutcome ? sportOutcomeLabel(selectedOutcome) : undefined;
 
   const chartWidth = screenWidth - 40;
   const chartHeight = 180;
@@ -365,8 +365,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                   {/* Outcome tabs for orderbook */}
                   <View style={styles.obOutcomeTabs}>
                     {sortedOutcomes.map((o, i) => {
-                      const isDraw = o.label.toLowerCase().includes('draw');
-                      const label = isDraw ? 'Draw' : o.label;
+                      const label = sportOutcomeLabel(o);
                       return (
                         <Pressable
                           key={`${o.conditionId ?? o.label}-${i}`}
@@ -407,13 +406,12 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
             {/* Selection rows */}
             <View style={styles.oddsSection}>
               <View style={styles.selHeader}>
-                <Text style={styles.selHeaderLabel}>{sortedOutcomes.length} Selections</Text>
+                <Text style={styles.selHeaderLabel}>{"What's your pick?"}</Text>
                 <OddsFormatToggle format={format} onFormatChange={setFormat} />
               </View>
               {sortedOutcomes.map((outcome, i) => {
-                const isDraw = outcome.label.toLowerCase().includes('draw');
-                const label = isDraw ? 'Draw' : outcome.label;
-                const isSelected = (side: 'yes' | 'no') => selectedOutcomeIdx === i && selectedSide === side;
+                const label = sportOutcomeLabel(outcome);
+                const isSelected = selectedOutcomeIdx === i;
                 return (
                   <View key={`${outcome.conditionId ?? outcome.label}-${i}`} style={[styles.selRow, i > 0 && styles.selRowBorder]}>
                     <View style={styles.selInfo}>
@@ -422,16 +420,10 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                     </View>
                     <View style={styles.selBtns}>
                       <Pressable
-                        style={[styles.selBtn, styles.selBtnYes, isSelected('yes') && styles.selBtnYesSelected]}
-                        onPress={() => tapOdd(i, 'yes')}>
-                        <Text style={styles.selBtnYesPct}>{outcome.price !== null ? formatOdds(outcome.price) : '--'}</Text>
-                        <Text style={styles.selBtnYesLabel}>Yes</Text>
-                      </Pressable>
-                      <Pressable
-                        style={[styles.selBtn, styles.selBtnNo, isSelected('no') && styles.selBtnNoSelected]}
-                        onPress={() => tapOdd(i, 'no')}>
-                        <Text style={styles.selBtnNoPct}>{outcome.price !== null ? formatOdds(1 - outcome.price) : '--'}</Text>
-                        <Text style={styles.selBtnNoLabel}>No</Text>
+                        style={[styles.selBtn, isSelected && styles.selBtnSelected]}
+                        onPress={() => tapOdd(i)}>
+                        <Text style={styles.selBtnPct}>{outcome.price !== null ? formatOdds(outcome.price) : '--'}</Text>
+                        <Text style={styles.selBtnLabel} numberOfLines={1}>Back {label}</Text>
                       </Pressable>
                     </View>
                   </View>
@@ -442,7 +434,8 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
             {/* Inline numpad */}
             <InlineNumpad
               visible={numpadOpen}
-              side={selectedSide ?? 'yes'}
+              side="yes"
+              pickLabel={selectedOutcomeLabel}
               price={numpadPrice}
               amount={numpadAmount}
               onAmountChange={setNumpadAmount}
@@ -646,9 +639,9 @@ const styles = StyleSheet.create({
   },
   selHeaderLabel: {
     fontFamily: 'monospace',
-    fontSize: 8,
-    letterSpacing: 1,
-    color: semantic.text.dim,
+    fontSize: 11,
+    fontWeight: '700',
+    color: semantic.text.primary,
   },
   selRow: {
     flexDirection: 'row',
@@ -674,51 +667,31 @@ const styles = StyleSheet.create({
   },
   selBtns: { flexDirection: 'row', gap: 8, flexShrink: 0 },
   selBtn: {
-    width: 58,
+    width: 92,
     height: 42,
     borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
     gap: 1,
+    backgroundColor: semantic.predict.outcomeYesBg,
   },
-  selBtnYes: { backgroundColor: semantic.predict.outcomeYesBg },
-  selBtnNo: { backgroundColor: semantic.predict.outcomeNoBg },
-  selBtnYesSelected: {
+  selBtnSelected: {
     backgroundColor: 'rgba(74,140,111,0.25)',
     borderWidth: 1,
     borderColor: 'rgba(74,140,111,0.35)',
   },
-  selBtnNoSelected: {
-    backgroundColor: 'rgba(217,83,79,0.20)',
-    borderWidth: 1,
-    borderColor: 'rgba(217,83,79,0.35)',
-  },
-  selBtnYesPct: {
+  selBtnPct: {
     fontFamily: 'monospace',
     fontSize: 12,
     fontWeight: '700',
     color: semantic.sentiment.positive,
     lineHeight: 14,
   },
-  selBtnYesLabel: {
+  selBtnLabel: {
     fontFamily: 'monospace',
     fontSize: 6.5,
     letterSpacing: 0.8,
     textTransform: 'uppercase',
     color: 'rgba(74,140,111,0.55)',
-  },
-  selBtnNoPct: {
-    fontFamily: 'monospace',
-    fontSize: 12,
-    fontWeight: '700',
-    color: semantic.sentiment.negative,
-    lineHeight: 14,
-  },
-  selBtnNoLabel: {
-    fontFamily: 'monospace',
-    fontSize: 6.5,
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-    color: 'rgba(217,83,79,0.45)',
   },
 });

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -1,6 +1,6 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'expo-router';
+import { useRouter, type Href } from 'expo-router';
 import {
   ActivityIndicator,
   Alert,
@@ -33,6 +33,11 @@ interface PredictSportDetailScreenProps {
 
 type Interval = '5m' | '1h' | '1d';
 type ActiveView = 'picks' | 'stats' | 'chart' | 'orderbook';
+type LivePick = {
+  label: string;
+  amount: number;
+  price: number;
+};
 
 const SOFT_COLLAPSED = 280; // handle + stats + ~3 selection rows
 const SOFT_EXPANDED = 720;
@@ -67,7 +72,7 @@ function DisplayTab({
   );
 }
 
-function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-sport/[sport]/[slug]'; params: { sport: string; slug: string } } {
+function marketHrefForSlug(rowSlug: string): Href {
   const sportMatch = rowSlug.match(/^cric(epl|ucl|ipl)-/);
   if (sportMatch) {
     return {
@@ -75,7 +80,10 @@ function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-spor
       params: { sport: sportMatch[1], slug: rowSlug },
     };
   }
-  return `/predict-market/${encodeURIComponent(rowSlug)}`;
+  return {
+    pathname: '/predict-market/[slug]',
+    params: { slug: rowSlug },
+  };
 }
 
 export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScreenProps) {
@@ -104,7 +112,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [selectedOutcomeIdx, setSelectedOutcomeIdx] = useState<number | null>(null);
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [livePick, setLivePick] = useState<LivePick | null>(null);
   const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
   const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
   const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
@@ -271,7 +279,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   });
 
   function tapOdd(outcomeIdx: number) {
-    setSuccessMessage(null);
+    setLivePick(null);
     if (numpadOpen && selectedOutcomeIdx === outcomeIdx) {
       setNumpadOpen(false);
       setSelectedOutcomeIdx(null);
@@ -350,7 +358,11 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
       });
       if (!result.success) throw new Error(result.error || 'Order failed');
 
-      setSuccessMessage(`${sportOutcomeLabel(outcome)} is live with $${amount}. Follow it in Your Picks.`);
+      setLivePick({
+        label: sportOutcomeLabel(outcome),
+        amount,
+        price,
+      });
       collapseNumpad();
     } catch (err: any) {
       Alert.alert('Order failed', err.message || 'Unknown error');
@@ -442,6 +454,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                   redeemablePositions={redeemablePositions}
                   openOrders={openOrders}
                   cancellingOrderId={cancellingOrderId}
+                  polygonAddress={poly.polygonAddress}
                   onScopeChange={setPickScope}
                   onCashOut={(position) => router.push({
                     pathname: '/predict-position/[conditionId]',
@@ -453,6 +466,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
                   })}
                   onBackMore={backMorePosition}
                   onCancelOrder={(orderId) => void handleCancelOrder(orderId)}
+                  onRedeemed={() => void loadPicks()}
                 />
               ) : activeView === 'stats' ? (
                 <View style={styles.statsView}>
@@ -512,10 +526,51 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
               </Pressable>
             </View>
 
-            {successMessage && (
-              <View style={styles.successBanner}>
-                <MaterialIcons name="check-circle" size={14} color={tokens.colors.viridian} />
-                <Text style={styles.successText}>{successMessage}</Text>
+            {livePick && (
+              <View style={styles.successPanel}>
+                <View style={styles.successPanelTop}>
+                  <MaterialIcons name="check-circle" size={16} color={tokens.colors.viridian} />
+                  <View style={styles.successPanelCopy}>
+                    <Text style={styles.successTitle}>Your pick is live</Text>
+                    <Text style={styles.successSub}>{livePick.label} at {Math.round(livePick.price * 100)}%</Text>
+                  </View>
+                </View>
+                <View style={styles.successStats}>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Put in</Text>
+                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
+                  </View>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Worth now</Text>
+                    <Text style={styles.successStatValue}>${livePick.amount.toFixed(2)}</Text>
+                  </View>
+                  <View style={styles.successStat}>
+                    <Text style={styles.successStatLabel}>Possible win</Text>
+                    <Text style={styles.successStatValue}>${(livePick.amount / livePick.price).toFixed(2)}</Text>
+                  </View>
+                </View>
+                <View style={styles.successActions}>
+                  <Pressable style={styles.successPrimaryAction} onPress={() => {
+                    setActiveView('picks');
+                    setPickScope('market');
+                    void loadPicks();
+                  }}>
+                    <Text style={styles.successPrimaryActionText}>View My Picks</Text>
+                  </Pressable>
+                  <Pressable style={styles.successSecondaryAction} onPress={() => {
+                    setActiveView('picks');
+                    setPickScope('market');
+                    void loadPicks();
+                  }}>
+                    <Text style={styles.successSecondaryActionText}>Cash Out</Text>
+                  </Pressable>
+                  <Pressable style={styles.successSecondaryAction} onPress={() => {
+                    const index = sortedOutcomes.findIndex((outcome) => sportOutcomeLabel(outcome) === livePick.label);
+                    tapOdd(index >= 0 ? index : 0);
+                  }}>
+                    <Text style={styles.successSecondaryActionText}>Add More</Text>
+                  </Pressable>
+                </View>
               </View>
             )}
 
@@ -867,6 +922,96 @@ const styles = StyleSheet.create({
     fontSize: 9,
     lineHeight: 13,
     color: semantic.text.primary,
+  },
+  successPanel: {
+    marginHorizontal: 20,
+    marginTop: 10,
+    padding: 12,
+    borderRadius: 14,
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.24)',
+    gap: 10,
+  },
+  successPanelTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  successPanelCopy: {
+    flex: 1,
+  },
+  successTitle: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  successSub: {
+    marginTop: 2,
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.dim,
+    textTransform: 'uppercase',
+  },
+  successStats: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  successStat: {
+    flex: 1,
+    borderRadius: 10,
+    backgroundColor: 'rgba(0,0,0,0.12)',
+    padding: 8,
+  },
+  successStatLabel: {
+    fontFamily: 'monospace',
+    fontSize: 7,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  successStatValue: {
+    marginTop: 2,
+    fontFamily: 'monospace',
+    fontSize: 10,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  successActions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  successPrimaryAction: {
+    flex: 1.3,
+    minHeight: 34,
+    borderRadius: 9,
+    backgroundColor: tokens.colors.viridian,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  successPrimaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '800',
+    color: tokens.colors.backgroundDark,
+    textTransform: 'uppercase',
+  },
+  successSecondaryAction: {
+    flex: 1,
+    minHeight: 34,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 7,
+  },
+  successSecondaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '800',
+    color: semantic.text.primary,
+    textTransform: 'uppercase',
   },
 
   // ── Selection rows ──

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -13,7 +13,8 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { fetchSportMarketDetail, fetchPriceHistory, fetchOrderbook, placeBet } from '@/features/predict/predict.api';
+import { cancelOrder, fetchMarketPositions, fetchOpenOrders, fetchOrderbook, fetchPortfolio, fetchPriceHistory, fetchSportMarketDetail, placeBet } from '@/features/predict/predict.api';
+import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import type { PredictSport, PricePoint, SportMarketDetail, SportOutcomeDetail, Orderbook } from '@/features/predict/predict.types';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { semantic, tokens } from '@/theme';
@@ -24,6 +25,7 @@ import { MultiLineChart } from '@/features/predict/components/MultiLineChart';
 import { OrderbookView } from '@/features/predict/components/OrderbookView';
 import { StatsStrip } from '@/features/predict/components/StatsStrip';
 import { InlineNumpad } from '@/features/predict/components/InlineNumpad';
+import { DetailPicksPanel } from '@/features/predict/components/DetailPicksPanel';
 
 interface PredictSportDetailScreenProps {
   sport: PredictSport;
@@ -45,6 +47,11 @@ function sportOutcomeLabel(outcome: SportOutcomeDetail): string {
   return outcome.label.toLowerCase().includes('draw') ? 'Draw' : outcome.label;
 }
 
+function formatPositionOutcome(outcome: string | null | undefined): string {
+  if (!outcome) return '';
+  return outcome.toLowerCase().includes('draw') ? 'Draw' : outcome;
+}
+
 function DisplayTab({
   label,
   active,
@@ -59,6 +66,17 @@ function DisplayTab({
       <Text style={[styles.displayTabText, active && styles.displayTabTextActive]}>{label}</Text>
     </Pressable>
   );
+}
+
+function marketHrefForSlug(rowSlug: string): string | { pathname: '/predict-sport/[sport]/[slug]'; params: { sport: string; slug: string } } {
+  const sportMatch = rowSlug.match(/^cric(epl|ucl|ipl)-/);
+  if (sportMatch) {
+    return {
+      pathname: '/predict-sport/[sport]/[slug]',
+      params: { sport: sportMatch[1], slug: rowSlug },
+    };
+  }
+  return `/predict-market/${encodeURIComponent(rowSlug)}`;
 }
 
 export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScreenProps) {
@@ -88,6 +106,13 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   const [numpadAmount, setNumpadAmount] = useState('50');
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [pickScope, setPickScope] = useState<'market' | 'all'>('market');
+  const [marketPositions, setMarketPositions] = useState<PortfolioPosition[]>([]);
+  const [allPositions, setAllPositions] = useState<PortfolioPosition[]>([]);
+  const [redeemablePositions, setRedeemablePositions] = useState<PortfolioPosition[]>([]);
+  const [openOrders, setOpenOrders] = useState<OpenOrder[]>([]);
+  const [picksLoading, setPicksLoading] = useState(false);
+  const [cancellingOrderId, setCancellingOrderId] = useState<string | null>(null);
 
   // Soft zone animation
   const softZoneAnim = useRef(new Animated.Value(SOFT_COLLAPSED)).current;
@@ -162,6 +187,44 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
     }
   }
 
+  async function loadPicks() {
+    const gammaAddr = poly.tradingAddress ?? poly.polygonAddress;
+    if (!gammaAddr) {
+      setMarketPositions([]);
+      setAllPositions([]);
+      setRedeemablePositions([]);
+      setOpenOrders([]);
+      return;
+    }
+    setPicksLoading(true);
+    try {
+      const [market, portfolio, orders] = await Promise.all([
+        fetchMarketPositions(gammaAddr, slug).catch(() => []),
+        fetchPortfolio(gammaAddr).catch(() => null),
+        poly.polygonAddress ? fetchOpenOrders(poly.polygonAddress).catch(() => []) : Promise.resolve([]),
+      ]);
+      setMarketPositions(market);
+      setAllPositions(portfolio?.positions ?? []);
+      setRedeemablePositions(portfolio?.redeemablePositions ?? []);
+      setOpenOrders(orders);
+    } finally {
+      setPicksLoading(false);
+    }
+  }
+
+  async function handleCancelOrder(orderId: string) {
+    if (!poly.polygonAddress || cancellingOrderId) return;
+    setCancellingOrderId(orderId);
+    try {
+      const result = await cancelOrder(poly.polygonAddress, orderId);
+      if (result.ok) {
+        setOpenOrders((prev) => prev.filter((order) => order.id !== orderId));
+      }
+    } finally {
+      setCancellingOrderId(null);
+    }
+  }
+
   useEffect(() => { void loadDetail(); }, [slug, sport]);
 
   useEffect(() => {
@@ -171,6 +234,10 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
   useEffect(() => {
     if (activeView === 'orderbook' && sortedOutcomes.length > 0) void loadOrderbook(obOutcomeIdx);
   }, [activeView, detail, obOutcomeIdx]);
+
+  useEffect(() => {
+    if (activeView === 'picks') void loadPicks();
+  }, [activeView, slug, poly.polygonAddress, poly.tradingAddress]);
 
   // LIVE pulse
   useEffect(() => {
@@ -214,6 +281,22 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
     setSelectedOutcomeIdx(outcomeIdx);
     setNumpadAmount('50');
     setNumpadOpen(true);
+  }
+
+  function backMorePosition(position: PortfolioPosition) {
+    if (position.slug && position.slug !== slug) {
+      router.push(marketHrefForSlug(position.slug));
+      return;
+    }
+    const byOutcome = sortedOutcomes.findIndex((outcome) =>
+      sportOutcomeLabel(outcome).toLowerCase() === formatPositionOutcome(position.outcome).toLowerCase()
+    );
+    if (byOutcome >= 0) {
+      tapOdd(byOutcome);
+      return;
+    }
+    const byIndex = sortedOutcomes.findIndex((outcome) => outcome.conditionId === position.conditionId);
+    tapOdd(byIndex >= 0 ? byIndex : 0);
   }
 
   function collapseNumpad() {
@@ -351,16 +434,26 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
             {/* Chart or Orderbook */}
             <View style={styles.viewContainer}>
               {activeView === 'picks' ? (
-                <View style={styles.picksView}>
-                  <View style={styles.picksHeading}>
-                    <Text style={styles.picksTitle}>Your Picks</Text>
-                    <Text style={styles.picksSubtitle}>This match</Text>
-                  </View>
-                  <View style={styles.picksEmptyCard}>
-                    <Text style={styles.picksEmptyTitle}>No picks here yet</Text>
-                    <Text style={styles.picksEmptyText}>Back Liverpool, Draw, or Crystal Palace below. Live picks show cash out, back more, or collect actions here.</Text>
-                  </View>
-                </View>
+                <DetailPicksPanel
+                  scope={pickScope}
+                  loading={picksLoading}
+                  marketPositions={marketPositions}
+                  allPositions={allPositions}
+                  redeemablePositions={redeemablePositions}
+                  openOrders={openOrders}
+                  cancellingOrderId={cancellingOrderId}
+                  onScopeChange={setPickScope}
+                  onCashOut={(position) => router.push({
+                    pathname: '/predict-position/[conditionId]',
+                    params: {
+                      conditionId: position.conditionId,
+                      slug: position.slug,
+                      outcomeIndex: String(position.outcomeIndex),
+                    },
+                  })}
+                  onBackMore={backMorePosition}
+                  onCancelOrder={(orderId) => void handleCancelOrder(orderId)}
+                />
               ) : activeView === 'stats' ? (
                 <View style={styles.statsView}>
                   <View style={styles.picksHeading}>

--- a/apps/hybrid-expo/features/predict/components/CashOutConfirmModal.tsx
+++ b/apps/hybrid-expo/features/predict/components/CashOutConfirmModal.tsx
@@ -1,0 +1,157 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { PortfolioPosition } from '@/features/predict/predict.api';
+import { portfolioPositionCost, truncateSignedUsd, truncateUsd } from '@/features/predict/formatPredictMoney';
+import { semantic, tokens } from '@/theme';
+
+interface CashOutConfirmModalProps {
+  position: PortfolioPosition | null;
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function CashOutConfirmModal({ position, visible, onClose }: CashOutConfirmModalProps) {
+  const cashOutValue = position?.currentValue ?? 0;
+  const pnl = position ? cashOutValue - portfolioPositionCost(position) : 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.card}>
+          <Text style={styles.eyebrow}>Cash out</Text>
+          <Text style={styles.title}>Are you sure?</Text>
+          <Text style={styles.copy}>
+            You are cashing out {position?.outcome || 'this pick'}.
+          </Text>
+          <View style={styles.amountRow}>
+            <Text style={styles.amountLabel}>You will get</Text>
+            <Text style={styles.amountValue}>{truncateUsd(cashOutValue)}</Text>
+          </View>
+          <View style={styles.amountRow}>
+            <Text style={styles.amountLabel}>P/L</Text>
+            <Text style={[styles.amountValue, pnl > 0 ? styles.pnlPositive : pnl < 0 ? styles.pnlNegative : styles.pnlFlat]}>
+              {truncateSignedUsd(pnl)}
+            </Text>
+          </View>
+          <View style={styles.actions}>
+            <Pressable style={styles.secondaryAction} onPress={onClose}>
+              <Text style={styles.secondaryActionText}>Not now</Text>
+            </Pressable>
+            <Pressable style={styles.primaryAction} onPress={onClose}>
+              <Text style={styles.primaryActionText}>Cash out</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.62)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 22,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 340,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: tokens.colors.ground,
+    padding: 18,
+  },
+  eyebrow: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+    color: semantic.text.faint,
+  },
+  title: {
+    marginTop: 6,
+    fontSize: 20,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  copy: {
+    marginTop: 6,
+    fontSize: 12,
+    lineHeight: 17,
+    color: semantic.text.dim,
+  },
+  amountRow: {
+    marginTop: 12,
+    minHeight: 42,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  amountLabel: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  amountValue: {
+    fontFamily: 'monospace',
+    fontSize: 14,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  pnlPositive: {
+    color: tokens.colors.viridian,
+  },
+  pnlNegative: {
+    color: tokens.colors.vermillion,
+  },
+  pnlFlat: {
+    color: semantic.text.faint,
+  },
+  actions: {
+    marginTop: 16,
+    flexDirection: 'row',
+    gap: 8,
+  },
+  secondaryAction: {
+    flex: 1,
+    minHeight: 42,
+    borderRadius: 11,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '800',
+    color: semantic.text.dim,
+    textTransform: 'uppercase',
+  },
+  primaryAction: {
+    flex: 1,
+    minHeight: 42,
+    borderRadius: 11,
+    backgroundColor: tokens.colors.viridian,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '800',
+    color: tokens.colors.backgroundDark,
+    textTransform: 'uppercase',
+  },
+});

--- a/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
+++ b/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
@@ -7,6 +7,7 @@ type DetailPickScope = 'market' | 'all';
 
 interface DetailPicksPanelProps {
   scope: DetailPickScope;
+  marketSlug: string;
   loading: boolean;
   marketPositions: PortfolioPosition[];
   allPositions: PortfolioPosition[];
@@ -37,8 +38,30 @@ function pickId(prefix: string, position: PortfolioPosition, index: number): str
   return `${prefix}-${position.conditionId}-${position.outcomeIndex}-${index}`;
 }
 
+function orderCost(order: OpenOrder): number {
+  const size = Number.parseFloat(order.original_size) || 0;
+  const price = Number.parseFloat(order.price) || 0;
+  return size * price;
+}
+
+function positionCost(position: PortfolioPosition): number {
+  return (position.avgPrice ?? 0) * (position.size ?? 0);
+}
+
+function isSameMarket(position: PortfolioPosition, marketSlug: string): boolean {
+  return position.slug === marketSlug || position.eventSlug === marketSlug;
+}
+
+function isMarketOrder(order: OpenOrder, marketSlug: string): boolean {
+  const market = order.market?.toLowerCase() ?? '';
+  const slug = marketSlug.toLowerCase();
+  if (!market) return false;
+  return market.includes(slug) || slug.includes(market);
+}
+
 export function DetailPicksPanel({
   scope,
+  marketSlug,
   loading,
   marketPositions,
   allPositions,
@@ -50,8 +73,14 @@ export function DetailPicksPanel({
   onCashOut,
   onCancelOrder,
 }: DetailPicksPanelProps) {
+  const marketRedeemables = redeemablePositions.filter((position) => isSameMarket(position, marketSlug));
+  const marketOrders = openOrders.filter((order) => isMarketOrder(order, marketSlug));
   const rows = scope === 'market'
-    ? marketPositions.map((position, index) => ({ kind: 'position' as const, id: pickId('market', position, index), position }))
+    ? [
+        ...marketPositions.map((position, index) => ({ kind: 'position' as const, id: pickId('market', position, index), position })),
+        ...marketOrders.map((order) => ({ kind: 'order' as const, id: `market-order-${order.id}`, order })),
+        ...marketRedeemables.map((position, index) => ({ kind: 'redeemable' as const, id: pickId('market-ready', position, index), position })),
+      ]
     : [
         ...redeemablePositions.map((position, index) => ({ kind: 'redeemable' as const, id: pickId('ready', position, index), position })),
         ...allPositions.map((position, index) => ({ kind: 'position' as const, id: pickId('all', position, index), position })),
@@ -60,6 +89,10 @@ export function DetailPicksPanel({
   const worthNow = rows.reduce((sum, row) => {
     if (row.kind === 'order') return sum;
     return sum + (row.position.currentValue ?? 0);
+  }, 0);
+  const putIn = rows.reduce((sum, row) => {
+    if (row.kind === 'order') return sum + orderCost(row.order);
+    return sum + positionCost(row.position);
   }, 0);
 
   return (
@@ -84,8 +117,8 @@ export function DetailPicksPanel({
 
       <View style={styles.summary}>
         <View>
-          <Text style={styles.summaryLabel}>{scope === 'market' ? 'Picks here' : 'Active picks'}</Text>
-          <Text style={styles.summaryValue}>{rows.length}</Text>
+          <Text style={styles.summaryLabel}>{scope === 'market' ? 'You put in' : 'Active picks'}</Text>
+          <Text style={styles.summaryValue}>{scope === 'market' ? formatUsd(putIn) : rows.length}</Text>
         </View>
         <View>
           <Text style={styles.summaryLabel}>Worth now</Text>

--- a/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
+++ b/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
@@ -1,6 +1,8 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
+import { redeemPosition } from '@/features/predict/predict.api';
 import { semantic, tokens } from '@/theme';
 
 type DetailPickScope = 'market' | 'all';
@@ -14,10 +16,12 @@ interface DetailPicksPanelProps {
   redeemablePositions: PortfolioPosition[];
   openOrders: OpenOrder[];
   cancellingOrderId?: string | null;
+  polygonAddress?: string | null;
   onScopeChange: (scope: DetailPickScope) => void;
   onBackMore: (position: PortfolioPosition) => void;
   onCashOut: (position: PortfolioPosition) => void;
   onCancelOrder?: (orderId: string) => void;
+  onRedeemed?: () => void;
 }
 
 function formatUsd(value: number): string {
@@ -68,10 +72,12 @@ export function DetailPicksPanel({
   redeemablePositions,
   openOrders,
   cancellingOrderId,
+  polygonAddress,
   onScopeChange,
   onBackMore,
   onCashOut,
   onCancelOrder,
+  onRedeemed,
 }: DetailPicksPanelProps) {
   const marketRedeemables = redeemablePositions.filter((position) => isSameMarket(position, marketSlug));
   const marketOrders = openOrders.filter((order) => isMarketOrder(order, marketSlug));
@@ -101,7 +107,7 @@ export function DetailPicksPanel({
         <Text style={styles.title}>Your Picks</Text>
         <View style={styles.headingSide}>
           <Text style={styles.subtitle}>
-            {scope === 'market' ? `${marketPositions.length} here` : `${rows.length} total`}
+            {scope === 'market' ? `${rows.length} here` : `${rows.length} total`}
           </Text>
           <Pressable
             style={[styles.scopeSwitch, scope === 'all' && styles.scopeSwitchActive]}
@@ -147,7 +153,14 @@ export function DetailPicksPanel({
           );
         }
         if (row.kind === 'redeemable') {
-          return <RedeemableRow key={row.id} position={row.position} />;
+          return (
+            <RedeemableRow
+              key={row.id}
+              position={row.position}
+              polygonAddress={polygonAddress}
+              onRedeemed={onRedeemed}
+            />
+          );
         }
         return (
           <PositionRow
@@ -224,7 +237,35 @@ function OrderRow({
   );
 }
 
-function RedeemableRow({ position }: { position: PortfolioPosition }) {
+function RedeemableRow({
+  position,
+  polygonAddress,
+  onRedeemed,
+}: {
+  position: PortfolioPosition;
+  polygonAddress?: string | null;
+  onRedeemed?: () => void;
+}) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  async function handleRedeem() {
+    if (!polygonAddress || status === 'loading' || status === 'success') return;
+    setStatus('loading');
+    try {
+      const result = await redeemPosition(polygonAddress, {
+        conditionId: position.conditionId,
+        asset: position.asset,
+        outcomeIndex: position.outcomeIndex,
+        negativeRisk: position.negativeRisk,
+      });
+      if (!result.ok) throw new Error(result.error || 'Redeem failed');
+      setStatus('success');
+      onRedeemed?.();
+    } catch {
+      setStatus('error');
+    }
+  }
+
   return (
     <View style={[styles.rowCard, styles.readyCard]}>
       <View style={styles.rowMain}>
@@ -232,10 +273,22 @@ function RedeemableRow({ position }: { position: PortfolioPosition }) {
           <Text style={styles.rowTitle}>{formatOutcome(position.outcome)} <Text style={styles.winText}>won</Text></Text>
           <Text style={styles.rowMeta} numberOfLines={1}>{position.title || position.slug} · ready to collect</Text>
         </View>
-        <View style={styles.redeemAction}>
-          <MaterialIcons name="redeem" size={12} color={tokens.colors.viridian} />
-          <Text style={styles.redeemActionText}>Redeem {formatUsd(position.currentValue ?? 0)}</Text>
-        </View>
+        <Pressable
+          style={[styles.redeemAction, status === 'error' && styles.redeemActionError]}
+          disabled={!polygonAddress || status === 'loading' || status === 'success'}
+          onPress={handleRedeem}
+        >
+          {status === 'loading' ? (
+            <ActivityIndicator size="small" color={tokens.colors.viridian} />
+          ) : (
+            <>
+              <MaterialIcons name={status === 'success' ? 'check' : 'redeem'} size={12} color={tokens.colors.viridian} />
+              <Text style={styles.redeemActionText}>
+                {status === 'success' ? 'Redeemed' : status === 'error' ? 'Try again' : `Redeem ${formatUsd(position.currentValue ?? 0)}`}
+              </Text>
+            </>
+          )}
+        </Pressable>
       </View>
     </View>
   );
@@ -448,6 +501,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: 5,
     paddingHorizontal: 8,
+  },
+  redeemActionError: {
+    borderWidth: 1,
+    borderColor: 'rgba(244,88,78,0.30)',
+    backgroundColor: 'rgba(244,88,78,0.10)',
   },
   redeemActionText: {
     fontFamily: 'monospace',

--- a/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
+++ b/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import { redeemPosition } from '@/features/predict/predict.api';
+import { portfolioPositionCost } from '@/features/predict/formatPredictMoney';
+import { PredictPositionRow } from '@/features/predict/components/PredictPositionRow';
 import { semantic, tokens } from '@/theme';
 
 type DetailPickScope = 'market' | 'all';
@@ -49,7 +51,7 @@ function orderCost(order: OpenOrder): number {
 }
 
 function positionCost(position: PortfolioPosition): number {
-  return (position.avgPrice ?? 0) * (position.size ?? 0);
+  return portfolioPositionCost(position);
 }
 
 function isSameMarket(position: PortfolioPosition, marketSlug: string): boolean {
@@ -163,46 +165,15 @@ export function DetailPicksPanel({
           );
         }
         return (
-          <PositionRow
+          <PredictPositionRow
             key={row.id}
             position={row.position}
+            showMarketTitle={scope === 'all'}
             onCashOut={() => onCashOut(row.position)}
             onBackMore={() => onBackMore(row.position)}
           />
         );
       })}
-    </View>
-  );
-}
-
-function PositionRow({
-  position,
-  onCashOut,
-  onBackMore,
-}: {
-  position: PortfolioPosition;
-  onCashOut: () => void;
-  onBackMore: () => void;
-}) {
-  const outcome = formatOutcome(position.outcome);
-  return (
-    <View style={[styles.rowCard, position.outcome === 'No' ? styles.noCard : styles.liveCard]}>
-      <View style={styles.rowMain}>
-        <View style={styles.rowCopy}>
-          <Text style={styles.rowTitle}>{outcome} <Text style={styles.rowNow}>{formatChance(position.curPrice)} now</Text></Text>
-          <Text style={styles.rowMeta} numberOfLines={1}>
-            {position.title || position.slug} · avg entry {formatChance(position.avgPrice)}
-          </Text>
-        </View>
-        <View style={styles.rowActions}>
-          <Pressable style={styles.cashAction} onPress={onCashOut}>
-            <Text style={styles.cashActionText}>{formatUsd(position.currentValue ?? 0)} cash out now</Text>
-          </Pressable>
-          <Pressable style={styles.backAction} onPress={onBackMore}>
-            <Text style={styles.backActionText}>Back more</Text>
-          </Pressable>
-        </View>
-      </View>
     </View>
   );
 }
@@ -219,7 +190,7 @@ function OrderRow({
   const price = Number.parseFloat(order.price) || 0;
   const outcome = formatOutcome(order.outcome);
   return (
-    <View style={[styles.rowCard, styles.waitingCard]}>
+    <View style={[styles.rowCard, styles.waitingCard, styles.limitStrip]}>
       <View style={styles.rowMain}>
         <View style={styles.rowCopy}>
           <Text style={styles.rowTitle}>{formatChance(price)} on {outcome}</Text>
@@ -267,11 +238,11 @@ function RedeemableRow({
   }
 
   return (
-    <View style={[styles.rowCard, styles.readyCard]}>
+    <View style={[styles.rowCard, styles.readyCard, styles.readyStrip]}>
       <View style={styles.rowMain}>
         <View style={styles.rowCopy}>
           <Text style={styles.rowTitle}>{formatOutcome(position.outcome)} <Text style={styles.winText}>won</Text></Text>
-          <Text style={styles.rowMeta} numberOfLines={1}>{position.title || position.slug} · ready to collect</Text>
+          <Text style={styles.rowMeta} numberOfLines={1}>Ready to collect</Text>
         </View>
         <Pressable
           style={[styles.redeemAction, status === 'error' && styles.redeemActionError]}
@@ -396,25 +367,32 @@ const styles = StyleSheet.create({
   },
   rowCard: {
     borderWidth: 1,
+    borderLeftWidth: 3,
     borderRadius: 12,
-    padding: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
     marginBottom: 7,
   },
-  liveCard: {
-    borderColor: 'rgba(74,140,111,0.22)',
-    backgroundColor: 'rgba(74,140,111,0.07)',
+  activeCard: {
+    borderColor: 'rgba(74,140,111,0.24)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
   },
-  noCard: {
-    borderColor: 'rgba(244,88,78,0.22)',
-    backgroundColor: 'rgba(244,88,78,0.07)',
+  activeStrip: {
+    borderLeftColor: tokens.colors.viridian,
   },
   waitingCard: {
     borderColor: 'rgba(232,197,71,0.25)',
     backgroundColor: 'rgba(232,197,71,0.08)',
   },
+  limitStrip: {
+    borderLeftColor: tokens.colors.primary,
+  },
   readyCard: {
     borderColor: 'rgba(74,140,111,0.28)',
     backgroundColor: 'rgba(74,140,111,0.10)',
+  },
+  readyStrip: {
+    borderLeftColor: tokens.colors.viridian,
   },
   rowMain: {
     flexDirection: 'row',
@@ -426,21 +404,32 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
   rowTitle: {
-    fontSize: 13,
+    fontSize: 17,
     fontWeight: '800',
     color: semantic.text.primary,
-  },
-  rowNow: {
-    color: tokens.colors.viridian,
-    fontSize: 11,
   },
   winText: {
     color: tokens.colors.viridian,
   },
   rowMeta: {
-    marginTop: 3,
+    marginTop: 4,
     fontFamily: 'monospace',
-    fontSize: 8,
+    fontSize: 11,
+    color: semantic.text.dim,
+  },
+  rowPnl: {
+    marginTop: 4,
+    fontFamily: 'monospace',
+    fontSize: 11,
+    fontWeight: '800',
+  },
+  pnlPositive: {
+    color: tokens.colors.viridian,
+  },
+  pnlNegative: {
+    color: tokens.colors.vermillion,
+  },
+  pnlFlat: {
     color: semantic.text.faint,
   },
   rowActions: {
@@ -451,29 +440,50 @@ const styles = StyleSheet.create({
     minHeight: 32,
     borderRadius: 9,
     borderWidth: 1,
-    borderColor: 'rgba(232,197,71,0.28)',
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 5,
   },
+  cashActionPositive: {
+    borderColor: 'rgba(74,140,111,0.34)',
+    backgroundColor: 'rgba(74,140,111,0.12)',
+  },
+  cashActionNegative: {
+    borderColor: 'rgba(244,88,78,0.30)',
+    backgroundColor: 'rgba(244,88,78,0.10)',
+  },
+  cashActionFlat: {
+    borderColor: semantic.border.muted,
+    backgroundColor: 'rgba(255,255,255,0.035)',
+  },
   cashActionText: {
     fontFamily: 'monospace',
     fontSize: 7.5,
-    color: tokens.colors.primary,
     fontWeight: '800',
     textAlign: 'center',
+  },
+  cashActionTextPositive: {
+    color: tokens.colors.viridian,
+  },
+  cashActionTextNegative: {
+    color: tokens.colors.vermillion,
+  },
+  cashActionTextFlat: {
+    color: semantic.text.dim,
   },
   backAction: {
     minHeight: 30,
     borderRadius: 9,
-    backgroundColor: 'rgba(74,140,111,0.12)',
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: 'rgba(255,255,255,0.025)',
     alignItems: 'center',
     justifyContent: 'center',
   },
   backActionText: {
     fontFamily: 'monospace',
     fontSize: 8,
-    color: tokens.colors.viridian,
+    color: semantic.text.dim,
     fontWeight: '800',
   },
   cancelAction: {

--- a/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
+++ b/apps/hybrid-expo/features/predict/components/DetailPicksPanel.tsx
@@ -1,0 +1,425 @@
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
+import { semantic, tokens } from '@/theme';
+
+type DetailPickScope = 'market' | 'all';
+
+interface DetailPicksPanelProps {
+  scope: DetailPickScope;
+  loading: boolean;
+  marketPositions: PortfolioPosition[];
+  allPositions: PortfolioPosition[];
+  redeemablePositions: PortfolioPosition[];
+  openOrders: OpenOrder[];
+  cancellingOrderId?: string | null;
+  onScopeChange: (scope: DetailPickScope) => void;
+  onBackMore: (position: PortfolioPosition) => void;
+  onCashOut: (position: PortfolioPosition) => void;
+  onCancelOrder?: (orderId: string) => void;
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatChance(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '--';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatOutcome(label: string | null | undefined): string {
+  if (!label) return 'Yes';
+  return label.toLowerCase().includes('draw') ? 'Draw' : label;
+}
+
+function pickId(prefix: string, position: PortfolioPosition, index: number): string {
+  return `${prefix}-${position.conditionId}-${position.outcomeIndex}-${index}`;
+}
+
+export function DetailPicksPanel({
+  scope,
+  loading,
+  marketPositions,
+  allPositions,
+  redeemablePositions,
+  openOrders,
+  cancellingOrderId,
+  onScopeChange,
+  onBackMore,
+  onCashOut,
+  onCancelOrder,
+}: DetailPicksPanelProps) {
+  const rows = scope === 'market'
+    ? marketPositions.map((position, index) => ({ kind: 'position' as const, id: pickId('market', position, index), position }))
+    : [
+        ...redeemablePositions.map((position, index) => ({ kind: 'redeemable' as const, id: pickId('ready', position, index), position })),
+        ...allPositions.map((position, index) => ({ kind: 'position' as const, id: pickId('all', position, index), position })),
+        ...openOrders.map((order) => ({ kind: 'order' as const, id: `order-${order.id}`, order })),
+      ];
+  const worthNow = rows.reduce((sum, row) => {
+    if (row.kind === 'order') return sum;
+    return sum + (row.position.currentValue ?? 0);
+  }, 0);
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.heading}>
+        <Text style={styles.title}>Your Picks</Text>
+        <View style={styles.headingSide}>
+          <Text style={styles.subtitle}>
+            {scope === 'market' ? `${marketPositions.length} here` : `${rows.length} total`}
+          </Text>
+          <Pressable
+            style={[styles.scopeSwitch, scope === 'all' && styles.scopeSwitchActive]}
+            onPress={() => onScopeChange(scope === 'market' ? 'all' : 'market')}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: scope === 'all' }}
+          >
+            <View style={styles.scopeKnob} />
+            <Text style={styles.scopeText}>{scope === 'market' ? 'All' : 'This'}</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.summary}>
+        <View>
+          <Text style={styles.summaryLabel}>{scope === 'market' ? 'Picks here' : 'Active picks'}</Text>
+          <Text style={styles.summaryValue}>{rows.length}</Text>
+        </View>
+        <View>
+          <Text style={styles.summaryLabel}>Worth now</Text>
+          <Text style={styles.summaryValue}>{formatUsd(worthNow)}</Text>
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={styles.empty}>
+          <ActivityIndicator color={tokens.colors.primary} size="small" />
+        </View>
+      ) : rows.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyTitle}>No picks here yet</Text>
+          <Text style={styles.emptyText}>Make a pick below. Once it is active, cash out and back-more actions show here.</Text>
+        </View>
+      ) : rows.map((row) => {
+        if (row.kind === 'order') {
+          return (
+            <OrderRow
+              key={row.id}
+              order={row.order}
+              cancelling={cancellingOrderId === row.order.id}
+              onCancel={onCancelOrder ? () => onCancelOrder(row.order.id) : undefined}
+            />
+          );
+        }
+        if (row.kind === 'redeemable') {
+          return <RedeemableRow key={row.id} position={row.position} />;
+        }
+        return (
+          <PositionRow
+            key={row.id}
+            position={row.position}
+            onCashOut={() => onCashOut(row.position)}
+            onBackMore={() => onBackMore(row.position)}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+function PositionRow({
+  position,
+  onCashOut,
+  onBackMore,
+}: {
+  position: PortfolioPosition;
+  onCashOut: () => void;
+  onBackMore: () => void;
+}) {
+  const outcome = formatOutcome(position.outcome);
+  return (
+    <View style={[styles.rowCard, position.outcome === 'No' ? styles.noCard : styles.liveCard]}>
+      <View style={styles.rowMain}>
+        <View style={styles.rowCopy}>
+          <Text style={styles.rowTitle}>{outcome} <Text style={styles.rowNow}>{formatChance(position.curPrice)} now</Text></Text>
+          <Text style={styles.rowMeta} numberOfLines={1}>
+            {position.title || position.slug} · avg entry {formatChance(position.avgPrice)}
+          </Text>
+        </View>
+        <View style={styles.rowActions}>
+          <Pressable style={styles.cashAction} onPress={onCashOut}>
+            <Text style={styles.cashActionText}>{formatUsd(position.currentValue ?? 0)} cash out now</Text>
+          </Pressable>
+          <Pressable style={styles.backAction} onPress={onBackMore}>
+            <Text style={styles.backActionText}>Back more</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function OrderRow({
+  order,
+  cancelling,
+  onCancel,
+}: {
+  order: OpenOrder;
+  cancelling: boolean;
+  onCancel?: () => void;
+}) {
+  const price = Number.parseFloat(order.price) || 0;
+  const outcome = formatOutcome(order.outcome);
+  return (
+    <View style={[styles.rowCard, styles.waitingCard]}>
+      <View style={styles.rowMain}>
+        <View style={styles.rowCopy}>
+          <Text style={styles.rowTitle}>{formatChance(price)} on {outcome}</Text>
+          <Text style={styles.rowMeta}>Yet to be placed</Text>
+        </View>
+        <Pressable style={styles.cancelAction} disabled={!onCancel || cancelling} onPress={onCancel}>
+          {cancelling ? (
+            <ActivityIndicator size="small" color={semantic.sentiment.negative} />
+          ) : (
+            <Text style={styles.cancelActionText}>Cancel</Text>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function RedeemableRow({ position }: { position: PortfolioPosition }) {
+  return (
+    <View style={[styles.rowCard, styles.readyCard]}>
+      <View style={styles.rowMain}>
+        <View style={styles.rowCopy}>
+          <Text style={styles.rowTitle}>{formatOutcome(position.outcome)} <Text style={styles.winText}>won</Text></Text>
+          <Text style={styles.rowMeta} numberOfLines={1}>{position.title || position.slug} · ready to collect</Text>
+        </View>
+        <View style={styles.redeemAction}>
+          <MaterialIcons name="redeem" size={12} color={tokens.colors.viridian} />
+          <Text style={styles.redeemActionText}>Redeem {formatUsd(position.currentValue ?? 0)}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  heading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  title: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: 'uppercase',
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  headingSide: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  subtitle: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  scopeSwitch: {
+    minHeight: 26,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 7,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: semantic.background.lift,
+  },
+  scopeSwitchActive: {
+    borderColor: 'rgba(232,197,71,0.45)',
+  },
+  scopeKnob: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+    backgroundColor: tokens.colors.accent,
+  },
+  scopeText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.primary,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+  },
+  summary: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 8,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 10,
+  },
+  summaryLabel: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 1,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  summaryValue: {
+    marginTop: 2,
+    fontFamily: 'monospace',
+    fontSize: 15,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  empty: {
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    borderRadius: 12,
+    padding: 14,
+  },
+  emptyTitle: {
+    color: semantic.text.primary,
+    fontSize: 12,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  emptyText: {
+    color: semantic.text.dim,
+    fontSize: 10,
+    lineHeight: 15,
+  },
+  rowCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 10,
+    marginBottom: 7,
+  },
+  liveCard: {
+    borderColor: 'rgba(74,140,111,0.22)',
+    backgroundColor: 'rgba(74,140,111,0.07)',
+  },
+  noCard: {
+    borderColor: 'rgba(244,88,78,0.22)',
+    backgroundColor: 'rgba(244,88,78,0.07)',
+  },
+  waitingCard: {
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: 'rgba(232,197,71,0.08)',
+  },
+  readyCard: {
+    borderColor: 'rgba(74,140,111,0.28)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
+  },
+  rowMain: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  rowCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowTitle: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  rowNow: {
+    color: tokens.colors.viridian,
+    fontSize: 11,
+  },
+  winText: {
+    color: tokens.colors.viridian,
+  },
+  rowMeta: {
+    marginTop: 3,
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+  },
+  rowActions: {
+    width: 112,
+    gap: 6,
+  },
+  cashAction: {
+    minHeight: 32,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.28)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 5,
+  },
+  cashActionText: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: tokens.colors.primary,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  backAction: {
+    minHeight: 30,
+    borderRadius: 9,
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: tokens.colors.viridian,
+    fontWeight: '800',
+  },
+  cancelAction: {
+    minHeight: 34,
+    minWidth: 86,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: 'rgba(244,88,78,0.30)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.sentiment.negative,
+    fontWeight: '800',
+  },
+  redeemAction: {
+    minHeight: 36,
+    minWidth: 102,
+    borderRadius: 10,
+    backgroundColor: 'rgba(74,140,111,0.22)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 5,
+    paddingHorizontal: 8,
+  },
+  redeemActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: tokens.colors.viridian,
+    fontWeight: '800',
+  },
+});

--- a/apps/hybrid-expo/features/predict/components/InlineNumpad.tsx
+++ b/apps/hybrid-expo/features/predict/components/InlineNumpad.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+import { truncateUsd } from '@/features/predict/formatPredictMoney';
 import { semantic, tokens } from '@/theme';
 
 interface InlineNumpadProps {
@@ -13,6 +14,8 @@ interface InlineNumpadProps {
   confirmLabel?: string;
   /** Override for the payout helper label */
   payoutLabel?: string;
+  /** Available cash for the Max quick action. */
+  availableCash?: number | null;
   onAmountChange: (amount: string) => void;
   onConfirm: () => void;
   /** Whether an order is currently being submitted */
@@ -21,7 +24,13 @@ interface InlineNumpadProps {
   disabled?: boolean;
 }
 
-const QUICK_AMOUNTS = ['10', '25', '50', '100'];
+const QUICK_AMOUNTS = ['10', '25', '50'] as const;
+
+function formatAmountInput(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0';
+  const truncated = Math.trunc(value * 100) / 100;
+  return truncated.toFixed(2).replace(/\.00$/u, '').replace(/(\.\d)0$/u, '$1');
+}
 
 function numpadKey(current: string, key: string): string {
   if (key === '.' && current.includes('.')) return current;
@@ -45,6 +54,7 @@ export function InlineNumpad({
   pickLabel,
   confirmLabel,
   payoutLabel = 'You could receive',
+  availableCash,
   onAmountChange,
   onConfirm,
   submitting = false,
@@ -61,10 +71,13 @@ export function InlineNumpad({
   }, [visible, heightAnim]);
 
   const amountNum = parseFloat(amount) || 0;
+  const hasCashLimit = availableCash !== null && availableCash !== undefined && Number.isFinite(availableCash);
+  const exceedsCash = hasCashLimit && amountNum > (availableCash ?? 0) + 0.000001;
   const payout = price > 0 ? amountNum / price : 0;
   const outcomeLabel = pickLabel ?? (side === 'yes' ? 'YES' : 'NO');
   const isYes = side === 'yes';
   const backLabel = confirmLabel ?? `Back ${outcomeLabel} with $${amountNum.toFixed(amountNum % 1 === 0 ? 0 : 2)}`;
+  const confirmDisabled = disabled || submitting || amountNum <= 0 || exceedsCash;
 
   return (
     <Animated.View style={[styles.container, { maxHeight: heightAnim }]}>
@@ -82,6 +95,12 @@ export function InlineNumpad({
               <Text style={styles.quickBtnText}>${q}</Text>
             </Pressable>
           ))}
+          <Pressable
+            style={styles.quickBtn}
+            onPress={() => onAmountChange(formatAmountInput(availableCash ?? 0))}
+          >
+            <Text style={styles.quickBtnText}>Max</Text>
+          </Pressable>
         </View>
 
         {/* Numpad grid */}
@@ -107,17 +126,21 @@ export function InlineNumpad({
           <Text style={styles.payoutValue}>${payout.toFixed(2)}</Text>
         </View>
         <View style={styles.downsideRow}>
-          <Text style={styles.downsideLabel}>If you are wrong, you lose</Text>
-          <Text style={styles.downsideValue}>${amountNum.toFixed(2)}</Text>
+          <Text style={[styles.downsideLabel, exceedsCash && styles.errorText]}>
+            {exceedsCash ? 'Not enough cash' : 'If you are wrong, you lose'}
+          </Text>
+          <Text style={[styles.downsideValue, exceedsCash && styles.errorText]}>
+            {exceedsCash ? `Cash ${truncateUsd(availableCash)}` : `$${amountNum.toFixed(2)}`}
+          </Text>
         </View>
 
         {/* Confirm button */}
         <Pressable
-          style={[styles.confirmBtn, isYes ? styles.confirmYes : styles.confirmNo, (disabled || submitting || amountNum <= 0) && styles.confirmDisabled]}
-          disabled={disabled || submitting || amountNum <= 0}
+          style={[styles.confirmBtn, isYes ? styles.confirmYes : styles.confirmNo, confirmDisabled && styles.confirmDisabled]}
+          disabled={confirmDisabled}
           onPress={onConfirm}>
           <Text style={styles.confirmText}>
-            {submitting ? 'Placing order\u2026' : backLabel}
+            {submitting ? 'Placing order\u2026' : exceedsCash ? 'Not enough cash' : backLabel}
           </Text>
         </Pressable>
       </View>
@@ -232,6 +255,9 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '700',
     color: semantic.text.dim,
+  },
+  errorText: {
+    color: tokens.colors.vermillion,
   },
   confirmBtn: {
     height: 44,

--- a/apps/hybrid-expo/features/predict/components/InlineNumpad.tsx
+++ b/apps/hybrid-expo/features/predict/components/InlineNumpad.tsx
@@ -7,6 +7,12 @@ interface InlineNumpadProps {
   side: 'yes' | 'no';
   price: number;
   amount: string;
+  /** Label for the selected outcome, e.g. YES, NO, or a team name */
+  pickLabel?: string;
+  /** Override for the confirm button label */
+  confirmLabel?: string;
+  /** Override for the payout helper label */
+  payoutLabel?: string;
   onAmountChange: (amount: string) => void;
   onConfirm: () => void;
   /** Whether an order is currently being submitted */
@@ -31,7 +37,19 @@ function numpadDel(current: string): string {
   return current.slice(0, -1);
 }
 
-export function InlineNumpad({ visible, side, price, amount, onAmountChange, onConfirm, submitting = false, disabled = false }: InlineNumpadProps) {
+export function InlineNumpad({
+  visible,
+  side,
+  price,
+  amount,
+  pickLabel,
+  confirmLabel,
+  payoutLabel = 'You could receive',
+  onAmountChange,
+  onConfirm,
+  submitting = false,
+  disabled = false,
+}: InlineNumpadProps) {
   const heightAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -44,8 +62,9 @@ export function InlineNumpad({ visible, side, price, amount, onAmountChange, onC
 
   const amountNum = parseFloat(amount) || 0;
   const payout = price > 0 ? amountNum / price : 0;
-  const sideLabel = side === 'yes' ? 'Yes' : 'No';
+  const outcomeLabel = pickLabel ?? (side === 'yes' ? 'YES' : 'NO');
   const isYes = side === 'yes';
+  const backLabel = confirmLabel ?? `Back ${outcomeLabel} with $${amountNum.toFixed(amountNum % 1 === 0 ? 0 : 2)}`;
 
   return (
     <Animated.View style={[styles.container, { maxHeight: heightAnim }]}>
@@ -84,8 +103,12 @@ export function InlineNumpad({ visible, side, price, amount, onAmountChange, onC
 
         {/* Payout row */}
         <View style={styles.payoutRow}>
-          <Text style={styles.payoutLabel}>Potential payout</Text>
+          <Text style={styles.payoutLabel}>{payoutLabel}</Text>
           <Text style={styles.payoutValue}>${payout.toFixed(2)}</Text>
+        </View>
+        <View style={styles.downsideRow}>
+          <Text style={styles.downsideLabel}>If you are wrong, you lose</Text>
+          <Text style={styles.downsideValue}>${amountNum.toFixed(2)}</Text>
         </View>
 
         {/* Confirm button */}
@@ -94,7 +117,7 @@ export function InlineNumpad({ visible, side, price, amount, onAmountChange, onC
           disabled={disabled || submitting || amountNum <= 0}
           onPress={onConfirm}>
           <Text style={styles.confirmText}>
-            {submitting ? 'Placing order\u2026' : `Confirm ${sideLabel} \u2014 $${amountNum}`}
+            {submitting ? 'Placing order\u2026' : backLabel}
           </Text>
         </Pressable>
       </View>
@@ -191,6 +214,24 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '700',
     color: semantic.sentiment.positive,
+  },
+  downsideRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingBottom: 2,
+  },
+  downsideLabel: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 0.5,
+    color: semantic.text.faint,
+  },
+  downsideValue: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: '700',
+    color: semantic.text.dim,
   },
   confirmBtn: {
     height: 44,

--- a/apps/hybrid-expo/features/predict/components/OrderbookView.tsx
+++ b/apps/hybrid-expo/features/predict/components/OrderbookView.tsx
@@ -7,8 +7,8 @@ interface OrderbookViewProps {
   loading: boolean;
 }
 
-function formatCents(price: number): string {
-  return `${(price * 100).toFixed(1)}\u00A2`;
+function formatProbability(price: number): string {
+  return `${Math.round(price * 100)}%`;
 }
 
 function formatShares(size: number): string {
@@ -66,7 +66,7 @@ export function OrderbookView({ book, loading }: OrderbookViewProps) {
         return (
           <View key={`ask-${i}`} style={styles.row}>
             <View style={[styles.depthBar, styles.depthAsk, { width: `${depthPct}%` }]} />
-            <Text style={[styles.price, styles.askPrice]}>{formatCents(level.price)}</Text>
+            <Text style={[styles.price, styles.askPrice]}>{formatProbability(level.price)}</Text>
             <Text style={[styles.shares]}>{formatShares(level.size)}</Text>
             <Text style={[styles.total]}>{formatTotal(runningAskTotal)}</Text>
           </View>
@@ -76,10 +76,10 @@ export function OrderbookView({ book, loading }: OrderbookViewProps) {
       {/* Spread */}
       <View style={styles.spreadRow}>
         <Text style={styles.spreadLabel}>
-          Last: {book.lastPrice !== null ? formatCents(book.lastPrice) : '--'}
+          Last: {book.lastPrice !== null ? formatProbability(book.lastPrice) : '--'}
         </Text>
         <Text style={styles.spreadVal}>
-          Spread: {book.spread !== null ? formatCents(book.spread) : '--'}
+          Spread: {book.spread !== null ? formatProbability(book.spread) : '--'}
         </Text>
       </View>
 
@@ -90,7 +90,7 @@ export function OrderbookView({ book, loading }: OrderbookViewProps) {
         return (
           <View key={`bid-${i}`} style={styles.row}>
             <View style={[styles.depthBar, styles.depthBid, { width: `${depthPct}%` }]} />
-            <Text style={[styles.price, styles.bidPrice]}>{formatCents(level.price)}</Text>
+            <Text style={[styles.price, styles.bidPrice]}>{formatProbability(level.price)}</Text>
             <Text style={[styles.shares]}>{formatShares(level.size)}</Text>
             <Text style={[styles.total]}>{formatTotal(runningBidTotal)}</Text>
           </View>

--- a/apps/hybrid-expo/features/predict/components/PredictPositionRow.tsx
+++ b/apps/hybrid-expo/features/predict/components/PredictPositionRow.tsx
@@ -1,0 +1,183 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { PortfolioPosition } from '@/features/predict/predict.api';
+import { formatPredictTitle } from '@/features/predict/formatPredictTitle';
+import { portfolioPositionCost, truncateSignedUsd, truncateUsd } from '@/features/predict/formatPredictMoney';
+import { semantic, tokens } from '@/theme';
+
+interface PredictPositionRowProps {
+  position: PortfolioPosition;
+  showMarketTitle?: boolean;
+  onCashOut: () => void;
+  onBackMore: () => void;
+}
+
+function formatChance(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '--';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatOutcome(label: string | null | undefined): string {
+  if (!label) return 'Yes';
+  return label.toLowerCase().includes('draw') ? 'Draw' : label;
+}
+
+function formatPositionTitle(position: PortfolioPosition): string {
+  return formatPredictTitle({
+    title: position.title,
+    slug: position.slug || position.eventSlug,
+  });
+}
+
+export function PredictPositionRow({
+  position,
+  showMarketTitle = true,
+  onCashOut,
+  onBackMore,
+}: PredictPositionRowProps) {
+  const outcome = formatOutcome(position.outcome);
+  const priceLine = `${formatChance(position.avgPrice)} entry -> ${formatChance(position.curPrice)} now`;
+  const cost = portfolioPositionCost(position);
+  const pnl = (position.currentValue ?? 0) - cost;
+  const pnlState = pnl > 0.005 ? 'positive' : pnl < -0.005 ? 'negative' : 'flat';
+  const pnlStyle = pnlState === 'positive' ? styles.pnlPositive : pnlState === 'negative' ? styles.pnlNegative : styles.pnlFlat;
+
+  return (
+    <View style={[styles.rowCard, styles.activeCard, styles.activeStrip]}>
+      <View style={styles.rowMain}>
+        <View style={styles.rowCopy}>
+          <Text style={styles.rowTitle}>{outcome}</Text>
+          <Text style={styles.rowMeta} numberOfLines={1}>
+            {showMarketTitle ? `${formatPositionTitle(position)} · ${priceLine}` : priceLine}
+          </Text>
+          <Text style={[styles.rowPnl, pnlStyle]}>{truncateSignedUsd(pnl)}</Text>
+        </View>
+        <View style={styles.rowActions}>
+          <Pressable
+            style={[
+              styles.cashAction,
+              pnlState === 'positive' ? styles.cashActionPositive : pnlState === 'negative' ? styles.cashActionNegative : styles.cashActionFlat,
+            ]}
+            onPress={onCashOut}
+          >
+            <Text style={[
+              styles.cashActionText,
+              pnlState === 'positive' ? styles.cashActionTextPositive : pnlState === 'negative' ? styles.cashActionTextNegative : styles.cashActionTextFlat,
+            ]}>
+              {truncateUsd(position.currentValue ?? 0)} cash out now
+            </Text>
+          </Pressable>
+          <Pressable style={styles.backAction} onPress={onBackMore}>
+            <Text style={styles.backActionText}>Back more</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  rowCard: {
+    borderWidth: 1,
+    borderLeftWidth: 3,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 7,
+  },
+  activeCard: {
+    borderColor: 'rgba(74,140,111,0.24)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
+  },
+  activeStrip: {
+    borderLeftColor: tokens.colors.viridian,
+  },
+  rowMain: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  rowCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowTitle: {
+    fontSize: 17,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  rowMeta: {
+    marginTop: 4,
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: semantic.text.dim,
+  },
+  rowPnl: {
+    marginTop: 4,
+    fontFamily: 'monospace',
+    fontSize: 11,
+    fontWeight: '800',
+  },
+  pnlPositive: {
+    color: tokens.colors.viridian,
+  },
+  pnlNegative: {
+    color: tokens.colors.vermillion,
+  },
+  pnlFlat: {
+    color: semantic.text.faint,
+  },
+  rowActions: {
+    width: 112,
+    gap: 6,
+  },
+  cashAction: {
+    minHeight: 32,
+    borderRadius: 9,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 5,
+  },
+  cashActionPositive: {
+    borderColor: 'rgba(74,140,111,0.34)',
+    backgroundColor: 'rgba(74,140,111,0.12)',
+  },
+  cashActionNegative: {
+    borderColor: 'rgba(244,88,78,0.30)',
+    backgroundColor: 'rgba(244,88,78,0.10)',
+  },
+  cashActionFlat: {
+    borderColor: semantic.border.muted,
+    backgroundColor: 'rgba(255,255,255,0.035)',
+  },
+  cashActionText: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  cashActionTextPositive: {
+    color: tokens.colors.viridian,
+  },
+  cashActionTextNegative: {
+    color: tokens.colors.vermillion,
+  },
+  cashActionTextFlat: {
+    color: semantic.text.dim,
+  },
+  backAction: {
+    minHeight: 30,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.dim,
+    fontWeight: '800',
+  },
+});

--- a/apps/hybrid-expo/features/predict/formatPredictMoney.ts
+++ b/apps/hybrid-expo/features/predict/formatPredictMoney.ts
@@ -1,0 +1,16 @@
+export function truncateUsd(value: number | null | undefined, decimals = 2): string {
+  if (value == null || !Number.isFinite(value)) return '--';
+  const factor = 10 ** decimals;
+  const sign = value < 0 ? '-' : '';
+  const truncated = Math.trunc(Math.abs(value) * factor) / factor;
+  return `${sign}$${truncated.toFixed(decimals)}`;
+}
+
+export function truncateSignedUsd(value: number | null | undefined, decimals = 2): string {
+  if (value == null || !Number.isFinite(value) || Math.abs(value) < 1 / 10 ** decimals) return '$0.00';
+  return `${value > 0 ? '+' : '-'}${truncateUsd(Math.abs(value), decimals)}`;
+}
+
+export function portfolioPositionCost(position: { avgPrice?: number | null; size?: number | null }): number {
+  return (position.avgPrice ?? 0) * (position.size ?? 0);
+}

--- a/apps/hybrid-expo/features/predict/formatPredictTitle.ts
+++ b/apps/hybrid-expo/features/predict/formatPredictTitle.ts
@@ -1,0 +1,34 @@
+export function teamInitials(label: string | null | undefined): string | null {
+  if (!label) return null;
+  const words = label.match(/[A-Za-z0-9]+/g) ?? [];
+  if (words.length === 0) return null;
+  if (words.length === 1) return words[0].slice(0, 3).toUpperCase();
+  return words.map((word) => word[0]).join('').toUpperCase();
+}
+
+export function formatIplTitleFromOutcomes(labels: Array<string | null | undefined>): string | null {
+  if (labels.length < 2) return null;
+  const left = teamInitials(labels[0]);
+  const right = teamInitials(labels[1]);
+  return left && right ? `${left} VS ${right}` : null;
+}
+
+export function formatPredictTitle({
+  title,
+  slug,
+  outcomes = [],
+}: {
+  title: string | null | undefined;
+  slug?: string | null;
+  outcomes?: Array<string | null | undefined>;
+}): string {
+  const isIpl = slug?.startsWith('cricipl-') || /^Indian Premier League:/i.test(title ?? '');
+  if (!isIpl) return title || slug || '--';
+
+  const outcomeTitle = formatIplTitleFromOutcomes(outcomes);
+  if (outcomeTitle) return outcomeTitle;
+
+  const cleanTitle = (title || '').replace(/^Indian Premier League:\s*/i, '').trim();
+  const parts = cleanTitle.split(/\s+v(?:s\.?|ersus)?\s+/i);
+  return formatIplTitleFromOutcomes([parts[0], parts[1]]) || cleanTitle || slug || '--';
+}

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -559,6 +559,7 @@ export interface PortfolioData {
   positions: PortfolioPosition[];
   redeemablePositions: PortfolioPosition[];
   closedPositions: ClosedPortfolioPosition[];
+  activity: ActivityItem[];
   profile: {
     name: string | null;
     bio: string | null;
@@ -568,6 +569,13 @@ export interface PortfolioData {
   summary: {
     openPositions: number;
     totalPnl: number;
+    cashOutNow?: number;
+    readyToCollect?: number;
+    activePickCount?: number;
+    closedPickCount?: number;
+    activityCount?: number;
+    hasActivity?: boolean;
+    hasAnyPicks?: boolean;
     totalCollected?: number;
   };
 }
@@ -584,6 +592,7 @@ export async function fetchPortfolio(polygonAddress: string): Promise<PortfolioD
       ? (p.redeemablePositions as PortfolioPosition[]).filter((position) => (position.currentValue ?? 0) >= 0.01)
       : [],
     closedPositions: Array.isArray(p.closedPositions) ? (p.closedPositions as ClosedPortfolioPosition[]) : [],
+    activity: Array.isArray(p.activity) ? (p.activity as ActivityItem[]) : [],
     profile: p.profile as PortfolioData['profile'] ?? null,
     summary: (p.summary as PortfolioData['summary']) ?? { openPositions: 0, totalPnl: 0, totalCollected: 0 },
   };

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -683,7 +683,7 @@ export async function redeemPosition(
   };
 }
 
-export async function fetchPriceHistory(tokenId: string, interval: '1h' | '1d' = '1h'): Promise<PriceHistory> {
+export async function fetchPriceHistory(tokenId: string, interval: '5m' | '1h' | '1d' = '1h'): Promise<PriceHistory> {
   const payload = await getJson(`/predict/history/${encodeURIComponent(tokenId)}?interval=${interval}`);
   if (!payload || typeof payload !== 'object') throw new Error('Invalid history response');
   const p = payload as Record<string, unknown>;

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -533,11 +533,32 @@ export interface PortfolioPosition {
   negativeRisk: boolean;
 }
 
+export interface ClosedPortfolioPosition {
+  proxyWallet: string;
+  asset: string;
+  conditionId: string;
+  avgPrice: number;
+  totalBought: number;
+  realizedPnl: number;
+  curPrice: number;
+  timestamp: number;
+  title: string;
+  slug: string;
+  icon: string | null;
+  eventSlug: string;
+  outcome: string;
+  outcomeIndex: number;
+  oppositeOutcome: string;
+  oppositeAsset: string;
+  endDate: string | null;
+}
+
 export interface PortfolioData {
   address: string;
   portfolioValue: number | null;
   positions: PortfolioPosition[];
   redeemablePositions: PortfolioPosition[];
+  closedPositions: ClosedPortfolioPosition[];
   profile: {
     name: string | null;
     bio: string | null;
@@ -547,6 +568,7 @@ export interface PortfolioData {
   summary: {
     openPositions: number;
     totalPnl: number;
+    totalCollected?: number;
   };
 }
 
@@ -561,8 +583,9 @@ export async function fetchPortfolio(polygonAddress: string): Promise<PortfolioD
     redeemablePositions: Array.isArray(p.redeemablePositions)
       ? (p.redeemablePositions as PortfolioPosition[]).filter((position) => (position.currentValue ?? 0) >= 0.01)
       : [],
+    closedPositions: Array.isArray(p.closedPositions) ? (p.closedPositions as ClosedPortfolioPosition[]) : [],
     profile: p.profile as PortfolioData['profile'] ?? null,
-    summary: (p.summary as PortfolioData['summary']) ?? { openPositions: 0, totalPnl: 0 },
+    summary: (p.summary as PortfolioData['summary']) ?? { openPositions: 0, totalPnl: 0, totalCollected: 0 },
   };
 }
 

--- a/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
+++ b/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
@@ -13,14 +13,38 @@ import type { TrendingMarket } from '@/features/predict/predict.types';
 import { semantic, tokens } from '@/theme';
 
 interface EmptyPortfolioProps {
-  onDeposit: () => void;
-  hasBalance: boolean;
+  mode: 'no-account' | 'no-balance' | 'no-picks';
+  onPrimaryAction: () => void;
+  primaryLabel: string;
 }
 
-export function EmptyPortfolio({ onDeposit, hasBalance }: EmptyPortfolioProps) {
+const EMPTY_COPY: Record<EmptyPortfolioProps['mode'], {
+  icon: keyof typeof MaterialIcons.glyphMap;
+  title: string;
+  description: string;
+}> = {
+  'no-account': {
+    icon: 'account-balance-wallet',
+    title: 'Set up your Predict account',
+    description: 'Sign in once to create the trading account for your picks, payouts, and open orders.',
+  },
+  'no-balance': {
+    icon: 'add-card',
+    title: 'Add funds for your first pick',
+    description: 'Deposit USDC, then back a market. Your live picks and waiting orders will appear here.',
+  },
+  'no-picks': {
+    icon: 'touch-app',
+    title: 'Make your first pick',
+    description: 'Choose a market below. Once you buy shares, this page will track what is live, waiting, or ready to redeem.',
+  },
+};
+
+export function EmptyPortfolio({ mode, onPrimaryAction, primaryLabel }: EmptyPortfolioProps) {
   const router = useRouter();
   const [trending, setTrending] = useState<TrendingMarket[]>([]);
   const [loading, setLoading] = useState(true);
+  const copy = EMPTY_COPY[mode];
 
   useEffect(() => {
     fetchTrendingMarkets(5)
@@ -33,21 +57,13 @@ export function EmptyPortfolio({ onDeposit, hasBalance }: EmptyPortfolioProps) {
     <View style={styles.container}>
       {/* CTA */}
       <View style={styles.ctaCard}>
-        <MaterialIcons name="rocket-launch" size={20} color={tokens.colors.primary} />
-        <Text style={styles.ctaTitle}>
-          {hasBalance ? 'Ready to trade' : 'Fund your account'}
-        </Text>
-        <Text style={styles.ctaDesc}>
-          {hasBalance
-            ? 'Pick a market below and place your first prediction'
-            : 'Deposit USDC to start trading on prediction markets'}
-        </Text>
-        {!hasBalance && (
-          <Pressable style={styles.ctaBtn} onPress={onDeposit}>
-            <MaterialIcons name="arrow-downward" size={12} color={tokens.colors.backgroundDark} />
-            <Text style={styles.ctaBtnText}>Deposit</Text>
-          </Pressable>
-        )}
+        <MaterialIcons name={copy.icon} size={20} color={tokens.colors.primary} />
+        <Text style={styles.ctaTitle}>{copy.title}</Text>
+        <Text style={styles.ctaDesc}>{copy.description}</Text>
+        <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
+          <MaterialIcons name={mode === 'no-balance' ? 'arrow-downward' : 'arrow-forward'} size={12} color={tokens.colors.backgroundDark} />
+          <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
+        </Pressable>
       </View>
 
       {/* Trending markets */}

--- a/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
+++ b/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
@@ -45,6 +45,7 @@ export function EmptyPortfolio({ mode, onPrimaryAction, primaryLabel }: EmptyPor
   const [trending, setTrending] = useState<TrendingMarket[]>([]);
   const [loading, setLoading] = useState(true);
   const copy = EMPTY_COPY[mode];
+  const signedOut = mode === 'no-account' && primaryLabel.toLowerCase().includes('sign');
 
   useEffect(() => {
     fetchTrendingMarkets(5)
@@ -60,17 +61,25 @@ export function EmptyPortfolio({ mode, onPrimaryAction, primaryLabel }: EmptyPor
           <View style={styles.onboardIcon}>
             <MaterialIcons name={copy.icon} size={24} color={tokens.colors.viridian} />
           </View>
-          <Text style={styles.onboardTitle}>{copy.title}</Text>
-          <Text style={styles.onboardSubtitle}>{copy.description}</Text>
+          <Text style={styles.onboardTitle}>
+            {signedOut ? 'Sign in to use Predict' : copy.title}
+          </Text>
+          <Text style={styles.onboardSubtitle}>
+            {signedOut
+              ? 'Connect your wallet to set up Predict, make picks, and collect winnings in one place.'
+              : copy.description}
+          </Text>
         </View>
 
         <View style={styles.ctaPad}>
           <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
             <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
           </Pressable>
-          <Text style={styles.reassurance}>
-            Signs a message to prepare your Predict account.{'\n'}No transaction. No gas. Reversible anytime.
-          </Text>
+          {!signedOut && (
+            <Text style={styles.reassurance}>
+              Signs a message to prepare your Predict account.{'\n'}No transaction. No gas. Reversible anytime.
+            </Text>
+          )}
         </View>
       </View>
     );

--- a/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
+++ b/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
@@ -24,19 +24,19 @@ const EMPTY_COPY: Record<EmptyPortfolioProps['mode'], {
   description: string;
 }> = {
   'no-account': {
-    icon: 'account-balance-wallet',
-    title: 'Set up your Predict account',
-    description: 'Sign in once to set up the account that keeps your picks, payouts, and waiting picks together.',
+    icon: 'check-circle',
+    title: 'Wallet connected.\nOne more step.',
+    description: 'Create your prediction account to start making picks. One signature, no transaction, no gas, no cost.',
   },
   'no-balance': {
     icon: 'add-card',
-    title: 'Add funds for your first pick',
-    description: 'Deposit USDC, then back a market. Your live picks and waiting picks will appear here.',
+    title: 'Deposit USDC to make your first pick',
+    description: 'Send USDC on Polygon. Funds show up here when ready.',
   },
   'no-picks': {
     icon: 'touch-app',
-    title: 'Make your first pick',
-    description: 'Choose a market below. This page will show what is live, waiting, or ready to collect.',
+    title: 'No picks yet',
+    description: 'Your cash is ready. Pick an outcome and it will show up here with its status and next action.',
   },
 };
 
@@ -53,22 +53,63 @@ export function EmptyPortfolio({ mode, onPrimaryAction, primaryLabel }: EmptyPor
       .finally(() => setLoading(false));
   }, []);
 
+  if (mode === 'no-account') {
+    return (
+      <View style={styles.container}>
+        <View style={styles.onboardHero}>
+          <View style={styles.onboardIcon}>
+            <MaterialIcons name={copy.icon} size={24} color={tokens.colors.viridian} />
+          </View>
+          <Text style={styles.onboardTitle}>{copy.title}</Text>
+          <Text style={styles.onboardSubtitle}>{copy.description}</Text>
+        </View>
+
+        <View style={styles.ctaPad}>
+          <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
+            <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
+          </Pressable>
+          <Text style={styles.reassurance}>
+            Signs a message to prepare your Predict account.{'\n'}No transaction. No gas. Reversible anytime.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      {/* CTA */}
-      <View style={styles.ctaCard}>
-        <MaterialIcons name={copy.icon} size={20} color={tokens.colors.primary} />
-        <Text style={styles.ctaTitle}>{copy.title}</Text>
-        <Text style={styles.ctaDesc}>{copy.description}</Text>
-        <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
-          <MaterialIcons name={mode === 'no-balance' ? 'arrow-downward' : 'arrow-forward'} size={12} color={tokens.colors.backgroundDark} />
-          <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
-        </Pressable>
-      </View>
+      {mode === 'no-balance' ? (
+        <View style={styles.depositPrompt}>
+          <Text style={styles.eyebrow}>Get started</Text>
+          <Text style={styles.promptTitle}>{copy.title}</Text>
+          <Text style={styles.promptCopy}>{copy.description}</Text>
+          <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
+            <MaterialIcons name="arrow-downward" size={12} color={tokens.colors.backgroundDark} />
+            <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <View style={styles.sectionWrap}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Your Picks</Text>
+            <Text style={styles.sectionCount}>none yet</Text>
+          </View>
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyStateTitle}>{copy.title}</Text>
+            <Text style={styles.emptyStateCopy}>{copy.description}</Text>
+            <Pressable style={styles.ctaBtn} onPress={onPrimaryAction}>
+              <Text style={styles.ctaBtnText}>{primaryLabel}</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
 
       {/* Trending markets */}
-      <View style={styles.trendingSection}>
-        <Text style={styles.trendingTitle}>TRENDING MARKETS</Text>
+      <View style={styles.sectionWrap}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>{mode === 'no-picks' ? 'Markets to watch' : 'Trending Markets'}</Text>
+          <Text style={styles.sectionCount}>{mode === 'no-picks' ? 'popular now' : 'explore'}</Text>
+        </View>
         {loading ? (
           <ActivityIndicator size="small" color={semantic.text.faint} style={{ paddingVertical: 20 }} />
         ) : trending.length === 0 ? (
@@ -87,17 +128,20 @@ export function EmptyPortfolio({ mode, onPrimaryAction, primaryLabel }: EmptyPor
                   <Text style={styles.marketQuestion} numberOfLines={2}>
                     {m.question}
                   </Text>
+                  <View style={styles.oddsBar}>
+                    <View style={[styles.oddsSegment, styles.yesSegment, { flex: Math.max(yesPrice, 0.01) }]}>
+                      <Text style={styles.oddsText}>Yes {Math.round(yesPrice * 100)}%</Text>
+                    </View>
+                    <View style={[styles.oddsSegment, styles.noSegment, { flex: Math.max(1 - yesPrice, 0.01) }]}>
+                      <Text style={styles.oddsText}>No {Math.round((1 - yesPrice) * 100)}%</Text>
+                    </View>
+                  </View>
                   {m.volume24h != null && m.volume24h > 0 && (
                     <Text style={styles.marketVol}>
                       ${m.volume24h >= 1000 ? `${(m.volume24h / 1000).toFixed(0)}K` : m.volume24h.toFixed(0)} vol
                     </Text>
                   )}
                 </View>
-                <View style={styles.marketPrice}>
-                  <Text style={styles.marketPriceVal}>{Math.round(yesPrice * 100)}{'\u00A2'}</Text>
-                  <Text style={styles.marketPriceLabel}>YES</Text>
-                </View>
-                <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
               </Pressable>
             );
           })
@@ -112,30 +156,77 @@ const styles = StyleSheet.create({
     gap: 16,
   },
 
-  // CTA card
-  ctaCard: {
-    backgroundColor: semantic.background.surface,
-    borderWidth: 1,
-    borderColor: semantic.border.muted,
-    borderRadius: 10,
-    padding: 20,
+  onboardHero: {
+    paddingTop: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 12,
     alignItems: 'center',
     gap: 8,
   },
-  ctaTitle: {
-    fontFamily: 'monospace',
-    fontSize: 12,
+  onboardIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.22)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 4,
+  },
+  onboardTitle: {
+    fontSize: 18,
     fontWeight: '700',
     color: semantic.text.primary,
-    letterSpacing: 0.3,
+    textAlign: 'center',
+    lineHeight: 24,
   },
-  ctaDesc: {
+  onboardSubtitle: {
     fontFamily: 'monospace',
     fontSize: 9,
     color: semantic.text.dim,
     textAlign: 'center',
-    lineHeight: 14,
-    letterSpacing: 0.2,
+    lineHeight: 15,
+    maxWidth: 280,
+  },
+  ctaPad: {
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    gap: 6,
+  },
+  reassurance: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+    textAlign: 'center',
+    lineHeight: 12,
+  },
+  depositPrompt: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    gap: 8,
+  },
+  eyebrow: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: semantic.text.dim,
+  },
+  promptTitle: {
+    fontSize: 12,
+    color: semantic.text.primary,
+    lineHeight: 18,
+    textAlign: 'center',
+  },
+  promptCopy: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textAlign: 'center',
+    lineHeight: 13,
+    marginBottom: 6,
   },
   ctaBtn: {
     flexDirection: 'row',
@@ -157,16 +248,47 @@ const styles = StyleSheet.create({
     color: tokens.colors.backgroundDark,
   },
 
-  // Trending
-  trendingSection: {
-    gap: 6,
+  sectionWrap: {
+    gap: 8,
   },
-  trendingTitle: {
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  sectionCount: {
     fontFamily: 'monospace',
     fontSize: 7.5,
-    letterSpacing: 2,
-    color: semantic.text.dim,
-    marginBottom: 2,
+    color: semantic.text.faint,
+  },
+  emptyState: {
+    backgroundColor: semantic.background.surface,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 8,
+    padding: 18,
+    alignItems: 'center',
+    gap: 8,
+  },
+  emptyStateTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: semantic.text.primary,
+  },
+  emptyStateCopy: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textAlign: 'center',
+    lineHeight: 13,
   },
   trendingEmpty: {
     fontFamily: 'monospace',
@@ -176,19 +298,16 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   marketRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
     backgroundColor: semantic.background.surface,
     borderWidth: 1,
     borderColor: semantic.border.muted,
     borderRadius: 8,
-    padding: 10,
-    minHeight: 48,
+    padding: 12,
+    minHeight: 72,
+    gap: 8,
   },
   marketInfo: {
-    flex: 1,
-    gap: 3,
+    gap: 7,
   },
   marketQuestion: {
     fontSize: 10,
@@ -200,21 +319,28 @@ const styles = StyleSheet.create({
     fontSize: 7.5,
     color: semantic.text.faint,
   },
-  marketPrice: {
+  oddsBar: {
+    flexDirection: 'row',
+    minHeight: 24,
+    borderRadius: 6,
+    overflow: 'hidden',
+    gap: 2,
+  },
+  oddsSegment: {
     alignItems: 'center',
-    gap: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 4,
   },
-  marketPriceVal: {
+  yesSegment: {
+    backgroundColor: 'rgba(74,140,111,0.22)',
+  },
+  noSegment: {
+    backgroundColor: 'rgba(244,88,78,0.16)',
+  },
+  oddsText: {
     fontFamily: 'monospace',
-    fontSize: 13,
+    fontSize: 8,
     fontWeight: '700',
-    color: tokens.colors.viridian,
-  },
-  marketPriceLabel: {
-    fontFamily: 'monospace',
-    fontSize: 6.5,
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-    color: 'rgba(74,140,111,0.55)',
+    color: semantic.text.primary,
   },
 });

--- a/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
+++ b/apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx
@@ -26,17 +26,17 @@ const EMPTY_COPY: Record<EmptyPortfolioProps['mode'], {
   'no-account': {
     icon: 'account-balance-wallet',
     title: 'Set up your Predict account',
-    description: 'Sign in once to create the trading account for your picks, payouts, and open orders.',
+    description: 'Sign in once to set up the account that keeps your picks, payouts, and waiting picks together.',
   },
   'no-balance': {
     icon: 'add-card',
     title: 'Add funds for your first pick',
-    description: 'Deposit USDC, then back a market. Your live picks and waiting orders will appear here.',
+    description: 'Deposit USDC, then back a market. Your live picks and waiting picks will appear here.',
   },
   'no-picks': {
     icon: 'touch-app',
     title: 'Make your first pick',
-    description: 'Choose a market below. Once you buy shares, this page will track what is live, waiting, or ready to redeem.',
+    description: 'Choose a market below. This page will show what is live, waiting, or ready to collect.',
   },
 };
 

--- a/apps/hybrid-expo/features/predict/profile/PositionDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/profile/PositionDetailScreen.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { fetchMarketPositions, fetchActivity, placeBet } from '@/features/predict/predict.api';
 import type { ActivityItem, PortfolioPosition } from '@/features/predict/predict.api';
+import { formatPredictTitle } from '@/features/predict/formatPredictTitle';
 import { useOddsFormat } from '@/hooks/useOddsFormat';
 import { usePolymarketWallet } from '@/hooks/usePolymarketWallet';
 import { semantic, tokens } from '@/theme';
@@ -201,7 +202,9 @@ export function PositionDetailScreen({ conditionId, slug, outcomeIndex }: Positi
               {position.outcome?.toUpperCase() ?? 'YES'}
             </Text>
           </View>
-          <Text style={styles.marketTitle}>{position.title}</Text>
+          <Text style={styles.marketTitle}>
+            {formatPredictTitle({ title: position.title, slug: position.slug || position.eventSlug })}
+          </Text>
           {position.endDate && (
             <Text style={styles.endDate}>
               Ends {new Date(position.endDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}

--- a/apps/hybrid-expo/features/predict/profile/RedeemableSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/RedeemableSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { PortfolioPosition } from '@/features/predict/predict.api';
 import { redeemPosition } from '@/features/predict/predict.api';
+import { formatPredictTitle } from '@/features/predict/formatPredictTitle';
 import { semantic, tokens } from '@/theme';
 
 interface RedeemableSectionProps {
@@ -82,7 +83,9 @@ function RedeemRow({
         </Text>
       </View>
       <View style={styles.info}>
-        <Text style={styles.rowTitle} numberOfLines={1}>{p.title || p.slug}</Text>
+        <Text style={styles.rowTitle} numberOfLines={1}>
+          {formatPredictTitle({ title: p.title, slug: p.slug || p.eventSlug })}
+        </Text>
         <Text style={styles.rowShares}>{p.size.toFixed(2)} shares</Text>
       </View>
       <Pressable

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -103,13 +103,19 @@ export function YourPicksSection({
   onRedeemed,
 }: YourPicksSectionProps) {
   const [scope, setScope] = useState<'active' | 'all'>('active');
-  const picks = getYourPicks(positions, openOrders, redeemablePositions, closedPositions, scope);
+  const hasActiveRows = positions.length + openOrders.length + redeemablePositions.length > 0;
+  const effectiveScope = hasActiveRows ? scope : 'all';
+  const picks = getYourPicks(positions, openOrders, redeemablePositions, closedPositions, effectiveScope);
   const allCount = positions.length + openOrders.length + redeemablePositions.length + closedPositions.length;
   if (allCount === 0) return null;
 
   const activeCount = positions.length + openOrders.length;
   const readyCount = redeemablePositions.length;
-  const scopeSwitchLabel = scope === 'active' ? 'All' : 'Active';
+  const closedCount = closedPositions.length;
+  const scopeSwitchLabel = effectiveScope === 'active' ? 'All' : 'Active';
+  const countLabel = hasActiveRows
+    ? `${activeCount} active${readyCount > 0 ? ` · ${readyCount} ready` : ''}${closedCount > 0 ? ` · ${closedCount} history` : ''}`
+    : `${closedCount} history`;
 
   return (
     <View style={styles.section}>
@@ -117,17 +123,19 @@ export function YourPicksSection({
         <Text style={styles.title}>Your Picks</Text>
         <View style={styles.headerSide}>
           <Text style={styles.count}>
-            {activeCount} active{readyCount > 0 ? ` · ${readyCount} ready` : ''}
+            {countLabel}
           </Text>
-          <Pressable
-            style={[styles.scopeSwitch, scope === 'all' && styles.scopeSwitchActive]}
-            onPress={() => setScope(scope === 'active' ? 'all' : 'active')}
-            accessibilityRole="switch"
-            accessibilityState={{ checked: scope === 'all' }}
-          >
-            <View style={styles.scopeSwitchKnob} />
-            <Text style={styles.scopeSwitchText}>{scopeSwitchLabel}</Text>
-          </Pressable>
+          {hasActiveRows && closedCount > 0 && (
+            <Pressable
+              style={[styles.scopeSwitch, effectiveScope === 'all' && styles.scopeSwitchActive]}
+              onPress={() => setScope(scope === 'active' ? 'all' : 'active')}
+              accessibilityRole="switch"
+              accessibilityState={{ checked: effectiveScope === 'all' }}
+            >
+              <View style={styles.scopeSwitchKnob} />
+              <Text style={styles.scopeSwitchText}>{scopeSwitchLabel}</Text>
+            </Pressable>
+          )}
         </View>
       </View>
 

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -1,6 +1,8 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
+import { redeemPosition } from '@/features/predict/predict.api';
 import { semantic, tokens } from '@/theme';
 
 type YourPick =
@@ -12,7 +14,12 @@ interface YourPicksSectionProps {
   positions: PortfolioPosition[];
   openOrders: OpenOrder[];
   redeemablePositions: PortfolioPosition[];
+  polygonAddress: string | null;
+  cancellingOrderId: string | null;
   onPositionPress: (position: PortfolioPosition) => void;
+  onMarketPress: (slug: string) => void;
+  onCancelOrder: (orderId: string) => void;
+  onRedeemed: () => void;
 }
 
 function formatPnl(value: number): string {
@@ -56,10 +63,21 @@ export function YourPicksSection({
   positions,
   openOrders,
   redeemablePositions,
+  polygonAddress,
+  cancellingOrderId,
   onPositionPress,
+  onMarketPress,
+  onCancelOrder,
+  onRedeemed,
 }: YourPicksSectionProps) {
-  const picks = getYourPicks(positions, openOrders, redeemablePositions);
-  if (picks.length === 0) return null;
+  const [scope, setScope] = useState<'active' | 'all'>('active');
+  const picks = getYourPicks(
+    positions,
+    openOrders,
+    scope === 'all' ? redeemablePositions : [],
+  );
+  const allCount = positions.length + openOrders.length + redeemablePositions.length;
+  if (allCount === 0) return null;
 
   const activeCount = positions.length + openOrders.length;
 
@@ -67,23 +85,63 @@ export function YourPicksSection({
     <View style={styles.section}>
       <View style={styles.header}>
         <Text style={styles.title}>Your Picks</Text>
-        <Text style={styles.count}>
-          {activeCount} active · {picks.length} total
-        </Text>
+        <View style={styles.scopeToggle} accessibilityRole="tablist">
+          <Pressable
+            style={[styles.scopeBtn, scope === 'active' && styles.scopeBtnActive]}
+            onPress={() => setScope('active')}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: scope === 'active' }}
+          >
+            <Text style={[styles.scopeText, scope === 'active' && styles.scopeTextActive]}>
+              Active {activeCount}
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.scopeBtn, scope === 'all' && styles.scopeBtnActive]}
+            onPress={() => setScope('all')}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: scope === 'all' }}
+          >
+            <Text style={[styles.scopeText, scope === 'all' && styles.scopeTextActive]}>
+              All {allCount}
+            </Text>
+          </Pressable>
+        </View>
       </View>
+
+      {picks.length === 0 && (
+        <View style={styles.emptyScope}>
+          <Text style={styles.emptyScopeText}>No active picks right now</Text>
+        </View>
+      )}
 
       {picks.map((pick) => {
         if (pick.kind === 'order') {
-          return <OrderRow key={pick.id} order={pick.order} />;
+          return (
+            <OrderRow
+              key={pick.id}
+              order={pick.order}
+              cancelling={cancellingOrderId === pick.order.id}
+              onCancel={() => onCancelOrder(pick.order.id)}
+            />
+          );
         }
         if (pick.kind === 'redeemable') {
-          return <RedeemableRow key={pick.id} position={pick.position} />;
+          return (
+            <RedeemableRow
+              key={pick.id}
+              position={pick.position}
+              polygonAddress={polygonAddress}
+              onRedeemed={onRedeemed}
+            />
+          );
         }
         return (
           <PositionRow
             key={pick.id}
             position={pick.position}
             onPress={() => onPositionPress(pick.position)}
+            onMarketPress={() => onMarketPress(pick.position.slug)}
           />
         );
       })}
@@ -91,37 +149,65 @@ export function YourPicksSection({
   );
 }
 
-function PositionRow({ position: p, onPress }: { position: PortfolioPosition; onPress: () => void }) {
+function PositionRow({
+  position: p,
+  onPress,
+  onMarketPress,
+}: {
+  position: PortfolioPosition;
+  onPress: () => void;
+  onMarketPress: () => void;
+}) {
   const pnl = p.cashPnl ?? 0;
   const isUp = pnl >= 0;
 
   return (
     <Pressable
-      style={styles.row}
+      style={styles.card}
       onPress={onPress}
       accessibilityLabel={`View position: ${p.title}`}
     >
-      <OutcomeBadge label={p.outcome ?? 'YES'} positive={p.outcome !== 'No'} />
-      <View style={styles.info}>
-        <Text style={styles.question} numberOfLines={2}>
-          {p.title || p.slug || '--'}
-        </Text>
-        <Text style={styles.meta}>
-          Live · {p.size.toFixed(2)} shares · {formatUsd(p.currentValue ?? 0)} value
-        </Text>
+      <View style={styles.row}>
+        <OutcomeBadge label={p.outcome ?? 'YES'} positive={p.outcome !== 'No'} />
+        <View style={styles.info}>
+          <Text style={styles.question} numberOfLines={2}>
+            {p.title || p.slug || '--'}
+          </Text>
+          <Text style={styles.meta}>
+            Live · {p.size.toFixed(2)} shares · {formatUsd(p.currentValue ?? 0)} value
+          </Text>
+        </View>
+        <View style={styles.trailing}>
+          <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatPnl(pnl)}</Text>
+          <Text style={styles.subValue}>
+            {p.avgPrice?.toFixed(2) ?? '--'}→{p.curPrice?.toFixed(2) ?? '--'}
+          </Text>
+        </View>
+        <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
       </View>
-      <View style={styles.trailing}>
-        <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatPnl(pnl)}</Text>
-        <Text style={styles.subValue}>
-          {p.avgPrice?.toFixed(2) ?? '--'}→{p.curPrice?.toFixed(2) ?? '--'}
-        </Text>
+      <View style={styles.actions}>
+        <Pressable style={styles.secondaryAction} onPress={onPress}>
+          <MaterialIcons name="payments" size={12} color={tokens.colors.viridian} />
+          <Text style={styles.secondaryActionText}>Cash out</Text>
+        </Pressable>
+        <Pressable style={styles.secondaryAction} onPress={onMarketPress}>
+          <MaterialIcons name="add-chart" size={12} color={tokens.colors.primary} />
+          <Text style={[styles.secondaryActionText, styles.primaryActionText]}>Back more</Text>
+        </Pressable>
       </View>
-      <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
     </Pressable>
   );
 }
 
-function OrderRow({ order: o }: { order: OpenOrder }) {
+function OrderRow({
+  order: o,
+  cancelling,
+  onCancel,
+}: {
+  order: OpenOrder;
+  cancelling: boolean;
+  onCancel: () => void;
+}) {
   const sizeNum = Number.parseFloat(o.original_size) || 0;
   const matched = Number.parseFloat(o.size_matched) || 0;
   const priceNum = Number.parseFloat(o.price) || 0;
@@ -129,42 +215,114 @@ function OrderRow({ order: o }: { order: OpenOrder }) {
   const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
 
   return (
-    <View style={styles.row}>
-      <OutcomeBadge label={o.side} positive={o.side === 'BUY'} />
-      <View style={styles.info}>
-        <Text style={styles.question} numberOfLines={2}>
-          {o.outcome || o.market || '--'}
-        </Text>
-        <Text style={styles.meta}>
-          Waiting · {sizeNum.toFixed(2)} shares at {Math.round(priceNum * 100)}¢ · {fillPct}% filled
-        </Text>
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <OutcomeBadge label={o.side} positive={o.side === 'BUY'} />
+        <View style={styles.info}>
+          <Text style={styles.question} numberOfLines={2}>
+            {o.outcome || o.market || '--'}
+          </Text>
+          <Text style={styles.meta}>
+            Waiting · {sizeNum.toFixed(2)} shares at {Math.round(priceNum * 100)}¢ · {fillPct}% filled
+          </Text>
+        </View>
+        <View style={styles.trailing}>
+          <Text style={styles.value}>{formatUsd(cost)}</Text>
+          <Text style={styles.subValue}>{o.status || o.order_type}</Text>
+        </View>
       </View>
-      <View style={styles.trailing}>
-        <Text style={styles.value}>{formatUsd(cost)}</Text>
-        <Text style={styles.subValue}>{o.status || o.order_type}</Text>
-      </View>
+      <Pressable
+        style={styles.dangerAction}
+        disabled={cancelling}
+        onPress={onCancel}
+        accessibilityLabel={`Cancel ${o.side.toLowerCase()} order`}
+      >
+        {cancelling ? (
+          <ActivityIndicator size="small" color={semantic.sentiment.negative} />
+        ) : (
+          <>
+            <MaterialIcons name="close" size={12} color={semantic.sentiment.negative} />
+            <Text style={styles.dangerActionText}>Cancel waiting order</Text>
+          </>
+        )}
+      </Pressable>
     </View>
   );
 }
 
-function RedeemableRow({ position: p }: { position: PortfolioPosition }) {
+function RedeemableRow({
+  position: p,
+  polygonAddress,
+  onRedeemed,
+}: {
+  position: PortfolioPosition;
+  polygonAddress: string | null;
+  onRedeemed: () => void;
+}) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const value = p.currentValue ?? 0;
 
+  async function handleRedeem() {
+    if (!polygonAddress || status === 'loading' || status === 'success') return;
+
+    setStatus('loading');
+    try {
+      const result = await redeemPosition(polygonAddress, {
+        conditionId: p.conditionId,
+        asset: p.asset,
+        outcomeIndex: p.outcomeIndex,
+        negativeRisk: p.negativeRisk,
+      });
+      if (!result.ok) throw new Error(result.error || 'Redeem failed');
+      setStatus('success');
+      onRedeemed();
+    } catch {
+      setStatus('error');
+    }
+  }
+
   return (
-    <View style={styles.row}>
-      <OutcomeBadge label={p.outcome ?? 'YES'} positive />
-      <View style={styles.info}>
-        <Text style={styles.question} numberOfLines={2}>
-          {p.title || p.slug || '--'}
-        </Text>
-        <Text style={styles.meta}>
-          Ready · {p.size.toFixed(2)} shares won
-        </Text>
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <OutcomeBadge label={p.outcome ?? 'YES'} positive />
+        <View style={styles.info}>
+          <Text style={styles.question} numberOfLines={2}>
+            {p.title || p.slug || '--'}
+          </Text>
+          <Text style={styles.meta}>
+            Ready · {p.size.toFixed(2)} winning shares
+          </Text>
+        </View>
+        <View style={styles.trailing}>
+          <Text style={[styles.value, styles.posText]}>{formatUsd(value)}</Text>
+          <Text style={styles.subValue}>Payout</Text>
+        </View>
       </View>
-      <View style={styles.trailing}>
-        <Text style={[styles.value, styles.posText]}>{formatUsd(value)}</Text>
-        <Text style={styles.subValue}>Redeemable</Text>
-      </View>
+      <Pressable
+        style={[
+          styles.redeemAction,
+          status === 'success' && styles.redeemActionSuccess,
+          status === 'error' && styles.redeemActionError,
+        ]}
+        disabled={status === 'loading' || status === 'success'}
+        onPress={handleRedeem}
+        accessibilityLabel={`Redeem ${formatUsd(value)} payout`}
+      >
+        {status === 'loading' ? (
+          <ActivityIndicator size="small" color={tokens.colors.viridian} />
+        ) : (
+          <>
+            <MaterialIcons
+              name={status === 'success' ? 'check' : 'redeem'}
+              size={12}
+              color={status === 'error' ? tokens.colors.vermillion : tokens.colors.viridian}
+            />
+            <Text style={[styles.redeemActionText, status === 'error' && styles.errorText]}>
+              {status === 'success' ? 'Redeemed' : status === 'error' ? 'Redeem failed' : `Redeem ${formatUsd(value)}`}
+            </Text>
+          </>
+        )}
+      </Pressable>
     </View>
   );
 }
@@ -202,16 +360,62 @@ const styles = StyleSheet.create({
     fontSize: 7.5,
     color: semantic.text.faint,
   },
-  row: {
+  emptyScope: {
+    backgroundColor: semantic.background.surface,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 8,
+    padding: 14,
+    alignItems: 'center',
+  },
+  emptyScopeText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  scopeToggle: {
+    flexDirection: 'row',
+    backgroundColor: semantic.background.lift,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 7,
+    padding: 2,
+  },
+  scopeBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 5,
+    minHeight: 24,
+    justifyContent: 'center',
+  },
+  scopeBtnActive: {
+    backgroundColor: semantic.background.surface,
+  },
+  scopeText: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    fontWeight: '700',
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  scopeTextActive: {
+    color: semantic.text.primary,
+  },
+  card: {
     backgroundColor: semantic.background.surface,
     borderWidth: 1,
     borderColor: semantic.border.muted,
     borderRadius: 8,
     padding: 11,
+    gap: 9,
+    marginBottom: 5,
+  },
+  row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    marginBottom: 5,
   },
   badge: {
     paddingHorizontal: 5,
@@ -254,6 +458,80 @@ const styles = StyleSheet.create({
     fontSize: 7.5,
     color: semantic.text.faint,
     textTransform: 'uppercase',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  secondaryAction: {
+    flex: 1,
+    minHeight: 32,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.lift,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  secondaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: tokens.colors.viridian,
+  },
+  primaryActionText: {
+    color: tokens.colors.primary,
+  },
+  dangerAction: {
+    minHeight: 32,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: 'rgba(255,69,58,0.25)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  dangerActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: semantic.sentiment.negative,
+  },
+  redeemAction: {
+    minHeight: 32,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: 'rgba(74,140,111,0.25)',
+    backgroundColor: 'rgba(74,140,111,0.12)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  redeemActionSuccess: {
+    backgroundColor: 'rgba(74,140,111,0.25)',
+  },
+  redeemActionError: {
+    borderColor: 'rgba(217,83,79,0.4)',
+    backgroundColor: 'rgba(217,83,79,0.1)',
+  },
+  redeemActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: tokens.colors.viridian,
+  },
+  errorText: {
+    color: tokens.colors.vermillion,
   },
   posText: { color: tokens.colors.viridian },
   negText: { color: tokens.colors.vermillion },

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -1,34 +1,34 @@
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
-import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
+import type { ClosedPortfolioPosition, OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import { redeemPosition } from '@/features/predict/predict.api';
 import { semantic, tokens } from '@/theme';
 
 type YourPick =
   | { kind: 'position'; id: string; position: PortfolioPosition }
   | { kind: 'order'; id: string; order: OpenOrder }
-  | { kind: 'redeemable'; id: string; position: PortfolioPosition };
+  | { kind: 'redeemable'; id: string; position: PortfolioPosition }
+  | { kind: 'closed'; id: string; position: ClosedPortfolioPosition };
 
 interface YourPicksSectionProps {
   positions: PortfolioPosition[];
   openOrders: OpenOrder[];
   redeemablePositions: PortfolioPosition[];
+  closedPositions: ClosedPortfolioPosition[];
   polygonAddress: string | null;
   cancellingOrderId: string | null;
-  onPositionPress: (position: PortfolioPosition) => void;
+  onCashOutPress: (position: PortfolioPosition) => void;
   onMarketPress: (slug: string) => void;
   onCancelOrder: (orderId: string) => void;
   onRedeemed: () => void;
 }
 
-function formatPnl(value: number): string {
-  const prefix = value >= 0 ? '+$' : '-$';
-  return `${prefix}${Math.abs(value).toFixed(2)}`;
-}
-
 function formatUsd(value: number): string {
   return `$${value.toFixed(2)}`;
+}
+
+function formatActionUsd(value: number): string {
+  return `$${Math.round(value)}`;
 }
 
 function formatChance(value: number | null | undefined): string {
@@ -41,6 +41,12 @@ function formatOutcome(label: string | null | undefined): string {
   return label.toLowerCase().includes('draw') ? 'Draw' : label;
 }
 
+function getClosedPayout(position: ClosedPortfolioPosition): number {
+  const putIn = Number.isFinite(position.totalBought) ? position.totalBought : 0;
+  const realized = Number.isFinite(position.realizedPnl) ? position.realizedPnl : 0;
+  return Math.max(putIn + realized, 0);
+}
+
 function makePositionId(prefix: string, p: PortfolioPosition, index: number): string {
   return `${prefix}-${p.conditionId}-${p.outcomeIndex}-${index}`;
 }
@@ -49,6 +55,7 @@ function getYourPicks(
   positions: PortfolioPosition[],
   openOrders: OpenOrder[],
   redeemablePositions: PortfolioPosition[],
+  closedPositions: ClosedPortfolioPosition[],
   scope: 'active' | 'all',
 ): YourPick[] {
   const livePicks: YourPick[] = positions.map((position, index) => ({
@@ -66,9 +73,14 @@ function getYourPicks(
     id: makePositionId('redeemable', position, index),
     position,
   }));
+  const closedPicks: YourPick[] = closedPositions.map((position, index) => ({
+    kind: 'closed' as const,
+    id: `closed-${position.conditionId}-${position.outcomeIndex}-${position.timestamp}-${index}`,
+    position,
+  }));
 
   if (scope === 'all') {
-    return [...readyPicks, ...livePicks, ...waitingPicks];
+    return [...readyPicks, ...livePicks, ...waitingPicks, ...closedPicks];
   }
 
   return [
@@ -82,16 +94,17 @@ export function YourPicksSection({
   positions,
   openOrders,
   redeemablePositions,
+  closedPositions,
   polygonAddress,
   cancellingOrderId,
-  onPositionPress,
+  onCashOutPress,
   onMarketPress,
   onCancelOrder,
   onRedeemed,
 }: YourPicksSectionProps) {
   const [scope, setScope] = useState<'active' | 'all'>('active');
-  const picks = getYourPicks(positions, openOrders, redeemablePositions, scope);
-  const allCount = positions.length + openOrders.length + redeemablePositions.length;
+  const picks = getYourPicks(positions, openOrders, redeemablePositions, closedPositions, scope);
+  const allCount = positions.length + openOrders.length + redeemablePositions.length + closedPositions.length;
   if (allCount === 0) return null;
 
   const activeCount = positions.length + openOrders.length;
@@ -145,11 +158,19 @@ export function YourPicksSection({
             />
           );
         }
+        if (pick.kind === 'closed') {
+          return (
+            <ClosedRow
+              key={pick.id}
+              position={pick.position}
+            />
+          );
+        }
         return (
           <PositionRow
             key={pick.id}
             position={pick.position}
-            onPress={() => onPositionPress(pick.position)}
+            onCashOut={() => onCashOutPress(pick.position)}
             onMarketPress={() => onMarketPress(pick.position.slug)}
           />
         );
@@ -158,53 +179,63 @@ export function YourPicksSection({
   );
 }
 
+function ClosedRow({ position: p }: { position: ClosedPortfolioPosition }) {
+  const payout = getClosedPayout(p);
+  const won = payout > 0 && (p.curPrice >= 0.99 || (p.realizedPnl ?? 0) > 0);
+
+  return (
+    <View style={[styles.card, won ? styles.finishedCard : styles.lostCard]}>
+      <View style={styles.row}>
+        <View style={styles.info}>
+          <Text style={styles.question} numberOfLines={2}>
+            {formatOutcome(p.outcome)} {won ? 'won' : 'lost'}
+          </Text>
+          <Text style={styles.meta}>
+            {p.title || p.slug || '--'} · {won ? `collected ${formatActionUsd(payout)}` : 'settled'}
+          </Text>
+        </View>
+        <View style={styles.actions}>
+          <View style={styles.settledAction}>
+            <Text style={styles.settledActionText}>{won ? 'Collected' : 'No payout'}</Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
 function PositionRow({
   position: p,
-  onPress,
+  onCashOut,
   onMarketPress,
 }: {
   position: PortfolioPosition;
-  onPress: () => void;
+  onCashOut: () => void;
   onMarketPress: () => void;
 }) {
-  const pnl = p.cashPnl ?? 0;
-  const isUp = pnl >= 0;
-
   return (
-    <Pressable
+    <View
       style={[styles.card, p.outcome === 'No' ? styles.noCard : styles.liveCard]}
-      onPress={onPress}
-      accessibilityLabel={`View position: ${p.title}`}
     >
       <View style={styles.row}>
-        <OutcomeBadge label={formatOutcome(p.outcome)} positive={p.outcome !== 'No'} />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
             {formatOutcome(p.outcome)} {formatChance(p.curPrice)} now
           </Text>
           <Text style={styles.meta}>
-            {p.title || p.slug || '--'} · Picked at {formatChance(p.avgPrice)}
+            {p.title || p.slug || '--'} · avg entry {formatChance(p.avgPrice)}
           </Text>
         </View>
-        <View style={styles.trailing}>
-          <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatUsd(p.currentValue ?? 0)}</Text>
-          <Text style={styles.subValue}>
-            {formatPnl(pnl)}
-          </Text>
+        <View style={styles.actions}>
+          <Pressable style={styles.cashAction} onPress={onCashOut}>
+            <Text style={styles.cashActionText}>{formatActionUsd(p.currentValue ?? 0)} cash out now</Text>
+          </Pressable>
+          <Pressable style={styles.secondaryAction} onPress={onMarketPress}>
+            <Text style={styles.secondaryActionText}>Back more</Text>
+          </Pressable>
         </View>
-        <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
       </View>
-      <View style={styles.actions}>
-        <Pressable style={styles.secondaryAction} onPress={onPress}>
-          <MaterialIcons name="payments" size={12} color={tokens.colors.viridian} />
-          <Text style={styles.secondaryActionText}>Cash out now</Text>
-        </Pressable>
-        <Pressable style={styles.secondaryAction} onPress={onMarketPress}>
-          <MaterialIcons name="add-chart" size={12} color={tokens.colors.primary} />
-          <Text style={[styles.secondaryActionText, styles.primaryActionText]}>Back more</Text>
-        </Pressable>
-      </View>
-    </Pressable>
+    </View>
   );
 }
 
@@ -220,14 +251,12 @@ function OrderRow({
   const sizeNum = Number.parseFloat(o.original_size) || 0;
   const matched = Number.parseFloat(o.size_matched) || 0;
   const priceNum = Number.parseFloat(o.price) || 0;
-  const cost = sizeNum * priceNum;
   const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
   const outcomeLabel = formatOutcome(o.outcome);
 
   return (
     <View style={[styles.card, styles.waitingCard]}>
       <View style={styles.row}>
-        <OutcomeBadge label={outcomeLabel} positive={o.side !== 'SELL'} />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
             {formatChance(priceNum)} on {outcomeLabel}
@@ -236,26 +265,21 @@ function OrderRow({
             Yet to be placed{fillPct > 0 ? ` · ${fillPct}% matched` : ''}
           </Text>
         </View>
-        <View style={styles.trailing}>
-          <Text style={styles.value}>{formatUsd(cost)}</Text>
-          <Text style={styles.subValue}>{o.status || o.order_type}</Text>
+        <View style={styles.actions}>
+          <Pressable
+            style={styles.dangerAction}
+            disabled={cancelling}
+            onPress={onCancel}
+            accessibilityLabel={`Cancel waiting pick`}
+          >
+            {cancelling ? (
+              <ActivityIndicator size="small" color={semantic.sentiment.negative} />
+            ) : (
+              <Text style={styles.dangerActionText}>Cancel</Text>
+            )}
+          </Pressable>
         </View>
       </View>
-      <Pressable
-        style={styles.dangerAction}
-        disabled={cancelling}
-        onPress={onCancel}
-        accessibilityLabel={`Cancel ${o.side.toLowerCase()} order`}
-      >
-        {cancelling ? (
-          <ActivityIndicator size="small" color={semantic.sentiment.negative} />
-        ) : (
-          <>
-            <MaterialIcons name="close" size={12} color={semantic.sentiment.negative} />
-            <Text style={styles.dangerActionText}>Cancel</Text>
-          </>
-        )}
-      </Pressable>
     </View>
   );
 }
@@ -294,7 +318,6 @@ function RedeemableRow({
   return (
     <View style={[styles.card, styles.attentionCard]}>
       <View style={styles.row}>
-        <OutcomeBadge label={formatOutcome(p.outcome)} positive />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
             {formatOutcome(p.outcome)} won
@@ -303,46 +326,27 @@ function RedeemableRow({
             {p.title || p.slug || '--'} · Ready to collect
           </Text>
         </View>
-        <View style={styles.trailing}>
-          <Text style={[styles.value, styles.posText]}>{formatUsd(value)}</Text>
-          <Text style={styles.subValue}>Payout</Text>
+        <View style={styles.actions}>
+          <Pressable
+            style={[
+              styles.redeemAction,
+              status === 'success' && styles.redeemActionSuccess,
+              status === 'error' && styles.redeemActionError,
+            ]}
+            disabled={status === 'loading' || status === 'success'}
+            onPress={handleRedeem}
+            accessibilityLabel={`Redeem ${formatUsd(value)} payout`}
+          >
+            {status === 'loading' ? (
+              <ActivityIndicator size="small" color={tokens.colors.backgroundDark} />
+            ) : (
+              <Text style={[styles.redeemActionText, status === 'error' && styles.errorText]}>
+                {status === 'success' ? 'Redeemed' : status === 'error' ? 'Redeem failed' : `Redeem ${formatActionUsd(value)}`}
+              </Text>
+            )}
+          </Pressable>
         </View>
       </View>
-      <Pressable
-        style={[
-          styles.redeemAction,
-          status === 'success' && styles.redeemActionSuccess,
-          status === 'error' && styles.redeemActionError,
-        ]}
-        disabled={status === 'loading' || status === 'success'}
-        onPress={handleRedeem}
-        accessibilityLabel={`Redeem ${formatUsd(value)} payout`}
-      >
-        {status === 'loading' ? (
-          <ActivityIndicator size="small" color={tokens.colors.viridian} />
-        ) : (
-          <>
-            <MaterialIcons
-              name={status === 'success' ? 'check' : 'redeem'}
-              size={12}
-              color={status === 'error' ? tokens.colors.vermillion : tokens.colors.viridian}
-            />
-            <Text style={[styles.redeemActionText, status === 'error' && styles.errorText]}>
-              {status === 'success' ? 'Redeemed' : status === 'error' ? 'Redeem failed' : `Redeem ${formatUsd(value)}`}
-            </Text>
-          </>
-        )}
-      </Pressable>
-    </View>
-  );
-}
-
-function OutcomeBadge({ label, positive }: { label: string; positive: boolean }) {
-  return (
-    <View style={[styles.badge, positive ? styles.badgePos : styles.badgeNeg]}>
-      <Text style={[styles.badgeText, positive ? styles.posText : styles.negText]}>
-        {label.toUpperCase()}
-      </Text>
     </View>
   );
 }
@@ -423,9 +427,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: semantic.border.muted,
     borderRadius: 8,
-    padding: 11,
-    gap: 9,
-    marginBottom: 5,
+    padding: 13,
+    marginBottom: 8,
+    minHeight: 70,
   },
   liveCard: {
     borderColor: 'rgba(74,140,111,0.22)',
@@ -443,68 +447,65 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(74,140,111,0.28)',
     backgroundColor: 'rgba(74,140,111,0.10)',
   },
+  lostCard: {
+    borderColor: 'rgba(244,88,78,0.20)',
+    backgroundColor: 'rgba(244,88,78,0.06)',
+  },
+  finishedCard: {
+    borderColor: 'rgba(210,202,157,0.12)',
+    backgroundColor: 'rgba(210,202,157,0.05)',
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
-  },
-  badge: {
-    paddingHorizontal: 5,
-    paddingVertical: 2,
-    borderRadius: 3,
-  },
-  badgePos: { backgroundColor: 'rgba(52,199,123,0.12)' },
-  badgeNeg: { backgroundColor: 'rgba(244,88,78,0.12)' },
-  badgeText: {
-    fontFamily: 'monospace',
-    fontSize: 7.5,
-    fontWeight: '700',
+    gap: 12,
   },
   info: {
     flex: 1,
     gap: 3,
   },
   question: {
-    fontSize: 9.5,
+    fontSize: 12,
+    fontWeight: '700',
     color: semantic.text.primary,
-    lineHeight: 13,
+    lineHeight: 16,
   },
   meta: {
     fontFamily: 'monospace',
-    fontSize: 7.5,
+    fontSize: 8,
     color: semantic.text.faint,
-  },
-  trailing: {
-    alignItems: 'flex-end',
-    gap: 1,
-  },
-  value: {
-    fontFamily: 'monospace',
-    fontSize: 9,
-    fontWeight: '700',
-    color: semantic.text.primary,
-  },
-  subValue: {
-    fontFamily: 'monospace',
-    fontSize: 7.5,
-    color: semantic.text.faint,
-    textTransform: 'uppercase',
   },
   actions: {
-    flexDirection: 'row',
+    width: 112,
     gap: 6,
   },
-  secondaryAction: {
-    flex: 1,
+  cashAction: {
     minHeight: 32,
-    borderRadius: 6,
+    borderRadius: 7,
+    borderWidth: 1,
+    borderColor: 'rgba(232,197,71,0.36)',
+    backgroundColor: 'rgba(232,197,71,0.08)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  cashActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+    color: tokens.colors.primary,
+    textAlign: 'center',
+  },
+  secondaryAction: {
+    minHeight: 32,
+    borderRadius: 7,
     borderWidth: 1,
     borderColor: semantic.border.muted,
     backgroundColor: semantic.background.lift,
-    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 4,
+    paddingHorizontal: 8,
   },
   secondaryActionText: {
     fontFamily: 'monospace',
@@ -514,18 +515,15 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     color: tokens.colors.viridian,
   },
-  primaryActionText: {
-    color: tokens.colors.primary,
-  },
   dangerAction: {
-    minHeight: 32,
-    borderRadius: 6,
+    minHeight: 46,
+    borderRadius: 7,
     borderWidth: 1,
     borderColor: 'rgba(255,69,58,0.25)',
-    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 4,
+    backgroundColor: 'rgba(244,88,78,0.06)',
+    paddingHorizontal: 8,
   },
   dangerActionText: {
     fontFamily: 'monospace',
@@ -536,15 +534,12 @@ const styles = StyleSheet.create({
     color: semantic.sentiment.negative,
   },
   redeemAction: {
-    minHeight: 32,
-    borderRadius: 6,
-    borderWidth: 1,
-    borderColor: 'rgba(74,140,111,0.25)',
-    backgroundColor: 'rgba(74,140,111,0.12)',
-    flexDirection: 'row',
+    minHeight: 46,
+    borderRadius: 7,
+    backgroundColor: tokens.colors.viridian,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 4,
+    paddingHorizontal: 8,
   },
   redeemActionSuccess: {
     backgroundColor: 'rgba(74,140,111,0.25)',
@@ -557,9 +552,27 @@ const styles = StyleSheet.create({
     fontFamily: 'monospace',
     fontSize: 8,
     fontWeight: '700',
-    letterSpacing: 0.5,
+    letterSpacing: 0,
     textTransform: 'uppercase',
-    color: tokens.colors.viridian,
+    color: tokens.colors.backgroundDark,
+  },
+  settledAction: {
+    minHeight: 46,
+    borderRadius: 7,
+    backgroundColor: semantic.background.lift,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+    opacity: 0.78,
+  },
+  settledActionText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+    color: semantic.text.dim,
+    textTransform: 'uppercase',
+    textAlign: 'center',
   },
   errorText: {
     color: tokens.colors.vermillion,

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { ClosedPortfolioPosition, OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
 import { redeemPosition } from '@/features/predict/predict.api';
+import { formatPredictTitle } from '@/features/predict/formatPredictTitle';
+import { truncateUsd } from '@/features/predict/formatPredictMoney';
+import { PredictPositionRow } from '@/features/predict/components/PredictPositionRow';
 import { semantic, tokens } from '@/theme';
 
 type YourPick =
@@ -28,7 +31,7 @@ function formatUsd(value: number): string {
 }
 
 function formatActionUsd(value: number): string {
-  return `$${Math.round(value)}`;
+  return truncateUsd(value);
 }
 
 function formatChance(value: number | null | undefined): string {
@@ -39,6 +42,14 @@ function formatChance(value: number | null | undefined): string {
 function formatOutcome(label: string | null | undefined): string {
   if (!label) return 'Yes';
   return label.toLowerCase().includes('draw') ? 'Draw' : label;
+}
+
+function formatMarketTitle(position: PortfolioPosition | ClosedPortfolioPosition): string {
+  return formatPredictTitle({
+    title: position.title,
+    slug: position.slug || position.eventSlug,
+    outcomes: 'oppositeOutcome' in position ? [position.outcome, position.oppositeOutcome] : [],
+  });
 }
 
 function getClosedPayout(position: ClosedPortfolioPosition): number {
@@ -175,11 +186,12 @@ export function YourPicksSection({
           );
         }
         return (
-          <PositionRow
+          <PredictPositionRow
             key={pick.id}
             position={pick.position}
+            showMarketTitle
             onCashOut={() => onCashOutPress(pick.position)}
-            onMarketPress={() => onMarketPress(pick.position.slug)}
+            onBackMore={() => onMarketPress(pick.position.slug)}
           />
         );
       })}
@@ -199,48 +211,13 @@ function ClosedRow({ position: p }: { position: ClosedPortfolioPosition }) {
             {formatOutcome(p.outcome)} {won ? 'won' : 'lost'}
           </Text>
           <Text style={styles.meta}>
-            {p.title || p.slug || '--'} · {won ? `collected ${formatActionUsd(payout)}` : 'settled'}
+            {formatMarketTitle(p)} · {won ? `collected ${formatActionUsd(payout)}` : 'settled'}
           </Text>
         </View>
         <View style={styles.actions}>
           <View style={styles.settledAction}>
             <Text style={styles.settledActionText}>{won ? 'Collected' : 'No payout'}</Text>
           </View>
-        </View>
-      </View>
-    </View>
-  );
-}
-
-function PositionRow({
-  position: p,
-  onCashOut,
-  onMarketPress,
-}: {
-  position: PortfolioPosition;
-  onCashOut: () => void;
-  onMarketPress: () => void;
-}) {
-  return (
-    <View
-      style={[styles.card, p.outcome === 'No' ? styles.noCard : styles.liveCard]}
-    >
-      <View style={styles.row}>
-        <View style={styles.info}>
-          <Text style={styles.question} numberOfLines={2}>
-            {formatOutcome(p.outcome)} {formatChance(p.curPrice)} now
-          </Text>
-          <Text style={styles.meta}>
-            {p.title || p.slug || '--'} · avg entry {formatChance(p.avgPrice)}
-          </Text>
-        </View>
-        <View style={styles.actions}>
-          <Pressable style={styles.cashAction} onPress={onCashOut}>
-            <Text style={styles.cashActionText}>{formatActionUsd(p.currentValue ?? 0)} cash out now</Text>
-          </Pressable>
-          <Pressable style={styles.secondaryAction} onPress={onMarketPress}>
-            <Text style={styles.secondaryActionText}>Back more</Text>
-          </Pressable>
         </View>
       </View>
     </View>
@@ -331,7 +308,7 @@ function RedeemableRow({
             {formatOutcome(p.outcome)} won
           </Text>
           <Text style={styles.meta}>
-            {p.title || p.slug || '--'} · Ready to collect
+            {formatMarketTitle(p)} · Ready to collect
           </Text>
         </View>
         <View style={styles.actions}>

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -31,6 +31,16 @@ function formatUsd(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
+function formatChance(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '--';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatOutcome(label: string | null | undefined): string {
+  if (!label) return 'Yes';
+  return label.toLowerCase().includes('draw') ? 'Draw' : label;
+}
+
 function makePositionId(prefix: string, p: PortfolioPosition, index: number): string {
   return `${prefix}-${p.conditionId}-${p.outcomeIndex}-${index}`;
 }
@@ -71,15 +81,11 @@ export function YourPicksSection({
   onRedeemed,
 }: YourPicksSectionProps) {
   const [scope, setScope] = useState<'active' | 'all'>('active');
-  const picks = getYourPicks(
-    positions,
-    openOrders,
-    scope === 'all' ? redeemablePositions : [],
-  );
+  const picks = getYourPicks(positions, openOrders, redeemablePositions);
   const allCount = positions.length + openOrders.length + redeemablePositions.length;
   if (allCount === 0) return null;
 
-  const activeCount = positions.length + openOrders.length;
+  const activeCount = allCount;
 
   return (
     <View style={styles.section}>
@@ -168,19 +174,19 @@ function PositionRow({
       accessibilityLabel={`View position: ${p.title}`}
     >
       <View style={styles.row}>
-        <OutcomeBadge label={p.outcome ?? 'YES'} positive={p.outcome !== 'No'} />
+        <OutcomeBadge label={formatOutcome(p.outcome)} positive={p.outcome !== 'No'} />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
-            {p.title || p.slug || '--'}
+            {formatOutcome(p.outcome)} {formatChance(p.curPrice)} now
           </Text>
           <Text style={styles.meta}>
-            Live · {p.size.toFixed(2)} shares · {formatUsd(p.currentValue ?? 0)} value
+            {p.title || p.slug || '--'} · Picked at {formatChance(p.avgPrice)}
           </Text>
         </View>
         <View style={styles.trailing}>
-          <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatPnl(pnl)}</Text>
+          <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatUsd(p.currentValue ?? 0)}</Text>
           <Text style={styles.subValue}>
-            {p.avgPrice?.toFixed(2) ?? '--'}→{p.curPrice?.toFixed(2) ?? '--'}
+            {formatPnl(pnl)}
           </Text>
         </View>
         <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
@@ -188,7 +194,7 @@ function PositionRow({
       <View style={styles.actions}>
         <Pressable style={styles.secondaryAction} onPress={onPress}>
           <MaterialIcons name="payments" size={12} color={tokens.colors.viridian} />
-          <Text style={styles.secondaryActionText}>Cash out</Text>
+          <Text style={styles.secondaryActionText}>Cash out now</Text>
         </Pressable>
         <Pressable style={styles.secondaryAction} onPress={onMarketPress}>
           <MaterialIcons name="add-chart" size={12} color={tokens.colors.primary} />
@@ -213,17 +219,18 @@ function OrderRow({
   const priceNum = Number.parseFloat(o.price) || 0;
   const cost = sizeNum * priceNum;
   const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
+  const outcomeLabel = formatOutcome(o.outcome);
 
   return (
     <View style={styles.card}>
       <View style={styles.row}>
-        <OutcomeBadge label={o.side} positive={o.side === 'BUY'} />
+        <OutcomeBadge label={outcomeLabel} positive={o.side !== 'SELL'} />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
-            {o.outcome || o.market || '--'}
+            {formatChance(priceNum)} on {outcomeLabel}
           </Text>
           <Text style={styles.meta}>
-            Waiting · {sizeNum.toFixed(2)} shares at {Math.round(priceNum * 100)}¢ · {fillPct}% filled
+            Yet to be placed{fillPct > 0 ? ` · ${fillPct}% matched` : ''}
           </Text>
         </View>
         <View style={styles.trailing}>
@@ -242,7 +249,7 @@ function OrderRow({
         ) : (
           <>
             <MaterialIcons name="close" size={12} color={semantic.sentiment.negative} />
-            <Text style={styles.dangerActionText}>Cancel waiting order</Text>
+            <Text style={styles.dangerActionText}>Cancel</Text>
           </>
         )}
       </Pressable>
@@ -284,13 +291,13 @@ function RedeemableRow({
   return (
     <View style={styles.card}>
       <View style={styles.row}>
-        <OutcomeBadge label={p.outcome ?? 'YES'} positive />
+        <OutcomeBadge label={formatOutcome(p.outcome)} positive />
         <View style={styles.info}>
           <Text style={styles.question} numberOfLines={2}>
-            {p.title || p.slug || '--'}
+            {formatOutcome(p.outcome)} won
           </Text>
           <Text style={styles.meta}>
-            Ready · {p.size.toFixed(2)} winning shares
+            {p.title || p.slug || '--'} · Ready to collect
           </Text>
         </View>
         <View style={styles.trailing}>

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -49,23 +49,32 @@ function getYourPicks(
   positions: PortfolioPosition[],
   openOrders: OpenOrder[],
   redeemablePositions: PortfolioPosition[],
+  scope: 'active' | 'all',
 ): YourPick[] {
+  const livePicks: YourPick[] = positions.map((position, index) => ({
+    kind: 'position' as const,
+    id: makePositionId('position', position, index),
+    position,
+  }));
+  const waitingPicks: YourPick[] = openOrders.map((order) => ({
+    kind: 'order' as const,
+    id: `order-${order.id}`,
+    order,
+  }));
+  const readyPicks: YourPick[] = redeemablePositions.map((position, index) => ({
+    kind: 'redeemable' as const,
+    id: makePositionId('redeemable', position, index),
+    position,
+  }));
+
+  if (scope === 'all') {
+    return [...readyPicks, ...livePicks, ...waitingPicks];
+  }
+
   return [
-    ...positions.map((position, index) => ({
-      kind: 'position' as const,
-      id: makePositionId('position', position, index),
-      position,
-    })),
-    ...openOrders.map((order) => ({
-      kind: 'order' as const,
-      id: `order-${order.id}`,
-      order,
-    })),
-    ...redeemablePositions.map((position, index) => ({
-      kind: 'redeemable' as const,
-      id: makePositionId('redeemable', position, index),
-      position,
-    })),
+    ...livePicks,
+    ...waitingPicks,
+    ...readyPicks,
   ];
 }
 
@@ -81,36 +90,30 @@ export function YourPicksSection({
   onRedeemed,
 }: YourPicksSectionProps) {
   const [scope, setScope] = useState<'active' | 'all'>('active');
-  const picks = getYourPicks(positions, openOrders, redeemablePositions);
+  const picks = getYourPicks(positions, openOrders, redeemablePositions, scope);
   const allCount = positions.length + openOrders.length + redeemablePositions.length;
   if (allCount === 0) return null;
 
-  const activeCount = allCount;
+  const activeCount = positions.length + openOrders.length;
+  const readyCount = redeemablePositions.length;
+  const scopeSwitchLabel = scope === 'active' ? 'All' : 'Active';
 
   return (
     <View style={styles.section}>
       <View style={styles.header}>
         <Text style={styles.title}>Your Picks</Text>
-        <View style={styles.scopeToggle} accessibilityRole="tablist">
+        <View style={styles.headerSide}>
+          <Text style={styles.count}>
+            {activeCount} active{readyCount > 0 ? ` · ${readyCount} ready` : ''}
+          </Text>
           <Pressable
-            style={[styles.scopeBtn, scope === 'active' && styles.scopeBtnActive]}
-            onPress={() => setScope('active')}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: scope === 'active' }}
+            style={[styles.scopeSwitch, scope === 'all' && styles.scopeSwitchActive]}
+            onPress={() => setScope(scope === 'active' ? 'all' : 'active')}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: scope === 'all' }}
           >
-            <Text style={[styles.scopeText, scope === 'active' && styles.scopeTextActive]}>
-              Active {activeCount}
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.scopeBtn, scope === 'all' && styles.scopeBtnActive]}
-            onPress={() => setScope('all')}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: scope === 'all' }}
-          >
-            <Text style={[styles.scopeText, scope === 'all' && styles.scopeTextActive]}>
-              All {allCount}
-            </Text>
+            <View style={styles.scopeSwitchKnob} />
+            <Text style={styles.scopeSwitchText}>{scopeSwitchLabel}</Text>
           </Pressable>
         </View>
       </View>
@@ -169,7 +172,7 @@ function PositionRow({
 
   return (
     <Pressable
-      style={styles.card}
+      style={[styles.card, p.outcome === 'No' ? styles.noCard : styles.liveCard]}
       onPress={onPress}
       accessibilityLabel={`View position: ${p.title}`}
     >
@@ -222,7 +225,7 @@ function OrderRow({
   const outcomeLabel = formatOutcome(o.outcome);
 
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, styles.waitingCard]}>
       <View style={styles.row}>
         <OutcomeBadge label={outcomeLabel} positive={o.side !== 'SELL'} />
         <View style={styles.info}>
@@ -289,7 +292,7 @@ function RedeemableRow({
   }
 
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, styles.attentionCard]}>
       <View style={styles.row}>
         <OutcomeBadge label={formatOutcome(p.outcome)} positive />
         <View style={styles.info}>
@@ -357,10 +360,16 @@ const styles = StyleSheet.create({
   },
   title: {
     fontFamily: 'monospace',
-    fontSize: 7.5,
+    fontSize: 8,
     letterSpacing: 2,
     textTransform: 'uppercase',
-    color: semantic.text.dim,
+    color: semantic.text.primary,
+    fontWeight: '700',
+  },
+  headerSide: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
   count: {
     fontFamily: 'monospace',
@@ -382,33 +391,32 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
-  scopeToggle: {
+  scopeSwitch: {
     flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
     backgroundColor: semantic.background.lift,
     borderWidth: 1,
-    borderColor: semantic.border.muted,
-    borderRadius: 7,
-    padding: 2,
+    borderColor: 'rgba(232,197,71,0.25)',
+    borderRadius: 999,
+    paddingHorizontal: 7,
+    minHeight: 28,
   },
-  scopeBtn: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
+  scopeSwitchActive: {
+    borderColor: 'rgba(232,197,71,0.45)',
+  },
+  scopeSwitchKnob: {
+    width: 10,
+    height: 10,
     borderRadius: 5,
-    minHeight: 24,
-    justifyContent: 'center',
+    backgroundColor: tokens.colors.accent,
   },
-  scopeBtnActive: {
-    backgroundColor: semantic.background.surface,
-  },
-  scopeText: {
+  scopeSwitchText: {
     fontFamily: 'monospace',
-    fontSize: 7.5,
+    fontSize: 8,
     fontWeight: '700',
-    color: semantic.text.faint,
-    textTransform: 'uppercase',
-  },
-  scopeTextActive: {
     color: semantic.text.primary,
+    textTransform: 'uppercase',
   },
   card: {
     backgroundColor: semantic.background.surface,
@@ -418,6 +426,22 @@ const styles = StyleSheet.create({
     padding: 11,
     gap: 9,
     marginBottom: 5,
+  },
+  liveCard: {
+    borderColor: 'rgba(74,140,111,0.22)',
+    backgroundColor: 'rgba(74,140,111,0.07)',
+  },
+  noCard: {
+    borderColor: 'rgba(244,88,78,0.22)',
+    backgroundColor: 'rgba(244,88,78,0.07)',
+  },
+  waitingCard: {
+    borderColor: 'rgba(232,197,71,0.25)',
+    backgroundColor: 'rgba(232,197,71,0.08)',
+  },
+  attentionCard: {
+    borderColor: 'rgba(74,140,111,0.28)',
+    backgroundColor: 'rgba(74,140,111,0.10)',
   },
   row: {
     flexDirection: 'row',

--- a/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
+++ b/apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx
@@ -1,0 +1,260 @@
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { OpenOrder, PortfolioPosition } from '@/features/predict/predict.api';
+import { semantic, tokens } from '@/theme';
+
+type YourPick =
+  | { kind: 'position'; id: string; position: PortfolioPosition }
+  | { kind: 'order'; id: string; order: OpenOrder }
+  | { kind: 'redeemable'; id: string; position: PortfolioPosition };
+
+interface YourPicksSectionProps {
+  positions: PortfolioPosition[];
+  openOrders: OpenOrder[];
+  redeemablePositions: PortfolioPosition[];
+  onPositionPress: (position: PortfolioPosition) => void;
+}
+
+function formatPnl(value: number): string {
+  const prefix = value >= 0 ? '+$' : '-$';
+  return `${prefix}${Math.abs(value).toFixed(2)}`;
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function makePositionId(prefix: string, p: PortfolioPosition, index: number): string {
+  return `${prefix}-${p.conditionId}-${p.outcomeIndex}-${index}`;
+}
+
+function getYourPicks(
+  positions: PortfolioPosition[],
+  openOrders: OpenOrder[],
+  redeemablePositions: PortfolioPosition[],
+): YourPick[] {
+  return [
+    ...positions.map((position, index) => ({
+      kind: 'position' as const,
+      id: makePositionId('position', position, index),
+      position,
+    })),
+    ...openOrders.map((order) => ({
+      kind: 'order' as const,
+      id: `order-${order.id}`,
+      order,
+    })),
+    ...redeemablePositions.map((position, index) => ({
+      kind: 'redeemable' as const,
+      id: makePositionId('redeemable', position, index),
+      position,
+    })),
+  ];
+}
+
+export function YourPicksSection({
+  positions,
+  openOrders,
+  redeemablePositions,
+  onPositionPress,
+}: YourPicksSectionProps) {
+  const picks = getYourPicks(positions, openOrders, redeemablePositions);
+  if (picks.length === 0) return null;
+
+  const activeCount = positions.length + openOrders.length;
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Your Picks</Text>
+        <Text style={styles.count}>
+          {activeCount} active · {picks.length} total
+        </Text>
+      </View>
+
+      {picks.map((pick) => {
+        if (pick.kind === 'order') {
+          return <OrderRow key={pick.id} order={pick.order} />;
+        }
+        if (pick.kind === 'redeemable') {
+          return <RedeemableRow key={pick.id} position={pick.position} />;
+        }
+        return (
+          <PositionRow
+            key={pick.id}
+            position={pick.position}
+            onPress={() => onPositionPress(pick.position)}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+function PositionRow({ position: p, onPress }: { position: PortfolioPosition; onPress: () => void }) {
+  const pnl = p.cashPnl ?? 0;
+  const isUp = pnl >= 0;
+
+  return (
+    <Pressable
+      style={styles.row}
+      onPress={onPress}
+      accessibilityLabel={`View position: ${p.title}`}
+    >
+      <OutcomeBadge label={p.outcome ?? 'YES'} positive={p.outcome !== 'No'} />
+      <View style={styles.info}>
+        <Text style={styles.question} numberOfLines={2}>
+          {p.title || p.slug || '--'}
+        </Text>
+        <Text style={styles.meta}>
+          Live · {p.size.toFixed(2)} shares · {formatUsd(p.currentValue ?? 0)} value
+        </Text>
+      </View>
+      <View style={styles.trailing}>
+        <Text style={[styles.value, isUp ? styles.posText : styles.negText]}>{formatPnl(pnl)}</Text>
+        <Text style={styles.subValue}>
+          {p.avgPrice?.toFixed(2) ?? '--'}→{p.curPrice?.toFixed(2) ?? '--'}
+        </Text>
+      </View>
+      <MaterialIcons name="chevron-right" size={14} color={semantic.text.faint} />
+    </Pressable>
+  );
+}
+
+function OrderRow({ order: o }: { order: OpenOrder }) {
+  const sizeNum = Number.parseFloat(o.original_size) || 0;
+  const matched = Number.parseFloat(o.size_matched) || 0;
+  const priceNum = Number.parseFloat(o.price) || 0;
+  const cost = sizeNum * priceNum;
+  const fillPct = sizeNum > 0 ? Math.round((matched / sizeNum) * 100) : 0;
+
+  return (
+    <View style={styles.row}>
+      <OutcomeBadge label={o.side} positive={o.side === 'BUY'} />
+      <View style={styles.info}>
+        <Text style={styles.question} numberOfLines={2}>
+          {o.outcome || o.market || '--'}
+        </Text>
+        <Text style={styles.meta}>
+          Waiting · {sizeNum.toFixed(2)} shares at {Math.round(priceNum * 100)}¢ · {fillPct}% filled
+        </Text>
+      </View>
+      <View style={styles.trailing}>
+        <Text style={styles.value}>{formatUsd(cost)}</Text>
+        <Text style={styles.subValue}>{o.status || o.order_type}</Text>
+      </View>
+    </View>
+  );
+}
+
+function RedeemableRow({ position: p }: { position: PortfolioPosition }) {
+  const value = p.currentValue ?? 0;
+
+  return (
+    <View style={styles.row}>
+      <OutcomeBadge label={p.outcome ?? 'YES'} positive />
+      <View style={styles.info}>
+        <Text style={styles.question} numberOfLines={2}>
+          {p.title || p.slug || '--'}
+        </Text>
+        <Text style={styles.meta}>
+          Ready · {p.size.toFixed(2)} shares won
+        </Text>
+      </View>
+      <View style={styles.trailing}>
+        <Text style={[styles.value, styles.posText]}>{formatUsd(value)}</Text>
+        <Text style={styles.subValue}>Redeemable</Text>
+      </View>
+    </View>
+  );
+}
+
+function OutcomeBadge({ label, positive }: { label: string; positive: boolean }) {
+  return (
+    <View style={[styles.badge, positive ? styles.badgePos : styles.badgeNeg]}>
+      <Text style={[styles.badgeText, positive ? styles.posText : styles.negText]}>
+        {label.toUpperCase()}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginHorizontal: tokens.spacing.lg,
+    marginTop: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  title: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    color: semantic.text.dim,
+  },
+  count: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+  },
+  row: {
+    backgroundColor: semantic.background.surface,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 8,
+    padding: 11,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 5,
+  },
+  badge: {
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    borderRadius: 3,
+  },
+  badgePos: { backgroundColor: 'rgba(52,199,123,0.12)' },
+  badgeNeg: { backgroundColor: 'rgba(244,88,78,0.12)' },
+  badgeText: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    fontWeight: '700',
+  },
+  info: {
+    flex: 1,
+    gap: 3,
+  },
+  question: {
+    fontSize: 9.5,
+    color: semantic.text.primary,
+    lineHeight: 13,
+  },
+  meta: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+  },
+  trailing: {
+    alignItems: 'flex-end',
+    gap: 1,
+  },
+  value: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '700',
+    color: semantic.text.primary,
+  },
+  subValue: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  posText: { color: tokens.colors.viridian },
+  negText: { color: tokens.colors.vermillion },
+});

--- a/docs/mockups/predict-detail-v2.html
+++ b/docs/mockups/predict-detail-v2.html
@@ -249,6 +249,36 @@
       color: var(--lo);
       flex-shrink: 0;
     }
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      flex-shrink: 0;
+    }
+    .cash-pill {
+      min-height: 24px;
+      border-radius: 12px;
+      border: 1px solid rgba(232,197,71,0.25);
+      background: var(--bg3);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3px 7px;
+    }
+    .cash-pill-label {
+      font-family: var(--mono);
+      font-size: 6px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      color: var(--lo);
+    }
+    .cash-pill-value {
+      font-family: var(--mono);
+      font-size: 9.5px;
+      font-weight: 800;
+      color: var(--hi);
+    }
     .profile-avatar-ring {
       width: 26px; height: 26px;
       border-radius: 50%;
@@ -583,8 +613,9 @@
       border-radius: 12px;
       background: rgba(74,140,111,0.10);
       border: 1px solid rgba(74,140,111,0.24);
-      padding: 9px 10px;
-      min-height: 64px;
+      border-left: 3px solid var(--pos);
+      padding: 10px 12px;
+      min-height: 82px;
     }
     .position-row.draw {
       background: rgba(199,183,112,0.10);
@@ -595,10 +626,18 @@
       background: rgba(217,83,79,0.10);
       border-color: rgba(217,83,79,0.24);
     }
+    .position-row.limit {
+      background: rgba(199,183,112,0.08);
+      border-color: rgba(199,183,112,0.24);
+      border-left-color: var(--a);
+    }
+    .position-row.redeemable {
+      border-left-color: var(--pos);
+    }
     .position-row-main { min-width: 0; flex: 1 }
     .position-row-name {
       font-family: var(--sans);
-      font-size: 14px;
+      font-size: 18px;
       font-weight: 800;
       color: var(--hi);
       white-space: nowrap;
@@ -615,12 +654,21 @@
     .position-row.away .position-row-name span,
     .position-row.no .position-row-name span { color: var(--neg) }
     .position-row-meta {
-      margin-top: 5px;
-      font-size: 8px;
+      margin-top: 4px;
+      font-size: 11px;
       letter-spacing: 0.3px;
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .position-row-pnl {
+      margin-top: 4px;
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 800;
+      color: var(--pos);
+    }
+    .position-row-pnl.down { color: var(--neg) }
+    .position-row-pnl.flat { color: var(--lo) }
     .position-row-side {
       text-align: right;
       flex-shrink: 0;
@@ -662,14 +710,24 @@
     }
     .position-action.sell {
       height: 28px;
-      color: var(--a);
-      border-color: rgba(199,183,112,0.28);
-      background: rgba(199,183,112,0.10);
+      color: var(--mid);
+      border-color: var(--border2);
+      background: rgba(255,255,255,0.04);
+    }
+    .position-action.sell.up {
+      color: var(--pos);
+      border-color: rgba(74,140,111,0.34);
+      background: rgba(74,140,111,0.12);
+    }
+    .position-action.sell.down {
+      color: var(--neg);
+      border-color: rgba(217,83,79,0.30);
+      background: rgba(217,83,79,0.10);
     }
     .position-action.add {
-      color: var(--pos);
-      border-color: rgba(74,140,111,0.26);
-      background: rgba(74,140,111,0.09);
+      color: var(--mid);
+      border-color: var(--border2);
+      background: rgba(255,255,255,0.035);
     }
     .position-action.redeem {
       height: 34px;
@@ -963,13 +1021,11 @@
     }
     .sel-odds {
       min-width: 66px;
-      height: 34px;
+      height: 32px;
       border-radius: 10px;
       display: flex;
-      flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 1px;
       background: rgba(74,140,111,0.12);
     }
     .sel-row.draw .sel-odds { background: rgba(199,183,112,0.12) }
@@ -983,14 +1039,6 @@
     }
     .sel-row.draw .sel-odds-pct { color: var(--a) }
     .sel-row.away .sel-odds-pct { color: var(--neg) }
-    .sel-odds-label {
-      font-family: var(--mono);
-      font-size: 6px;
-      letter-spacing: 0.8px;
-      text-transform: uppercase;
-      color: var(--lo);
-    }
-
     .sel-header {
       display: flex;
       align-items: center;
@@ -1175,12 +1223,107 @@
       transition: opacity 0.12s;
     }
     .numpad-confirm:active { opacity: 0.85 }
+    .numpad-confirm:disabled { opacity: 0.45; cursor: default }
     .numpad-confirm.yes { background: var(--pos) }
     .numpad-confirm.home { background: var(--pos) }
     .numpad-confirm.draw { background: var(--a) }
     .numpad-confirm.away { background: var(--neg) }
     .numpad-confirm.no  { background: var(--neg) }
     .numpad-confirm.sell { background: var(--a) }
+    .numpad-error { color: var(--neg) !important }
+
+    .cashout-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 50;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 22px;
+      background: rgba(0,0,0,0.62);
+    }
+    .cashout-modal.open { display: flex }
+    .cashout-card {
+      width: min(340px, 100%);
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      background: var(--bg2);
+      padding: 18px;
+      box-shadow: 0 18px 50px rgba(0,0,0,0.45);
+    }
+    .cashout-eyebrow {
+      font-family: var(--mono);
+      font-size: 8px;
+      letter-spacing: 1.4px;
+      text-transform: uppercase;
+      color: var(--lo);
+    }
+    .cashout-title {
+      margin-top: 6px;
+      font-family: var(--sans);
+      font-size: 20px;
+      font-weight: 800;
+      color: var(--hi);
+    }
+    .cashout-copy {
+      margin-top: 6px;
+      font-family: var(--sans);
+      font-size: 12px;
+      line-height: 17px;
+      color: var(--mid);
+    }
+    .cashout-row {
+      min-height: 42px;
+      margin-top: 12px;
+      border-radius: 10px;
+      border: 1px solid var(--border0);
+      background: var(--bg3);
+      padding: 0 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+    .cashout-row span {
+      font-family: var(--mono);
+      font-size: 8px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      color: var(--lo);
+    }
+    .cashout-row strong {
+      font-family: var(--mono);
+      font-size: 14px;
+      font-weight: 800;
+      color: var(--hi);
+    }
+    .cashout-row strong.pos { color: var(--pos) }
+    .cashout-row strong.neg { color: var(--neg) }
+    .cashout-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      margin-top: 16px;
+    }
+    .cashout-actions button {
+      min-height: 42px;
+      border-radius: 11px;
+      font-family: var(--mono);
+      font-size: 9px;
+      font-weight: 800;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .cashout-secondary {
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--mid);
+    }
+    .cashout-primary {
+      border: none;
+      background: var(--pos);
+      color: #131209;
+    }
 
     /* ─── Y-AXIS LABELS ─── */
     .chart-y-axis {
@@ -1251,7 +1394,10 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="#D0CAA8" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
           </div>
           <span class="detail-header-title">China invade Taiwan by 2026?</span>
-          <span class="header-end">Dec 31</span>
+          <div class="cash-pill">
+            <span class="cash-pill-label">Cash</span>
+            <span class="cash-pill-value">$2.9042</span>
+          </div>
         </div>
 
         <!-- DARK ZONE — chart -->
@@ -1297,20 +1443,20 @@
                 <span>Total</span>
               </div>
               <div class="ob-asks">
-                <div class="ob-row ask" style="--depth:40%"><div class="ob-price">5.8&#162;</div><div class="ob-shares">200.00</div><div class="ob-total">$132.50</div></div>
-                <div class="ob-row ask" style="--depth:35%"><div class="ob-price">5.7&#162;</div><div class="ob-shares">100.00</div><div class="ob-total">$120.90</div></div>
-                <div class="ob-row ask" style="--depth:80%"><div class="ob-price">5.0&#162;</div><div class="ob-shares">2,121.00</div><div class="ob-total">$115.20</div></div>
-                <div class="ob-row ask" style="--depth:20%"><div class="ob-price">4.6&#162;</div><div class="ob-shares">199.00</div><div class="ob-total">$9.15</div></div>
+                <div class="ob-row ask" style="--depth:40%"><div class="ob-price">6%</div><div class="ob-shares">200.00</div><div class="ob-total">$132.50</div></div>
+                <div class="ob-row ask" style="--depth:35%"><div class="ob-price">6%</div><div class="ob-shares">100.00</div><div class="ob-total">$120.90</div></div>
+                <div class="ob-row ask" style="--depth:80%"><div class="ob-price">5%</div><div class="ob-shares">2,121.00</div><div class="ob-total">$115.20</div></div>
+                <div class="ob-row ask" style="--depth:20%"><div class="ob-price">5%</div><div class="ob-shares">199.00</div><div class="ob-total">$9.15</div></div>
               </div>
               <div class="ob-spread">
-                <span class="ob-spread-label">Last: 4.0&#162;</span>
-                <span class="ob-spread-val">Spread: 0.5&#162;</span>
+                <span class="ob-spread-label">Last: 4%</span>
+                <span class="ob-spread-val">Spread: 1%</span>
               </div>
               <div class="ob-bids">
-                <div class="ob-row bid" style="--depth:25%"><div class="ob-price">4.1&#162;</div><div class="ob-shares">255.00</div><div class="ob-total">$10.46</div></div>
-                <div class="ob-row bid" style="--depth:70%"><div class="ob-price">4.0&#162;</div><div class="ob-shares">1,030.00</div><div class="ob-total">$51.66</div></div>
-                <div class="ob-row bid" style="--depth:30%"><div class="ob-price">3.9&#162;</div><div class="ob-shares">200.00</div><div class="ob-total">$59.46</div></div>
-                <div class="ob-row bid" style="--depth:30%"><div class="ob-price">3.8&#162;</div><div class="ob-shares">200.00</div><div class="ob-total">$67.06</div></div>
+                <div class="ob-row bid" style="--depth:25%"><div class="ob-price">4%</div><div class="ob-shares">255.00</div><div class="ob-total">$10.46</div></div>
+                <div class="ob-row bid" style="--depth:70%"><div class="ob-price">4%</div><div class="ob-shares">1,030.00</div><div class="ob-total">$51.66</div></div>
+                <div class="ob-row bid" style="--depth:30%"><div class="ob-price">4%</div><div class="ob-shares">200.00</div><div class="ob-total">$59.46</div></div>
+                <div class="ob-row bid" style="--depth:30%"><div class="ob-price">4%</div><div class="ob-shares">200.00</div><div class="ob-total">$67.06</div></div>
               </div>
             </div>
 
@@ -1333,24 +1479,26 @@
                 <div class="position-list">
                   <div class="position-row yes">
                     <div class="position-row-main">
-                      <div class="position-row-name">Yes <span>7% now</span></div>
-                      <div class="position-row-meta">Your avg entry 12%</div>
+                      <div class="position-row-name">Yes</div>
+                      <div class="position-row-meta">12% entry → 7% now</div>
+                      <div class="position-row-pnl down">-$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('binary','Yes','yes',7,23,22)">$22 cash out now</button>
+                        <button class="position-action sell down" onclick="sellExposure('binary','Yes','yes',7,23,22)">$22 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('binary','China invade Taiwan?','yes',7)">Back more</button>
                       </div>
                     </div>
                   </div>
                   <div class="position-row no">
                     <div class="position-row-main">
-                      <div class="position-row-name">No <span>93% now</span></div>
-                      <div class="position-row-meta">Your avg entry 88%</div>
+                      <div class="position-row-name">No</div>
+                      <div class="position-row-meta">88% entry → 93% now</div>
+                      <div class="position-row-pnl">+$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('binary','China invade Taiwan?','no',93)">Back more</button>
                       </div>
                     </div>
@@ -1366,29 +1514,31 @@
                 <div class="position-list">
                   <div class="position-row">
                     <div class="position-row-main">
-                      <div class="position-row-name">Liverpool <span>68% now</span></div>
-                      <div class="position-row-meta">Liverpool vs Crystal Palace · avg entry 58%</div>
+                      <div class="position-row-name">Liverpool</div>
+                      <div class="position-row-meta">Liverpool vs Crystal Palace · 58% entry → 68% now</div>
+                      <div class="position-row-pnl">+$8.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('sport','Liverpool','home',61)">Back more</button>
                       </div>
                     </div>
                   </div>
                   <div class="position-row no">
                     <div class="position-row-main">
-                      <div class="position-row-name">No <span>93% now</span></div>
-                      <div class="position-row-meta">China invade Taiwan by 2026 · avg entry 88%</div>
+                      <div class="position-row-name">No</div>
+                      <div class="position-row-meta">China invade Taiwan by 2026 · 88% entry → 93% now</div>
+                      <div class="position-row-pnl">+$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('binary','China invade Taiwan?','no',93)">Back more</button>
                       </div>
                     </div>
                   </div>
-                  <div class="position-row draw">
+                  <div class="position-row limit draw">
                     <div class="position-row-main">
                       <div class="position-row-name">45% on Draw</div>
                       <div class="position-row-meta">Yet to be placed</div>
@@ -1399,10 +1549,10 @@
                       </div>
                     </div>
                   </div>
-                  <div class="position-row yes">
+                  <div class="position-row redeemable yes">
                     <div class="position-row-main">
                       <div class="position-row-name">Yes <span>won</span></div>
-                      <div class="position-row-meta">Fed cuts rates in June · ready to collect</div>
+                      <div class="position-row-meta">Ready to collect</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
@@ -1484,7 +1634,7 @@
                 <div class="numpad-quick" onclick="npSet('b','10')">$10</div>
                 <div class="numpad-quick" onclick="npSet('b','25')">$25</div>
                 <div class="numpad-quick" onclick="npSet('b','50')">$50</div>
-                <div class="numpad-quick" onclick="npSet('b','100')">$100</div>
+                <div class="numpad-quick" onclick="npMax('b')">Max</div>
               </div>
               <div class="numpad-grid">
                 <div class="numpad-key" onclick="npKey('b','1')">1</div>
@@ -1548,8 +1698,14 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="#D0CAA8" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
           </div>
           <span class="detail-header-title">Liverpool vs Crystal Palace</span>
-          <div class="live-badge">
-            <div class="live-badge-dot"></div>LIVE
+          <div class="header-right">
+            <div class="live-badge">
+              <div class="live-badge-dot"></div>LIVE
+            </div>
+            <div class="cash-pill">
+              <span class="cash-pill-label">Cash</span>
+              <span class="cash-pill-value">$2.9042</span>
+            </div>
           </div>
         </div>
 
@@ -1600,20 +1756,20 @@
                 <span>Total</span>
               </div>
               <div class="ob-asks">
-                <div class="ob-row ask" style="--depth:45%"><div class="ob-price">63.2&#162;</div><div class="ob-shares">450.00</div><div class="ob-total">$284.40</div></div>
-                <div class="ob-row ask" style="--depth:60%"><div class="ob-price">62.5&#162;</div><div class="ob-shares">800.00</div><div class="ob-total">$500.00</div></div>
-                <div class="ob-row ask" style="--depth:90%"><div class="ob-price">62.0&#162;</div><div class="ob-shares">1,200.00</div><div class="ob-total">$744.00</div></div>
-                <div class="ob-row ask" style="--depth:30%"><div class="ob-price">61.5&#162;</div><div class="ob-shares">350.00</div><div class="ob-total">$215.25</div></div>
+                <div class="ob-row ask" style="--depth:45%"><div class="ob-price">63%</div><div class="ob-shares">450.00</div><div class="ob-total">$284.40</div></div>
+                <div class="ob-row ask" style="--depth:60%"><div class="ob-price">63%</div><div class="ob-shares">800.00</div><div class="ob-total">$500.00</div></div>
+                <div class="ob-row ask" style="--depth:90%"><div class="ob-price">62%</div><div class="ob-shares">1,200.00</div><div class="ob-total">$744.00</div></div>
+                <div class="ob-row ask" style="--depth:30%"><div class="ob-price">62%</div><div class="ob-shares">350.00</div><div class="ob-total">$215.25</div></div>
               </div>
               <div class="ob-spread">
-                <span class="ob-spread-label">Last: 61.0&#162;</span>
-                <span class="ob-spread-val">Spread: 0.5&#162;</span>
+                <span class="ob-spread-label">Last: 61%</span>
+                <span class="ob-spread-val">Spread: 1%</span>
               </div>
               <div class="ob-bids">
-                <div class="ob-row bid" style="--depth:95%"><div class="ob-price">61.0&#162;</div><div class="ob-shares">1,500.00</div><div class="ob-total">$915.00</div></div>
-                <div class="ob-row bid" style="--depth:50%"><div class="ob-price">60.5&#162;</div><div class="ob-shares">620.00</div><div class="ob-total">$375.10</div></div>
-                <div class="ob-row bid" style="--depth:70%"><div class="ob-price">60.0&#162;</div><div class="ob-shares">900.00</div><div class="ob-total">$540.00</div></div>
-                <div class="ob-row bid" style="--depth:35%"><div class="ob-price">59.5&#162;</div><div class="ob-shares">400.00</div><div class="ob-total">$238.00</div></div>
+                <div class="ob-row bid" style="--depth:95%"><div class="ob-price">61%</div><div class="ob-shares">1,500.00</div><div class="ob-total">$915.00</div></div>
+                <div class="ob-row bid" style="--depth:50%"><div class="ob-price">61%</div><div class="ob-shares">620.00</div><div class="ob-total">$375.10</div></div>
+                <div class="ob-row bid" style="--depth:70%"><div class="ob-price">60%</div><div class="ob-shares">900.00</div><div class="ob-total">$540.00</div></div>
+                <div class="ob-row bid" style="--depth:35%"><div class="ob-price">60%</div><div class="ob-shares">400.00</div><div class="ob-total">$238.00</div></div>
               </div>
             </div>
 
@@ -1636,36 +1792,39 @@
                 <div class="position-list">
                   <div class="position-row">
                     <div class="position-row-main">
-                      <div class="position-row-name">Liverpool <span>68% now</span></div>
-                      <div class="position-row-meta">Your avg entry 58%</div>
+                      <div class="position-row-name">Liverpool</div>
+                      <div class="position-row-meta">58% entry → 68% now</div>
+                      <div class="position-row-pnl">+$8.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('sport','Liverpool','home',61)">Back more</button>
                       </div>
                     </div>
                   </div>
                   <div class="position-row draw">
                     <div class="position-row-main">
-                      <div class="position-row-name">Draw <span>18% now</span></div>
-                      <div class="position-row-meta">Your avg entry 21%</div>
+                      <div class="position-row-name">Draw</div>
+                      <div class="position-row-meta">21% entry → 18% now</div>
+                      <div class="position-row-pnl down">-$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('sport','Draw','draw',18,21,20)">$20 cash out now</button>
+                        <button class="position-action sell down" onclick="sellExposure('sport','Draw','draw',18,21,20)">$20 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('sport','Draw','draw',22)">Back more</button>
                       </div>
                     </div>
                   </div>
                   <div class="position-row away">
                     <div class="position-row-main">
-                      <div class="position-row-name">Crystal Palace <span>16% now</span></div>
-                      <div class="position-row-meta">Your avg entry 18%</div>
+                      <div class="position-row-name">Crystal Palace</div>
+                      <div class="position-row-meta">18% entry → 16% now</div>
+                      <div class="position-row-pnl down">-$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('sport','Crystal Palace','away',16,18,17)">$17 cash out now</button>
+                        <button class="position-action sell down" onclick="sellExposure('sport','Crystal Palace','away',16,18,17)">$17 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('sport','Crystal Palace','away',18)">Back more</button>
                       </div>
                     </div>
@@ -1681,29 +1840,31 @@
                 <div class="position-list">
                   <div class="position-row">
                     <div class="position-row-main">
-                      <div class="position-row-name">Liverpool <span>68% now</span></div>
-                      <div class="position-row-meta">Liverpool vs Crystal Palace · avg entry 58%</div>
+                      <div class="position-row-name">Liverpool</div>
+                      <div class="position-row-meta">Liverpool vs Crystal Palace · 58% entry → 68% now</div>
+                      <div class="position-row-pnl">+$8.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('sport','Liverpool','home',68,58,56)">$56 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('sport','Liverpool','home',61)">Back more</button>
                       </div>
                     </div>
                   </div>
                   <div class="position-row no">
                     <div class="position-row-main">
-                      <div class="position-row-name">No <span>93% now</span></div>
-                      <div class="position-row-meta">China invade Taiwan by 2026 · avg entry 88%</div>
+                      <div class="position-row-name">No</div>
+                      <div class="position-row-meta">China invade Taiwan by 2026 · 88% entry → 93% now</div>
+                      <div class="position-row-pnl">+$1.00</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
-                        <button class="position-action sell" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
+                        <button class="position-action sell up" onclick="sellExposure('binary','No','no',93,21,20)">$20 cash out now</button>
                         <button class="position-action add" onclick="tapOdd('binary','China invade Taiwan?','no',93)">Back more</button>
                       </div>
                     </div>
                   </div>
-                  <div class="position-row draw">
+                  <div class="position-row limit draw">
                     <div class="position-row-main">
                       <div class="position-row-name">45% on Draw</div>
                       <div class="position-row-meta">Yet to be placed</div>
@@ -1714,10 +1875,10 @@
                       </div>
                     </div>
                   </div>
-                  <div class="position-row yes">
+                  <div class="position-row redeemable yes">
                     <div class="position-row-main">
                       <div class="position-row-name">Yes <span>won</span></div>
-                      <div class="position-row-meta">Fed cuts rates in June · ready to collect</div>
+                      <div class="position-row-meta">Ready to collect</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
@@ -1736,10 +1897,10 @@
                       </div>
                     </div>
                   </div>
-                  <div class="position-row draw">
+                  <div class="position-row redeemable draw">
                     <div class="position-row-main">
                       <div class="position-row-name">Democrat <span>won</span></div>
-                      <div class="position-row-meta">Election popular vote · ready to collect</div>
+                      <div class="position-row-meta">Ready to collect</div>
                     </div>
                     <div class="position-row-side">
                       <div class="position-actions">
@@ -1783,30 +1944,27 @@
                 <div class="sel-name">Liverpool</div>
                 <div class="sel-vol">$498K vol</div>
               </div>
-              <div class="sel-odds">
-                <span class="sel-odds-pct">61%</span>
-                <span class="sel-odds-label">Chance</span>
-              </div>
+	              <div class="sel-odds">
+	                <span class="sel-odds-pct">61%</span>
+	              </div>
             </div>
             <div class="sel-row draw" onclick="tapOdd('sport','Draw','draw',22)">
               <div class="sel-info">
                 <div class="sel-name">Draw</div>
                 <div class="sel-vol">$176K vol</div>
               </div>
-              <div class="sel-odds">
-                <span class="sel-odds-pct">22%</span>
-                <span class="sel-odds-label">Chance</span>
-              </div>
+	              <div class="sel-odds">
+	                <span class="sel-odds-pct">22%</span>
+	              </div>
             </div>
             <div class="sel-row away" onclick="tapOdd('sport','Crystal Palace','away',18)">
               <div class="sel-info">
                 <div class="sel-name">Crystal Palace</div>
                 <div class="sel-vol">$148K vol</div>
               </div>
-              <div class="sel-odds">
-                <span class="sel-odds-pct">18%</span>
-                <span class="sel-odds-label">Chance</span>
-              </div>
+	              <div class="sel-odds">
+	                <span class="sel-odds-pct">18%</span>
+	              </div>
             </div>
               </div>
           </div>
@@ -1832,7 +1990,7 @@
                 <div class="numpad-quick" onclick="npSet('s','10')">$10</div>
                 <div class="numpad-quick" onclick="npSet('s','25')">$25</div>
                 <div class="numpad-quick" onclick="npSet('s','50')">$50</div>
-                <div class="numpad-quick" onclick="npSet('s','100')">$100</div>
+                <div class="numpad-quick" onclick="npMax('s')">Max</div>
               </div>
               <div class="numpad-grid">
                 <div class="numpad-key" onclick="npKey('s','1')">1</div>
@@ -1866,6 +2024,26 @@
       </div>
     </div>
 
+  </div>
+
+  <div class="cashout-modal" id="cashout-modal">
+    <div class="cashout-card">
+      <div class="cashout-eyebrow">Cash out</div>
+      <div class="cashout-title">Are you sure?</div>
+      <div class="cashout-copy" id="cashout-copy">You are cashing out this pick.</div>
+      <div class="cashout-row">
+        <span>You will get</span>
+        <strong id="cashout-receive">$0.00</strong>
+      </div>
+      <div class="cashout-row">
+        <span>P/L</span>
+        <strong id="cashout-pnl">$0.00</strong>
+      </div>
+      <div class="cashout-actions">
+        <button class="cashout-secondary" onclick="closeCashoutModal()">Not now</button>
+        <button class="cashout-primary" onclick="closeCashoutModal()">Cash out</button>
+      </div>
+    </div>
   </div>
 
 <script>
@@ -1905,8 +2083,8 @@ function togglePicksScope(btnEl, screen) {
 }
 
 var npState = {
-  b: { amount: '50', price: 0.07, side: 'yes', open: false, selection: '', mode: 'buy', available: 0, cashOut: 0 },
-  s: { amount: '50', price: 0.61, side: 'home', open: false, selection: 'Liverpool', mode: 'buy', available: 0, cashOut: 0 }
+  b: { amount: '50', price: 0.07, side: 'yes', open: false, selection: '', mode: 'buy', available: 0, cashOut: 0, cash: 0.93 },
+  s: { amount: '50', price: 0.61, side: 'home', open: false, selection: 'Liverpool', mode: 'buy', available: 0, cashOut: 0, cash: 0.93 }
 };
 
 function tapOdd(screen, selection, side, cents) {
@@ -1956,27 +2134,32 @@ function tapOdd(screen, selection, side, cents) {
 }
 
 function sellExposure(screen, selection, side, cents, availableValue, cashOutValue) {
-  var prefix = screen === 'binary' ? 'b' : 's';
-  var state = npState[prefix];
-  var numpadEl = document.getElementById('numpad-' + screen);
-  var softEl = document.getElementById('soft-' + screen);
+  var pnl = cashOutValue - availableValue;
+  var pnlEl = document.getElementById('cashout-pnl');
+  document.getElementById('cashout-copy').textContent = 'You are cashing out ' + selection + '.';
+  document.getElementById('cashout-receive').textContent = preciseUsd(cashOutValue);
+  pnlEl.textContent = signedPreciseUsd(pnl);
+  pnlEl.className = pnl > 0 ? 'pos' : pnl < 0 ? 'neg' : '';
+  document.getElementById('cashout-modal').classList.add('open');
+}
 
-  state.mode = 'sell';
-  state.price = cents / 100;
-  state.side = side;
-  state.selection = selection;
-  state.amount = String(availableValue);
-  state.available = availableValue;
-  state.cashOut = cashOutValue;
-  state.open = true;
+function preciseUsd(value) {
+  var num = Number(value);
+  if (!Number.isFinite(num)) return '--';
+  var sign = num < 0 ? '-' : '';
+  var factor = 100;
+  var truncated = Math.trunc(Math.abs(num) * factor) / factor;
+  return sign + '$' + truncated.toFixed(2);
+}
 
-  clearSelected(screen);
-  softEl.classList.add('sell-mode');
-  var confirmEl = document.getElementById('np-' + prefix + '-confirm');
-  confirmEl.className = 'numpad-confirm sell';
+function signedPreciseUsd(value) {
+  var num = Number(value);
+  if (!Number.isFinite(num) || Math.abs(num) < 0.01) return '$0.00';
+  return (num > 0 ? '+' : '-') + preciseUsd(Math.abs(num));
+}
 
-  npRender(prefix);
-  numpadEl.classList.add('open');
+function closeCashoutModal() {
+  document.getElementById('cashout-modal').classList.remove('open');
 }
 
 function collapseNumpad(screen) {
@@ -2032,6 +2215,12 @@ function npSet(prefix, val) {
   npRender(prefix);
 }
 
+function npMax(prefix) {
+  var state = npState[prefix];
+  state.amount = String(Math.floor((state.cash || 0) * 100) / 100);
+  npRender(prefix);
+}
+
 function npRender(prefix) {
   var state = npState[prefix];
   var amount = parseFloat(state.amount) || 0;
@@ -2068,17 +2257,24 @@ function npRender(prefix) {
     riskLabelEl.textContent = 'Remaining';
     document.getElementById('np-' + prefix + '-payout').textContent = '~$' + receive.toFixed(0);
     document.getElementById('np-' + prefix + '-risk').textContent = '$' + remaining.toFixed(0);
+    document.getElementById('np-' + prefix + '-risk').classList.remove('numpad-error');
+    riskLabelEl.classList.remove('numpad-error');
+    confirmEl.disabled = false;
     confirmEl.textContent = 'Cash out ' + pickLabel + ' for $' + receive.toFixed(0);
   } else {
+    var overCash = amount > (state.cash || 0) + 0.000001;
     modeLabelEl.textContent = 'You picked';
     priceLabelEl.textContent = 'Current chance';
     priceEl.textContent = Math.round(state.price * 100) + '%';
     currencyEl.textContent = 'USDC';
     payoutLabelEl.textContent = 'If right';
-    riskLabelEl.textContent = 'If wrong';
+    riskLabelEl.textContent = overCash ? 'Not enough cash' : 'If wrong';
+    riskLabelEl.classList.toggle('numpad-error', overCash);
     document.getElementById('np-' + prefix + '-payout').textContent = '$' + payout.toFixed(2);
-    document.getElementById('np-' + prefix + '-risk').textContent = 'Lose $' + amount.toFixed(0);
-    confirmEl.textContent = 'Back ' + pickLabel + ' with $' + amount.toFixed(0);
+    document.getElementById('np-' + prefix + '-risk').textContent = overCash ? 'Cash ' + preciseUsd(state.cash || 0) : 'Lose $' + amount.toFixed(2);
+    document.getElementById('np-' + prefix + '-risk').classList.toggle('numpad-error', overCash);
+    confirmEl.disabled = overCash || amount <= 0;
+    confirmEl.textContent = overCash ? 'Not enough cash' : 'Back ' + pickLabel + ' with $' + amount.toFixed(amount % 1 === 0 ? 0 : 2);
   }
 }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -190,6 +190,171 @@ function isPositivePositionValue(position: unknown): boolean {
   return value >= 0.01
 }
 
+function asRecord(input: unknown): Record<string, unknown> | null {
+  return input && typeof input === 'object' ? input as Record<string, unknown> : null
+}
+
+function parseBoolean(input: unknown): boolean {
+  return input === true || input === 'true'
+}
+
+type ActivityFallbackGroup = {
+  proxyWallet: string
+  asset: string
+  conditionId: string
+  totalSize: number
+  totalUsdc: number
+  timestamp: number
+  title: string
+  slug: string
+  icon: string | null
+  eventSlug: string
+  outcome: string
+  outcomeIndex: number
+}
+
+async function fetchGammaMarketsForSlug(slug: string): Promise<Record<string, unknown>[]> {
+  const eventRes = await gammaFetch(`events?slug=${encodeURIComponent(slug)}`)
+  if (eventRes.ok) {
+    const body = await eventRes.json() as unknown
+    if (Array.isArray(body)) {
+      const markets = body.flatMap((event) => {
+        const record = asRecord(event)
+        return Array.isArray(record?.markets) ? record.markets : []
+      })
+      if (markets.length > 0) return markets.filter((market): market is Record<string, unknown> => !!asRecord(market))
+    }
+  }
+
+  const marketRes = await gammaFetch(`markets?slug=${encodeURIComponent(slug)}`)
+  if (!marketRes.ok) return []
+  const body = await marketRes.json() as unknown
+  return Array.isArray(body) ? body.filter((market): market is Record<string, unknown> => !!asRecord(market)) : []
+}
+
+async function buildClosedPositionsFromActivity(address: string): Promise<unknown[]> {
+  const activityRes = await dataApiFetch(
+    `activity?user=${encodeURIComponent(address)}&limit=50&sortBy=TIMESTAMP&sortDirection=DESC`
+  )
+  if (!activityRes.ok) return []
+
+  const body = await activityRes.json() as unknown
+  if (!Array.isArray(body)) return []
+
+  const seenTrades = new Set<string>()
+  const groups = new Map<string, ActivityFallbackGroup>()
+
+  for (const raw of body) {
+    const activity = asRecord(raw)
+    if (!activity) continue
+    if (activity.type !== 'TRADE' || activity.side !== 'BUY') continue
+
+    const slug = typeof activity.slug === 'string' ? activity.slug : null
+    const conditionId = typeof activity.conditionId === 'string' ? activity.conditionId : null
+    const asset = typeof activity.asset === 'string' ? activity.asset : ''
+    const size = parseNullableNumber(activity.size) ?? parseNullableNumber(activity.amount) ?? 0
+    const usdcSize = parseNullableNumber(activity.usdcSize) ?? 0
+    const outcomeIndex = parseNullableNumber(activity.outcomeIndex)
+    const timestamp = parseNullableNumber(activity.timestamp) ?? 0
+
+    if (!slug || !conditionId || outcomeIndex === null || size <= 0 || usdcSize <= 0 || timestamp <= 0) continue
+
+    const dedupeKey = [
+      activity.transactionHash,
+      asset,
+      conditionId,
+      outcomeIndex,
+      size,
+      usdcSize,
+      activity.price,
+    ].join(':')
+    if (seenTrades.has(dedupeKey)) continue
+    seenTrades.add(dedupeKey)
+
+    const groupKey = `${conditionId}:${outcomeIndex}:${asset}`
+    const existing = groups.get(groupKey)
+    if (existing) {
+      existing.totalSize += size
+      existing.totalUsdc += usdcSize
+      existing.timestamp = Math.max(existing.timestamp, timestamp)
+      continue
+    }
+
+    groups.set(groupKey, {
+      proxyWallet: typeof activity.proxyWallet === 'string' ? activity.proxyWallet : address,
+      asset,
+      conditionId,
+      totalSize: size,
+      totalUsdc: usdcSize,
+      timestamp,
+      title: typeof activity.title === 'string' ? activity.title : slug,
+      slug,
+      icon: typeof activity.icon === 'string' ? activity.icon : null,
+      eventSlug: typeof activity.eventSlug === 'string' ? activity.eventSlug : slug,
+      outcome: typeof activity.outcome === 'string' ? activity.outcome : 'Yes',
+      outcomeIndex,
+    })
+  }
+
+  const marketsBySlug = new Map<string, Record<string, unknown>[]>()
+  await Promise.all([...new Set([...groups.values()].map((group) => group.slug))].map(async (slug) => {
+    try {
+      marketsBySlug.set(slug, await fetchGammaMarketsForSlug(slug))
+    } catch (err) {
+      console.warn(`[api] Activity fallback market lookup failed for ${slug}:`, err instanceof Error ? err.message : err)
+      marketsBySlug.set(slug, [])
+    }
+  }))
+
+  const closedPositions: unknown[] = []
+  for (const group of groups.values()) {
+    const markets = marketsBySlug.get(group.slug) ?? []
+    const market = markets.find((candidate) => candidate.conditionId === group.conditionId)
+      ?? markets.find((candidate) => candidate.slug === group.slug)
+    if (!market || !parseBoolean(market.closed)) continue
+
+    const outcomePrices = parseStringArray(market.outcomePrices)
+    const outcomes = parseStringArray(market.outcomes)
+    const finalPrice = parseNullableNumber(outcomePrices[group.outcomeIndex])
+    if (finalPrice === null) continue
+
+    // The current app renders closed winners as "Collected"; avoid implying a payout
+    // was collected when we only know about raw trade activity.
+    if (finalPrice >= 0.99) continue
+
+    const payout = 0
+    const totalBought = Math.round(group.totalUsdc * 100) / 100
+    const realizedPnl = Math.round((payout - group.totalUsdc) * 100) / 100
+
+    closedPositions.push({
+      proxyWallet: group.proxyWallet,
+      asset: group.asset,
+      conditionId: group.conditionId,
+      avgPrice: group.totalSize > 0 ? Math.round((group.totalUsdc / group.totalSize) * 100) / 100 : 0,
+      totalBought,
+      realizedPnl,
+      curPrice: finalPrice,
+      timestamp: group.timestamp,
+      title: group.title,
+      slug: group.slug,
+      icon: group.icon,
+      eventSlug: group.eventSlug,
+      outcome: group.outcome,
+      outcomeIndex: group.outcomeIndex,
+      oppositeOutcome: outcomes.find((_, index) => index !== group.outcomeIndex) ?? '',
+      oppositeAsset: '',
+      endDate: typeof market.endDate === 'string' ? market.endDate : null,
+      fallbackSource: 'activity',
+    })
+  }
+
+  return closedPositions.sort((a, b) => {
+    const left = parseNullableNumber(asRecord(a)?.timestamp) ?? 0
+    const right = parseNullableNumber(asRecord(b)?.timestamp) ?? 0
+    return right - left
+  })
+}
+
 // --- dome fallback wrapper ---
 
 async function withDomeFallback<T>(
@@ -1018,6 +1183,23 @@ app.get('/predict/portfolio/:address', async (c) => {
     if (closedRes.status === 'fulfilled' && closedRes.value.ok) {
       const body = await closedRes.value.json() as unknown
       closedPositions = Array.isArray(body) ? body : []
+    }
+
+    // Some deposit-wallet trades appear in data-api /activity before they appear in
+    // /positions or /closed-positions. If portfolio state is otherwise empty, expose
+    // closed historical picks reconstructed from activity and final Gamma prices.
+    if (positions.length === 0 && redeemablePositions.length === 0 && closedPositions.length === 0) {
+      try {
+        closedPositions = await buildClosedPositionsFromActivity(address)
+        if (closedPositions.length > 0) {
+          console.log(`[api] Portfolio ${address}: using ${closedPositions.length} activity fallback closed positions`)
+        }
+      } catch (fallbackErr) {
+        console.warn(
+          `[api] Portfolio ${address}: activity fallback failed:`,
+          fallbackErr instanceof Error ? fallbackErr.message : fallbackErr,
+        )
+      }
     }
 
     // Parse profile

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -213,6 +213,35 @@ type ActivityFallbackGroup = {
   outcomeIndex: number
 }
 
+function activityDedupeKey(input: unknown): string {
+  const activity = asRecord(input)
+  if (!activity) return JSON.stringify(input)
+  return [
+    activity.transactionHash,
+    activity.type,
+    activity.side,
+    activity.conditionId,
+    activity.asset,
+    activity.outcomeIndex,
+    activity.size,
+    activity.usdcSize,
+    activity.price,
+    activity.timestamp,
+  ].join(':')
+}
+
+function dedupeActivity(input: unknown[]): unknown[] {
+  const seen = new Set<string>()
+  const deduped: unknown[] = []
+  for (const item of input) {
+    const key = activityDedupeKey(item)
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(item)
+  }
+  return deduped
+}
+
 async function fetchGammaMarketsForSlug(slug: string): Promise<Record<string, unknown>[]> {
   const eventRes = await gammaFetch(`events?slug=${encodeURIComponent(slug)}`)
   if (eventRes.ok) {
@@ -1143,12 +1172,14 @@ app.get('/predict/portfolio/:address', async (c) => {
   if (!address?.trim()) return c.json({ error: 'Bad request' }, 400)
 
   try {
-    // Fetch value, active positions, positive-payout redeemables, closed picks, and profile in parallel
-    const [valueRes, posRes, redeemableRes, closedRes, profileRes] = await Promise.allSettled([
+    // Fetch value, active positions, positive-payout redeemables, closed picks,
+    // recent activity, and profile in parallel.
+    const [valueRes, posRes, redeemableRes, closedRes, activityRes, profileRes] = await Promise.allSettled([
       dataApiFetch(`value?user=${encodeURIComponent(address)}`),
       dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=false&limit=100&sortBy=CURRENT&sortDirection=DESC`),
       dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=true&limit=50&sortBy=CURRENT&sortDirection=DESC`),
       dataApiFetch(`closed-positions?user=${encodeURIComponent(address)}&limit=50&sortBy=TIMESTAMP&sortDirection=DESC`),
+      dataApiFetch(`activity?user=${encodeURIComponent(address)}&limit=50&sortBy=TIMESTAMP&sortDirection=DESC`),
       gammaFetch(`public-profile?proxyWallet=${encodeURIComponent(address)}`),
     ])
 
@@ -1185,6 +1216,14 @@ app.get('/predict/portfolio/:address', async (c) => {
       closedPositions = Array.isArray(body) ? body : []
     }
 
+    // Parse recent activity. Keep it separate from picks so the UI can acknowledge
+    // trades/deposits/redeems without pretending they are actionable positions.
+    let activity: unknown[] = []
+    if (activityRes.status === 'fulfilled' && activityRes.value.ok) {
+      const body = await activityRes.value.json() as unknown
+      activity = Array.isArray(body) ? dedupeActivity(body) : []
+    }
+
     // Some deposit-wallet trades appear in data-api /activity before they appear in
     // /positions or /closed-positions. If portfolio state is otherwise empty, expose
     // closed historical picks reconstructed from activity and final Gamma prices.
@@ -1210,11 +1249,17 @@ app.get('/predict/portfolio/:address', async (c) => {
 
     // Compute summary from positions
     let totalPnl = 0
+    let cashOutNow = 0
     let openCount = 0
     for (const p of positions) {
       const pos = p as Record<string, unknown>
       totalPnl += parseNullableNumber(pos.cashPnl) ?? 0
+      cashOutNow += parseNullableNumber(pos.currentValue) ?? 0
       openCount++
+    }
+    let readyToCollect = 0
+    for (const p of redeemablePositions) {
+      readyToCollect += parseNullableNumber((p as Record<string, unknown>).currentValue) ?? 0
     }
     let totalCollected = 0
     for (const p of closedPositions) {
@@ -1230,6 +1275,7 @@ app.get('/predict/portfolio/:address', async (c) => {
       positions,
       redeemablePositions,
       closedPositions,
+      activity,
       profile: profile ? {
         name: profile.name ?? profile.pseudonym ?? null,
         bio: profile.bio ?? null,
@@ -1239,6 +1285,13 @@ app.get('/predict/portfolio/:address', async (c) => {
       summary: {
         openPositions: openCount,
         totalPnl: Math.round(totalPnl * 100) / 100,
+        cashOutNow: Math.round(cashOutNow * 100) / 100,
+        readyToCollect: Math.round(readyToCollect * 100) / 100,
+        activePickCount: openCount,
+        closedPickCount: closedPositions.length,
+        activityCount: activity.length,
+        hasActivity: activity.length > 0,
+        hasAnyPicks: openCount + redeemablePositions.length + closedPositions.length > 0,
         totalCollected: Math.round(totalCollected * 100) / 100,
       },
     })

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -978,11 +978,12 @@ app.get('/predict/portfolio/:address', async (c) => {
   if (!address?.trim()) return c.json({ error: 'Bad request' }, 400)
 
   try {
-    // Fetch value, active positions, positive-payout redeemables, and profile in parallel
-    const [valueRes, posRes, redeemableRes, profileRes] = await Promise.allSettled([
+    // Fetch value, active positions, positive-payout redeemables, closed picks, and profile in parallel
+    const [valueRes, posRes, redeemableRes, closedRes, profileRes] = await Promise.allSettled([
       dataApiFetch(`value?user=${encodeURIComponent(address)}`),
       dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=false&limit=100&sortBy=CURRENT&sortDirection=DESC`),
       dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=true&limit=50&sortBy=CURRENT&sortDirection=DESC`),
+      dataApiFetch(`closed-positions?user=${encodeURIComponent(address)}&limit=50&sortBy=TIMESTAMP&sortDirection=DESC`),
       gammaFetch(`public-profile?proxyWallet=${encodeURIComponent(address)}`),
     ])
 
@@ -1012,6 +1013,13 @@ app.get('/predict/portfolio/:address', async (c) => {
       redeemablePositions = Array.isArray(body) ? body.filter(isPositivePositionValue) : []
     }
 
+    // Parse closed picks
+    let closedPositions: unknown[] = []
+    if (closedRes.status === 'fulfilled' && closedRes.value.ok) {
+      const body = await closedRes.value.json() as unknown
+      closedPositions = Array.isArray(body) ? body : []
+    }
+
     // Parse profile
     let profile: Record<string, unknown> | null = null
     if (profileRes.status === 'fulfilled' && profileRes.value.ok) {
@@ -1026,12 +1034,20 @@ app.get('/predict/portfolio/:address', async (c) => {
       totalPnl += parseNullableNumber(pos.cashPnl) ?? 0
       openCount++
     }
+    let totalCollected = 0
+    for (const p of closedPositions) {
+      const closed = p as Record<string, unknown>
+      const realized = parseNullableNumber(closed.realizedPnl) ?? 0
+      const putIn = parseNullableNumber(closed.totalBought) ?? 0
+      if (realized > 0) totalCollected += Math.max(putIn + realized, 0)
+    }
 
     return c.json({
       address,
       portfolioValue: portfolioValue !== null ? Math.round(portfolioValue * 100) / 100 : null,
       positions,
       redeemablePositions,
+      closedPositions,
       profile: profile ? {
         name: profile.name ?? profile.pseudonym ?? null,
         bio: profile.bio ?? null,
@@ -1041,6 +1057,7 @@ app.get('/predict/portfolio/:address', async (c) => {
       summary: {
         openPositions: openCount,
         totalPnl: Math.round(totalPnl * 100) / 100,
+        totalCollected: Math.round(totalCollected * 100) / 100,
       },
     })
   } catch (err) {


### PR DESCRIPTION
## Summary
- Aligns Predict Profile with the beginner-friendly `Your Picks` lifecycle model from issue #129.
- Reworks profile empty states for no Predict account, no balance, and funded/no-picks accounts.
- Updates profile pick rows so live, waiting, redeemable, lost, and collected states share one visual system.
- Extends the portfolio response with closed picks and collected totals so the `All` view can show settled lifecycle states honestly.

## Validation
- `git diff --check -- apps/hybrid-expo/app/predict-profile.tsx apps/hybrid-expo/features/predict/profile/EmptyPortfolio.tsx apps/hybrid-expo/features/predict/profile/YourPicksSection.tsx apps/hybrid-expo/features/predict/predict.api.ts packages/api/src/index.ts`
- `pnpm --filter hybrid-expo exec eslint features/predict/profile/EmptyPortfolio.tsx features/predict/profile/YourPicksSection.tsx features/predict/predict.api.ts`

Known existing issue: linting `app/predict-profile.tsx` still reports `import/no-unresolved` for `@/hooks/useWallet`, which was already present outside this change.

Closes #129
