### PR TITLE
[codex] Add predict deposit status tracking

### DIFF
--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -407,7 +407,10 @@ export default function PredictProfileScreen() {
         <DepositModal
           isOpen={depositOpen}
           onClose={() => setDepositOpen(false)}
-          polygonAddress={poly.tradingAddress ?? poly.polygonAddress}
+          polygonAddress={poly.polygonAddress}
+          depositWalletAddress={poly.tradingAddress ?? poly.polygonAddress}
+          cashBalance={cashBalance}
+          onFundsAvailable={loadPortfolio}
         />
       )}
 

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -409,7 +409,6 @@ export default function PredictProfileScreen() {
           onClose={() => setDepositOpen(false)}
           polygonAddress={poly.polygonAddress}
           depositWalletAddress={poly.tradingAddress ?? poly.polygonAddress}
-          cashBalance={cashBalance}
           onFundsAvailable={loadPortfolio}
         />
       )}

--- a/apps/hybrid-expo/components/predict/DepositModal.tsx
+++ b/apps/hybrid-expo/components/predict/DepositModal.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -12,13 +11,20 @@ import * as Clipboard from 'expo-clipboard';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { semantic, tokens } from '@/theme';
 import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
+import { fetchClobBalance, fetchDepositStatus } from '@/features/predict/predict.api';
+import type { DepositBridgeTransaction } from '@/features/predict/predict.api';
 
 const API_BASE = resolveApiBaseUrl();
 
 interface DepositModalProps {
   isOpen: boolean;
   onClose: () => void;
+  /** EOA/session address. Required for balance polling and auto-wrap. */
   polygonAddress: string;
+  /** Trading/deposit wallet address used to create bridge deposit addresses. */
+  depositWalletAddress: string;
+  cashBalance: number | null;
+  onFundsAvailable?: () => void | Promise<void>;
 }
 
 interface DepositAddresses {
@@ -41,19 +47,105 @@ function truncateAddress(addr: string): string {
   return `${addr.slice(0, 10)}···${addr.slice(-8)}`;
 }
 
-export function DepositModal({ isOpen, onClose, polygonAddress }: DepositModalProps) {
+type DepositStatusTone = 'waiting' | 'active' | 'success' | 'error';
+
+interface TrackedDeposit {
+  chain: string;
+  address: string;
+  baselineBalance: number | null;
+  startedAt: number;
+}
+
+interface DepositStatusView {
+  label: string;
+  detail: string;
+  tone: DepositStatusTone;
+}
+
+const DEPOSIT_POLL_MS = 10_000;
+const DELAYED_AFTER_MS = 5 * 60_000;
+
+function latestTransaction(transactions: DepositBridgeTransaction[]): DepositBridgeTransaction | null {
+  if (transactions.length === 0) return null;
+  return [...transactions].sort((a, b) => (b.createdTimeMs ?? 0) - (a.createdTimeMs ?? 0))[0] ?? null;
+}
+
+function statusFromTransaction(transaction: DepositBridgeTransaction | null, startedAt: number): DepositStatusView {
+  if (!transaction?.status) {
+    const delayed = Date.now() - startedAt > DELAYED_AFTER_MS;
+    return delayed
+      ? {
+          label: 'Deposit delayed',
+          detail: 'No bridge transaction detected yet. You can refresh or keep this open.',
+          tone: 'error',
+        }
+      : {
+          label: 'Waiting for deposit',
+          detail: 'Send funds to the copied address. We will keep checking while this is open.',
+          tone: 'waiting',
+        };
+  }
+
+  switch (transaction.status) {
+    case 'DEPOSIT_DETECTED':
+      return {
+        label: 'Deposit detected',
+        detail: 'Funds were seen on the source chain and are waiting to process.',
+        tone: 'active',
+      };
+    case 'PROCESSING':
+    case 'ORIGIN_TX_CONFIRMED':
+    case 'SUBMITTED':
+      return {
+        label: 'Wrapping / bridging funds',
+        detail: 'The bridge is routing funds into your Predict wallet.',
+        tone: 'active',
+      };
+    case 'COMPLETED':
+      return {
+        label: 'Finalizing funds',
+        detail: 'Bridge completed. Checking your pUSD balance now.',
+        tone: 'active',
+      };
+    case 'FAILED':
+      return {
+        label: 'Deposit delayed',
+        detail: 'The bridge reported a failed transaction. Refresh or try another supported route.',
+        tone: 'error',
+      };
+    default:
+      return {
+        label: 'Waiting for deposit',
+        detail: 'We will keep checking while this is open.',
+        tone: 'waiting',
+      };
+  }
+}
+
+export function DepositModal({
+  isOpen,
+  onClose,
+  polygonAddress,
+  depositWalletAddress,
+  cashBalance,
+  onFundsAvailable,
+}: DepositModalProps) {
   const [addresses, setAddresses] = useState<DepositAddresses | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
+  const [trackedDeposit, setTrackedDeposit] = useState<TrackedDeposit | null>(null);
+  const [statusView, setStatusView] = useState<DepositStatusView | null>(null);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const fundsNotifiedRef = useRef(false);
 
   useEffect(() => {
-    if (!isOpen || !polygonAddress) return;
+    if (!isOpen || !depositWalletAddress) return;
 
     setLoading(true);
     setError(null);
 
-    fetchWithTimeout(`${API_BASE}/clob/deposit/${polygonAddress}`)
+    fetchWithTimeout(`${API_BASE}/clob/deposit/${encodeURIComponent(depositWalletAddress)}`)
       .then((res) => {
         if (!res.ok) throw new Error('Failed to fetch deposit addresses');
         return res.json();
@@ -66,11 +158,91 @@ export function DepositModal({ isOpen, onClose, polygonAddress }: DepositModalPr
         setError(err.message);
       })
       .finally(() => setLoading(false));
-  }, [isOpen, polygonAddress]);
+  }, [isOpen, depositWalletAddress]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCopied(null);
+      setTrackedDeposit(null);
+      setStatusView(null);
+      setStatusLoading(false);
+      fundsNotifiedRef.current = false;
+    }
+  }, [isOpen]);
+
+  const refreshDepositStatus = useCallback(async () => {
+    if (!trackedDeposit || !polygonAddress) return;
+
+    setStatusLoading(true);
+    try {
+      const [transactions, balance] = await Promise.all([
+        fetchDepositStatus(trackedDeposit.address).catch(() => []),
+        fetchClobBalance(polygonAddress).catch(() => null),
+      ]);
+
+      const baseline = trackedDeposit.baselineBalance;
+      const balanceReady = balance
+        ? baseline === null
+          ? balance.balance > 0
+          : balance.balance > baseline + 0.000001
+        : false;
+
+      if (balanceReady) {
+        setStatusView({
+          label: 'Funds available',
+          detail: `Cash balance is now $${balance!.balance.toFixed(2)}.`,
+          tone: 'success',
+        });
+
+        if (!fundsNotifiedRef.current) {
+          fundsNotifiedRef.current = true;
+          await onFundsAvailable?.();
+        }
+        return;
+      }
+
+      if (balance?.wrap?.error) {
+        setStatusView({
+          label: 'Deposit delayed',
+          detail: 'Funds may have arrived, but wrapping needs another refresh.',
+          tone: 'error',
+        });
+        return;
+      }
+
+      const bridgeView = statusFromTransaction(latestTransaction(transactions), trackedDeposit.startedAt);
+      setStatusView(bridgeView);
+    } finally {
+      setStatusLoading(false);
+    }
+  }, [onFundsAvailable, polygonAddress, trackedDeposit]);
+
+  useEffect(() => {
+    if (!isOpen || !trackedDeposit) return;
+
+    void refreshDepositStatus();
+    const interval = setInterval(() => {
+      void refreshDepositStatus();
+    }, DEPOSIT_POLL_MS);
+
+    return () => clearInterval(interval);
+  }, [isOpen, refreshDepositStatus, trackedDeposit]);
 
   const handleCopy = async (chain: string, address: string) => {
     await Clipboard.setStringAsync(address);
     setCopied(chain);
+    setTrackedDeposit({
+      chain,
+      address,
+      baselineBalance: cashBalance,
+      startedAt: Date.now(),
+    });
+    setStatusView({
+      label: 'Waiting for deposit',
+      detail: 'Send funds to the copied address. We will keep checking while this is open.',
+      tone: 'waiting',
+    });
+    fundsNotifiedRef.current = false;
     setTimeout(() => setCopied(null), 2000);
   };
 
@@ -150,6 +322,55 @@ export function DepositModal({ isOpen, onClose, polygonAddress }: DepositModalPr
                   </Pressable>
                 );
               })}
+            </View>
+          )}
+
+          {trackedDeposit && statusView && (
+            <View
+              style={[
+                styles.statusCard,
+                statusView.tone === 'success'
+                  ? styles.statusCard_success
+                  : statusView.tone === 'error'
+                    ? styles.statusCard_error
+                    : statusView.tone === 'active'
+                      ? styles.statusCard_active
+                      : styles.statusCard_waiting,
+              ]}
+            >
+              <View style={styles.statusHeader}>
+                <View
+                  style={[
+                    styles.statusDot,
+                    statusView.tone === 'success'
+                      ? styles.statusDot_success
+                      : statusView.tone === 'error'
+                        ? styles.statusDot_error
+                        : statusView.tone === 'active'
+                          ? styles.statusDot_active
+                          : styles.statusDot_waiting,
+                  ]}
+                />
+                <View style={styles.statusTextWrap}>
+                  <Text style={styles.statusLabel}>{statusView.label}</Text>
+                  <Text style={styles.statusDetail}>{statusView.detail}</Text>
+                </View>
+                {statusLoading ? (
+                  <ActivityIndicator size="small" color={tokens.colors.primary} />
+                ) : (
+                  <Pressable onPress={() => void refreshDepositStatus()} style={styles.refreshBtn}>
+                    <MaterialIcons name="refresh" size={14} color={semantic.text.dim} />
+                  </Pressable>
+                )}
+              </View>
+              <Text style={styles.trackedText}>
+                Tracking {CHAIN_META[trackedDeposit.chain]?.label ?? trackedDeposit.chain.toUpperCase()} {truncateAddress(trackedDeposit.address)}
+              </Text>
+              {statusView.tone === 'success' && (
+                <Pressable onPress={onClose} style={styles.doneBtn}>
+                  <Text style={styles.doneText}>Done</Text>
+                </Pressable>
+              )}
             </View>
           )}
 
@@ -312,5 +533,93 @@ const styles = StyleSheet.create({
     color: semantic.text.dim,
     textAlign: 'center',
     paddingVertical: 20,
+  },
+  statusCard: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 11,
+    marginTop: 8,
+    gap: 8,
+  },
+  statusCard_waiting: {
+    backgroundColor: semantic.background.lift,
+    borderColor: semantic.border.muted,
+  },
+  statusCard_active: {
+    backgroundColor: 'rgba(232,197,71,0.10)',
+    borderColor: 'rgba(232,197,71,0.25)',
+  },
+  statusCard_success: {
+    backgroundColor: 'rgba(45,145,110,0.12)',
+    borderColor: 'rgba(45,145,110,0.35)',
+  },
+  statusCard_error: {
+    backgroundColor: 'rgba(214,77,64,0.12)',
+    borderColor: 'rgba(214,77,64,0.35)',
+  },
+  statusHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  statusDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+  },
+  statusDot_waiting: {
+    backgroundColor: semantic.text.dim,
+  },
+  statusDot_active: {
+    backgroundColor: tokens.colors.primary,
+  },
+  statusDot_success: {
+    backgroundColor: tokens.colors.viridian,
+  },
+  statusDot_error: {
+    backgroundColor: tokens.colors.vermillion,
+  },
+  statusTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  statusLabel: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    fontWeight: '700',
+    color: semantic.text.primary,
+  },
+  statusDetail: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    lineHeight: 12,
+    color: semantic.text.dim,
+  },
+  refreshBtn: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: semantic.background.surface,
+  },
+  trackedText: {
+    fontFamily: 'monospace',
+    fontSize: 7.5,
+    color: semantic.text.faint,
+  },
+  doneBtn: {
+    alignSelf: 'flex-start',
+    backgroundColor: tokens.colors.viridian,
+    borderRadius: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  doneText: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '700',
+    color: '#fff',
+    letterSpacing: 0.5,
   },
 });

--- a/apps/hybrid-expo/components/predict/DepositModal.tsx
+++ b/apps/hybrid-expo/components/predict/DepositModal.tsx
@@ -23,7 +23,6 @@ interface DepositModalProps {
   polygonAddress: string;
   /** Trading/deposit wallet address used to create bridge deposit addresses. */
   depositWalletAddress: string;
-  cashBalance: number | null;
   onFundsAvailable?: () => void | Promise<void>;
 }
 
@@ -53,6 +52,9 @@ interface TrackedDeposit {
   chain: string;
   address: string;
   baselineBalance: number | null;
+  baselineKnown: boolean;
+  baselineTransactionKeys: string[];
+  hasStatusSnapshot: boolean;
   startedAt: number;
 }
 
@@ -64,10 +66,42 @@ interface DepositStatusView {
 
 const DEPOSIT_POLL_MS = 10_000;
 const DELAYED_AFTER_MS = 5 * 60_000;
+const TRANSACTION_TIME_TOLERANCE_MS = 30_000;
+
+function transactionKey(transaction: DepositBridgeTransaction): string {
+  return [
+    transaction.fromChainId ?? '',
+    transaction.fromTokenAddress ?? '',
+    transaction.fromAmountBaseUnit ?? '',
+    transaction.toChainId ?? '',
+    transaction.toTokenAddress ?? '',
+    transaction.status ?? '',
+    transaction.txHash ?? '',
+    transaction.createdTimeMs ?? '',
+  ].join(':');
+}
+
+function trackingTransactions(
+  transactions: DepositBridgeTransaction[],
+  trackedDeposit: TrackedDeposit,
+): DepositBridgeTransaction[] {
+  const baselineKeys = new Set(trackedDeposit.baselineTransactionKeys);
+  return transactions.filter((transaction) => {
+    if (baselineKeys.has(transactionKey(transaction))) return false;
+    if (typeof transaction.createdTimeMs === 'number') {
+      return transaction.createdTimeMs >= trackedDeposit.startedAt - TRANSACTION_TIME_TOLERANCE_MS;
+    }
+    return trackedDeposit.hasStatusSnapshot;
+  });
+}
 
 function latestTransaction(transactions: DepositBridgeTransaction[]): DepositBridgeTransaction | null {
   if (transactions.length === 0) return null;
-  return [...transactions].sort((a, b) => (b.createdTimeMs ?? 0) - (a.createdTimeMs ?? 0))[0] ?? null;
+  return [...transactions].sort((a, b) => {
+    const aTime = a.createdTimeMs ?? Number.MAX_SAFE_INTEGER;
+    const bTime = b.createdTimeMs ?? Number.MAX_SAFE_INTEGER;
+    return bTime - aTime;
+  })[0] ?? null;
 }
 
 function statusFromTransaction(transaction: DepositBridgeTransaction | null, startedAt: number): DepositStatusView {
@@ -127,7 +161,6 @@ export function DepositModal({
   onClose,
   polygonAddress,
   depositWalletAddress,
-  cashBalance,
   onFundsAvailable,
 }: DepositModalProps) {
   const [addresses, setAddresses] = useState<DepositAddresses | null>(null);
@@ -180,11 +213,9 @@ export function DepositModal({
         fetchClobBalance(polygonAddress).catch(() => null),
       ]);
 
-      const baseline = trackedDeposit.baselineBalance;
-      const balanceReady = balance
-        ? baseline === null
-          ? balance.balance > 0
-          : balance.balance > baseline + 0.000001
+      const baseline = trackedDeposit.baselineBalance ?? 0;
+      const balanceReady = trackedDeposit.baselineKnown && balance
+        ? balance.balance > baseline + 0.000001
         : false;
 
       if (balanceReady) {
@@ -201,6 +232,12 @@ export function DepositModal({
         return;
       }
 
+      if (!trackedDeposit.baselineKnown && balance) {
+        setTrackedDeposit((prev) => prev && prev.address === trackedDeposit.address
+          ? { ...prev, baselineBalance: balance.balance, baselineKnown: true }
+          : prev);
+      }
+
       if (balance?.wrap?.error) {
         setStatusView({
           label: 'Deposit delayed',
@@ -210,7 +247,10 @@ export function DepositModal({
         return;
       }
 
-      const bridgeView = statusFromTransaction(latestTransaction(transactions), trackedDeposit.startedAt);
+      const bridgeView = statusFromTransaction(
+        latestTransaction(trackingTransactions(transactions, trackedDeposit)),
+        trackedDeposit.startedAt,
+      );
       setStatusView(bridgeView);
     } finally {
       setStatusLoading(false);
@@ -231,18 +271,38 @@ export function DepositModal({
   const handleCopy = async (chain: string, address: string) => {
     await Clipboard.setStringAsync(address);
     setCopied(chain);
+    const startedAt = Date.now();
+    setStatusLoading(true);
+    setStatusView({
+      label: 'Waiting for deposit',
+      detail: 'Checking current balance before tracking this deposit.',
+      tone: 'waiting',
+    });
+    fundsNotifiedRef.current = false;
+
+    const [baseline, existingTransactions] = await Promise.all([
+      polygonAddress ? fetchClobBalance(polygonAddress).catch(() => null) : Promise.resolve(null),
+      fetchDepositStatus(address).then(
+        (transactions) => ({ transactions, ok: true }),
+        () => ({ transactions: [] as DepositBridgeTransaction[], ok: false }),
+      ),
+    ]);
+
     setTrackedDeposit({
       chain,
       address,
-      baselineBalance: cashBalance,
-      startedAt: Date.now(),
+      baselineBalance: baseline?.balance ?? null,
+      baselineKnown: !!baseline,
+      baselineTransactionKeys: existingTransactions.transactions.map(transactionKey),
+      hasStatusSnapshot: existingTransactions.ok,
+      startedAt,
     });
     setStatusView({
       label: 'Waiting for deposit',
       detail: 'Send funds to the copied address. We will keep checking while this is open.',
       tone: 'waiting',
     });
-    fundsNotifiedRef.current = false;
+    setStatusLoading(false);
     setTimeout(() => setCopied(null), 2000);
   };
 

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -493,6 +493,13 @@ export async function cancelOrder(polygonAddress: string, orderId: string): Prom
 export interface ClobBalance {
   balance: number;
   allowance: number;
+  wrap?: {
+    attempted: boolean;
+    wrapped: boolean;
+    amount: number;
+    txHash: string | null;
+    error: string | null;
+  };
 }
 
 export async function fetchClobBalance(polygonAddress: string): Promise<ClobBalance | null> {
@@ -506,7 +513,41 @@ export async function fetchClobBalance(polygonAddress: string): Promise<ClobBala
   return {
     balance: typeof data.balance === 'number' ? data.balance : 0,
     allowance: typeof data.allowance === 'number' ? data.allowance : 0,
+    wrap: data.wrap && typeof data.wrap === 'object'
+      ? data.wrap as ClobBalance['wrap']
+      : undefined,
   };
+}
+
+// --- Deposit Status ---
+
+export type DepositBridgeStatus =
+  | 'DEPOSIT_DETECTED'
+  | 'PROCESSING'
+  | 'ORIGIN_TX_CONFIRMED'
+  | 'SUBMITTED'
+  | 'COMPLETED'
+  | 'FAILED';
+
+export interface DepositBridgeTransaction {
+  fromChainId?: string;
+  fromTokenAddress?: string;
+  fromAmountBaseUnit?: string;
+  toChainId?: string;
+  toTokenAddress?: string;
+  status?: DepositBridgeStatus;
+  txHash?: string;
+  createdTimeMs?: number;
+}
+
+export async function fetchDepositStatus(depositAddress: string): Promise<DepositBridgeTransaction[]> {
+  const baseUrl = resolveApiBaseUrl();
+  const response = await fetchWithTimeout(`${baseUrl}/clob/deposit-status/${encodeURIComponent(depositAddress)}`);
+  if (!response.ok) return [];
+  const data = await response.json() as Record<string, unknown>;
+  return Array.isArray(data.transactions)
+    ? data.transactions.filter((entry): entry is DepositBridgeTransaction => !!entry && typeof entry === 'object')
+    : [];
 }
 
 // --- Portfolio & Positions (Gamma data-api, proxied through VPS) ---

--- a/packages/api/src/clob.ts
+++ b/packages/api/src/clob.ts
@@ -134,7 +134,19 @@ async function getUsdceBalance(walletAddress: string): Promise<bigint> {
   return BigInt(res)
 }
 
-async function autoWrapUsdce(session: ClobSession): Promise<{ wrapped: boolean; amount: number; txHash: string | null }> {
+type AutoWrapResult = { wrapped: boolean; amount: number; txHash: string | null }
+
+async function autoWrapUsdce(session: ClobSession): Promise<AutoWrapResult> {
+  if (session.wrapInFlight) return session.wrapInFlight
+
+  session.wrapInFlight = doAutoWrapUsdce(session).finally(() => {
+    session.wrapInFlight = undefined
+  })
+
+  return session.wrapInFlight
+}
+
+async function doAutoWrapUsdce(session: ClobSession): Promise<AutoWrapResult> {
   if (!relayerBuilderConfig) return { wrapped: false, amount: 0, txHash: null }
 
   const usdceBalance = await getUsdceBalance(session.tradingAddress)
@@ -217,6 +229,7 @@ interface ClobSession {
   walletMode: WalletMode
   tradingAddress: string
   depositWalletAddress?: string
+  wrapInFlight?: Promise<AutoWrapResult>
   createdAt: number
 }
 
@@ -574,6 +587,32 @@ clobRoutes.get('/deposit/:polygonAddress', async (c) => {
 })
 
 /**
+ * GET /clob/deposit-status/:depositAddress
+ * Proxies Polymarket Bridge status for a copied deposit address.
+ */
+clobRoutes.get('/deposit-status/:depositAddress', async (c) => {
+  const depositAddress = c.req.param('depositAddress')
+  if (!depositAddress) {
+    return c.json({ error: 'Missing deposit address' }, 400)
+  }
+
+  try {
+    const res = await fetch(`https://bridge.polymarket.com/status/${encodeURIComponent(depositAddress)}`)
+
+    if (!res.ok) {
+      const text = await res.text()
+      console.error(`[clob] Bridge status API error ${res.status}: ${text}`)
+      return c.json({ error: 'Bridge status API error', detail: text }, 502)
+    }
+
+    return c.json(await res.json())
+  } catch (err: any) {
+    console.error('[clob] Deposit status fetch failed:', err.message || err)
+    return c.json({ error: 'Failed to fetch deposit status', detail: err.message }, 500)
+  }
+})
+
+/**
  * GET /clob/balance/:polygonAddress
  */
 clobRoutes.get('/balance/:polygonAddress', async (c) => {
@@ -585,13 +624,23 @@ clobRoutes.get('/balance/:polygonAddress', async (c) => {
   }
 
   try {
+    let wrapMeta: {
+      attempted: boolean
+      wrapped: boolean
+      amount: number
+      txHash: string | null
+      error: string | null
+    } = { attempted: false, wrapped: false, amount: 0, txHash: null, error: null }
+
     // Auto-wrap any USDC.e sitting in the trading wallet (bridge deposits arrive as USDC.e)
     try {
       const wrapResult = await autoWrapUsdce(session)
+      wrapMeta = { attempted: wrapResult.amount > 0, wrapped: wrapResult.wrapped, amount: wrapResult.amount, txHash: wrapResult.txHash, error: null }
       if (wrapResult.wrapped) {
         console.log(`[clob] Auto-wrapped ${wrapResult.amount} USDC.e before balance check`)
       }
     } catch (wrapErr: any) {
+      wrapMeta = { attempted: true, wrapped: false, amount: 0, txHash: null, error: wrapErr.message ?? 'Auto-wrap failed' }
       console.warn(`[clob] Auto-wrap failed (non-fatal): ${wrapErr.message}`)
     }
 
@@ -604,7 +653,7 @@ clobRoutes.get('/balance/:polygonAddress', async (c) => {
     const allowance = rawAllowance >= 1000 ? rawAllowance / 1e6 : rawAllowance
 
     console.log(`[clob] Balance for ${polygonAddress} (${session.walletMode}: ${session.tradingAddress}): raw=${rawBalance} -> ${balance} pUSD`)
-    return c.json({ balance, allowance, raw: result })
+    return c.json({ balance, allowance, wrap: wrapMeta, raw: result })
   } catch (err: any) {
     console.error('[clob] Balance fetch failed:', err.message || err)
     return c.json({ error: 'Failed to fetch balance', detail: err.message }, 500)


### PR DESCRIPTION
## Summary

Adds a lightweight Predict deposit status flow after a user copies a bridge deposit address.

- Proxies Polymarket Bridge `/status/{depositAddress}` through the API.
- Adds a per-session auto-wrap in-flight guard so repeated balance polling does not submit duplicate wrap attempts.
- Returns wrap metadata from `/clob/balance/:polygonAddress` so the client can distinguish wrap errors from normal waiting.
- Polls bridge status plus pUSD balance in the deposit modal and refreshes the profile when funds become available.
- Keeps deposit-wallet address generation separate from EOA/session balance polling.

## Why

Issue #134 needs a simple, reassuring post-copy deposit experience. Bridge status gives progress, but existing CLOB balance polling remains the readiness signal because it triggers USDC.e -> pUSD auto-wrap.

## Validation

- `pnpm --filter hybrid-expo exec eslint components/predict/DepositModal.tsx features/predict/predict.api.ts`
- `pnpm --filter hybrid-expo exec eslint app/predict-profile.tsx --rule 'import/no-unresolved: off'`\n- `pnpm --filter @myboon/api exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck src/clob.ts`\n- `git diff --check`\n\nFull Expo `tsc --noEmit` still has existing unrelated failures around `@/hooks/useWallet` module resolution and pre-existing perps typing.