### PR TITLE
[codex] Add perps contract and Phoenix read-only proxy

### DIFF
--- a/apps/hybrid-expo/features/perps/perps.api.ts
+++ b/apps/hybrid-expo/features/perps/perps.api.ts
@@ -1,3 +1,5 @@
+export * from '@/features/perps/perps.contract';
+export * from '@/features/perps/perps.registry';
 export * from '@/features/perps/perps.public-api';
 export * from '@/features/perps/perps.signed-api';
 export * from '@/features/perps/perps.deposit-api';

--- a/apps/hybrid-expo/features/perps/perps.contract.ts
+++ b/apps/hybrid-expo/features/perps/perps.contract.ts
@@ -1,0 +1,463 @@
+export const PERPS_VENUE_IDS = ['pacifica', 'phoenix'] as const;
+
+export type PerpsVenueId = (typeof PERPS_VENUE_IDS)[number];
+export type PerpsVenueEnvironment = 'mainnet' | 'testnet' | 'devnet' | 'local';
+export type PerpsVenueIntegrationStatus = 'active' | 'read_only' | 'incomplete' | 'disabled';
+export type PerpsSide = 'long' | 'short';
+export type PerpsVenueSide = 'bid' | 'ask';
+export type PerpsMarginMode = 'cross' | 'isolated' | 'unknown';
+export type PerpsOrderKind = 'market' | 'limit' | 'stop_market' | 'stop_limit' | 'take_profit' | 'stop_loss';
+export type PerpsTimeInForce = 'GTC' | 'IOC' | 'FOK' | 'ALO' | 'TOB' | 'unknown';
+export type PerpsMarketStatus =
+  | 'active'
+  | 'post_only'
+  | 'paused'
+  | 'closed'
+  | 'tombstoned'
+  | 'maintenance'
+  | 'unknown';
+export type PerpsDataFreshness = 'live' | 'snapshot' | 'stale' | 'partial' | 'unavailable';
+export type PerpsQuoteAsset = 'USD' | 'USDC';
+export type PerpsCollateralAsset = 'USDC' | 'USDC-P';
+
+export type PerpsCandleInterval =
+  | '1s'
+  | '5s'
+  | '1m'
+  | '3m'
+  | '5m'
+  | '15m'
+  | '30m'
+  | '1h'
+  | '2h'
+  | '4h'
+  | '8h'
+  | '12h'
+  | '1d';
+
+export type PerpsAction =
+  | 'deposit'
+  | 'withdraw'
+  | 'place_order'
+  | 'cancel_order'
+  | 'close_position'
+  | 'set_tpsl';
+
+export type PerpsExecutionMode = 'signed_rest' | 'solana_transaction' | 'read_only_unavailable';
+export type PerpsSignMessageFn = (message: Uint8Array) => Promise<Uint8Array>;
+export type PerpsSignTransactionFn<TTransaction = unknown> = (transaction: TTransaction) => Promise<TTransaction>;
+export type PerpsSignAndSendTransactionFn<TTransaction = unknown> = (transaction: TTransaction) => Promise<string>;
+
+export interface PerpsVenueCapabilities {
+  publicMarkets: boolean;
+  candles: boolean;
+  liveMarketData: boolean;
+  accountRead: boolean;
+  positionsRead: boolean;
+  ordersRead: boolean;
+  deposit: boolean;
+  withdraw: boolean;
+  marketOrder: boolean;
+  limitOrder: boolean;
+  cancelOrder: boolean;
+  closePosition: boolean;
+  takeProfitStopLoss: boolean;
+  history: boolean;
+  messageSigningExecution: boolean;
+  transactionSigningExecution: boolean;
+  accessCodeRequired?: boolean;
+  regionRestricted?: boolean;
+  readOnly?: boolean;
+  incomplete?: boolean;
+}
+
+export interface PerpsVenueDescriptor {
+  venueId: PerpsVenueId;
+  displayName: string;
+  shortName?: string;
+  routeBase: string;
+  apiBasePath: string;
+  env: PerpsVenueEnvironment;
+  integrationStatus: PerpsVenueIntegrationStatus;
+  quoteAsset: PerpsQuoteAsset;
+  defaultCollateralAsset: PerpsCollateralAsset;
+  publicRestBaseUrl?: string;
+  publicWsBaseUrl?: string;
+  collateralMint?: string;
+  minDepositUsdc?: number;
+  supportedIntervals: readonly PerpsCandleInterval[];
+  defaultInterval: PerpsCandleInterval;
+  capabilities: PerpsVenueCapabilities;
+  notes?: readonly string[];
+}
+
+export interface PerpsPrecisionMetadata {
+  priceDecimals?: number | null;
+  sizeDecimals?: number | null;
+  baseLotsDecimals?: number | null;
+  priceTickRaw?: string | null;
+  baseLotSizeRaw?: string | null;
+  leverageTiers?: readonly PerpsLeverageTier[];
+}
+
+export interface PerpsLeverageTier {
+  maxLeverage: number;
+  notionalCapUsd?: number | null;
+}
+
+export interface PerpsMarket {
+  venueId: PerpsVenueId;
+  symbol: string;
+  venueSymbol: string;
+  baseSymbol: string;
+  quoteSymbol: PerpsQuoteAsset;
+  displayName: string;
+  iconPath?: string | null;
+  status: PerpsMarketStatus;
+  tradeable: boolean;
+  dataFreshness: PerpsDataFreshness;
+  updatedAt?: number | null;
+  maxLeverage: number | null;
+  marginModes: readonly PerpsMarginMode[];
+  isolatedOnly?: boolean;
+  tickSize: string | null;
+  lotSize: string | null;
+  minOrderSize: string | null;
+  minOrderSizeUsd?: number | null;
+  maxOrderSizeUsd?: number | null;
+  precision?: PerpsPrecisionMetadata;
+  markPrice: number | null;
+  oraclePrice: number | null;
+  midPrice: number | null;
+  fundingRate: number | null;
+  openInterest: number | null;
+  volume24h: number | null;
+  change24h: number | null;
+  yesterdayPrice: number | null;
+  raw?: unknown;
+}
+
+export interface PerpsCandle {
+  venueId: PerpsVenueId;
+  symbol: string;
+  venueSymbol: string;
+  interval: PerpsCandleInterval;
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  source: 'trade' | 'mark' | 'oracle' | 'unknown';
+}
+
+export interface PerpsLiveMarketUpdate {
+  venueId: PerpsVenueId;
+  symbol: string;
+  venueSymbol: string;
+  markPrice?: number | null;
+  oraclePrice?: number | null;
+  midPrice?: number | null;
+  fundingRate?: number | null;
+  openInterest?: number | null;
+  volume24h?: number | null;
+  timestamp?: number | null;
+  dataFreshness: PerpsDataFreshness;
+}
+
+export interface PerpsWalletCapabilities {
+  connected: boolean;
+  address: string | null;
+  source?: 'privy' | 'mwa' | 'web' | 'e2e' | 'unknown';
+  isPreparing?: boolean;
+  canSignMessage: boolean;
+  canSignTransaction: boolean;
+  canSignAndSendTransaction: boolean;
+}
+
+export interface PerpsExecutionContext<TTransaction = unknown> {
+  wallet: PerpsWalletCapabilities;
+  signMessage?: PerpsSignMessageFn | null;
+  signTransaction?: PerpsSignTransactionFn<TTransaction> | null;
+  signAndSendTransaction?: PerpsSignAndSendTransactionFn<TTransaction> | null;
+}
+
+export type PerpsReadinessStatus =
+  | 'disconnected'
+  | 'wallet_preparing'
+  | 'wallet_unsupported'
+  | 'access_required'
+  | 'region_blocked'
+  | 'account_missing'
+  | 'deposit_required'
+  | 'ready'
+  | 'risk_blocked'
+  | 'market_unavailable'
+  | 'maintenance'
+  | 'read_only'
+  | 'data_unavailable';
+
+export type PerpsReadinessRequirement =
+  | 'connect_wallet'
+  | 'sign_message'
+  | 'sign_transaction'
+  | 'access_code'
+  | 'region_ok'
+  | 'deposit'
+  | 'risk_reduction';
+
+export interface PerpsReadiness {
+  venueId: PerpsVenueId;
+  status: PerpsReadinessStatus;
+  canView: boolean;
+  canDeposit: boolean;
+  canWithdraw: boolean;
+  canTrade: boolean;
+  canCancel: boolean;
+  wallet: PerpsWalletCapabilities;
+  reasonCode?: PerpsErrorCode;
+  message?: string;
+  requirements?: readonly PerpsReadinessRequirement[];
+}
+
+export interface PerpsAccount {
+  venueId: PerpsVenueId;
+  authority: string;
+  accountId?: string | null;
+  portfolioIndex?: number | null;
+  subaccountIndex?: number | null;
+  status: 'active' | 'missing' | 'restricted' | 'liquidatable' | 'unknown';
+  equity: number | null;
+  availableToSpend: number | null;
+  availableToWithdraw: number | null;
+  totalMarginUsed: number | null;
+  unrealizedPnl?: number | null;
+  positionsCount: number;
+  ordersCount: number;
+  riskTier?: string | null;
+  updatedAt?: number | null;
+  raw?: unknown;
+}
+
+export interface PerpsBalanceSummary {
+  venueId: PerpsVenueId;
+  authority: string;
+  walletUsdc?: number | null;
+  venueCollateralUsdc?: number | null;
+  pendingDepositUsdc?: number | null;
+  pendingWithdrawUsdc?: number | null;
+  withdrawQueueState?: 'none' | 'queued' | 'processing' | 'failed' | 'unknown';
+}
+
+export interface PerpsPosition {
+  id: string;
+  venueId: PerpsVenueId;
+  symbol: string;
+  venueSymbol: string;
+  side: PerpsSide;
+  marginMode: PerpsMarginMode;
+  size: number;
+  sizeRaw?: string | null;
+  notionalUsd?: number | null;
+  entryPrice: number | null;
+  markPrice: number | null;
+  liquidationPrice?: number | null;
+  leverage?: number | null;
+  unrealizedPnl: number | null;
+  unrealizedPnlPct: number | null;
+  fundingPnl?: number | null;
+  takeProfitPrice?: number | null;
+  stopLossPrice?: number | null;
+  openedAt?: number | null;
+  updatedAt?: number | null;
+  raw?: unknown;
+}
+
+export type PerpsOrderStatus =
+  | 'open'
+  | 'pending'
+  | 'filled'
+  | 'cancel_requested'
+  | 'cancelled'
+  | 'rejected'
+  | 'unknown';
+
+export interface PerpsOrder {
+  id: string;
+  venueId: PerpsVenueId;
+  venueOrderId?: string | number | null;
+  clientOrderId?: string | null;
+  symbol: string;
+  venueSymbol: string;
+  side: PerpsSide;
+  venueSide?: PerpsVenueSide;
+  orderKind: PerpsOrderKind;
+  status: PerpsOrderStatus;
+  price: number | null;
+  triggerPrice?: number | null;
+  stopPrice?: number | null;
+  size: number | null;
+  filledSize?: number | null;
+  remainingSize?: number | null;
+  reduceOnly: boolean;
+  postOnly?: boolean;
+  timeInForce?: PerpsTimeInForce;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  raw?: unknown;
+}
+
+export interface PerpsTpSlInput {
+  takeProfitTriggerPrice?: string;
+  takeProfitLimitPrice?: string;
+  stopLossTriggerPrice?: string;
+  stopLossLimitPrice?: string;
+  executionType?: 'market' | 'limit';
+}
+
+export interface PerpsOrderInput {
+  venueId: PerpsVenueId;
+  authority: string;
+  symbol: string;
+  side: PerpsSide;
+  orderType: 'market' | 'limit';
+  amountMode: 'notional_usdc' | 'base';
+  amount: string;
+  limitPrice?: string;
+  slippageBps?: number;
+  reduceOnly?: boolean;
+  postOnly?: boolean;
+  timeInForce?: PerpsTimeInForce;
+  tpSl?: PerpsTpSlInput;
+  clientOrderId?: string;
+}
+
+export interface PerpsTransferInput {
+  venueId: PerpsVenueId;
+  authority: string;
+  amountUsdc: string;
+}
+
+export interface PerpsCancelOrderInput {
+  venueId: PerpsVenueId;
+  authority: string;
+  order: Pick<PerpsOrder, 'id' | 'venueOrderId' | 'symbol' | 'venueSymbol' | 'orderKind' | 'raw'>;
+}
+
+export interface PerpsSetTpSlInput {
+  venueId: PerpsVenueId;
+  authority: string;
+  symbol: string;
+  positionId?: string;
+  tpSl: PerpsTpSlInput;
+}
+
+export interface PerpsBuiltTransaction {
+  venueId: PerpsVenueId;
+  mode: 'solana_transaction';
+  action: PerpsAction;
+  instructions: readonly PerpsInstructionDto[];
+  estimatedLiquidationPrice?: number | null;
+  warnings?: readonly string[];
+  raw?: unknown;
+}
+
+export interface PerpsInstructionDto {
+  programId: string;
+  keys: readonly PerpsInstructionAccountMeta[];
+  data: string;
+}
+
+export interface PerpsInstructionAccountMeta {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+
+export interface PerpsExecutionResult {
+  venueId: PerpsVenueId;
+  action: PerpsAction;
+  status: 'built' | 'submitted' | 'confirmed' | 'partial_success' | 'failed';
+  mode?: PerpsExecutionMode;
+  orderId?: string | null;
+  txSignature?: string | null;
+  operationId?: string | null;
+  warnings?: readonly string[];
+  refreshAfterMs?: number;
+  error?: PerpsError;
+}
+
+export type PerpsErrorCode =
+  | 'WALLET_DISCONNECTED'
+  | 'WALLET_PREPARING'
+  | 'WALLET_MESSAGE_UNSUPPORTED'
+  | 'WALLET_TX_UNSUPPORTED'
+  | 'WALLET_REJECTED'
+  | 'ACCESS_REQUIRED'
+  | 'REGION_BLOCKED'
+  | 'ACCOUNT_MISSING'
+  | 'DEPOSIT_REQUIRED'
+  | 'INSUFFICIENT_WALLET_USDC'
+  | 'INSUFFICIENT_COLLATERAL'
+  | 'AMOUNT_TOO_SMALL'
+  | 'PRICE_TICK_INVALID'
+  | 'UNSUPPORTED_INTERVAL'
+  | 'MARKET_INACTIVE'
+  | 'RISK_BLOCKED'
+  | 'REDUCE_ONLY_WOULD_INCREASE'
+  | 'SLIPPAGE_EXCEEDED'
+  | 'ORDER_NOT_FILLED'
+  | 'ORDER_NOT_FOUND'
+  | 'TX_BUILD_FAILED'
+  | 'TX_SEND_FAILED'
+  | 'TX_EXPIRED'
+  | 'TX_UNCONFIRMED'
+  | 'WITHDRAW_QUEUED'
+  | 'RATE_LIMITED'
+  | 'UPSTREAM_UNAVAILABLE'
+  | 'DATA_STALE'
+  | 'UNKNOWN';
+
+export interface PerpsError {
+  code: PerpsErrorCode;
+  message: string;
+  retryable: boolean;
+  venueId?: PerpsVenueId;
+  cause?: unknown;
+}
+
+export interface PerpsCandleQuery {
+  symbol: string;
+  interval: PerpsCandleInterval;
+  count?: number;
+  startTime?: number;
+  endTime?: number;
+}
+
+export interface PerpsReadinessInput {
+  authority: string | null;
+  wallet: PerpsWalletCapabilities;
+  symbol?: string;
+}
+
+export interface PerpsPublicDataAdapter {
+  descriptor: PerpsVenueDescriptor;
+  getMarkets(): Promise<readonly PerpsMarket[]>;
+  getMarket(symbol: string): Promise<PerpsMarket>;
+  getCandles(query: PerpsCandleQuery): Promise<readonly PerpsCandle[]>;
+  getAccount(authority: string): Promise<PerpsAccount | null>;
+  getPositions(authority: string): Promise<readonly PerpsPosition[]>;
+  getOpenOrders(authority: string): Promise<readonly PerpsOrder[]>;
+  subscribeMarket?(symbol: string, onUpdate: (update: PerpsLiveMarketUpdate) => void): () => void;
+}
+
+export interface PerpsExecutionAdapter {
+  descriptor: PerpsVenueDescriptor;
+  getReadiness(input: PerpsReadinessInput): Promise<PerpsReadiness>;
+  deposit(input: PerpsTransferInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+  withdraw(input: PerpsTransferInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+  placeOrder(input: PerpsOrderInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+  closePosition(input: PerpsOrderInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+  cancelOrder(input: PerpsCancelOrderInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+  setTpSl(input: PerpsSetTpSlInput, context?: PerpsExecutionContext): Promise<PerpsExecutionResult>;
+}

--- a/apps/hybrid-expo/features/perps/perps.registry.ts
+++ b/apps/hybrid-expo/features/perps/perps.registry.ts
@@ -1,0 +1,138 @@
+import {
+  PACIFIC_ENV,
+  PACIFIC_MIN_DEPOSIT,
+  PACIFIC_REST,
+  PACIFIC_WS,
+  USDC_LABEL,
+  USDC_MINT,
+} from '@/features/perps/pacific.config';
+import type { PerpsCandleInterval, PerpsVenueDescriptor, PerpsVenueId } from '@/features/perps/perps.contract';
+import { PERPS_VENUE_IDS } from '@/features/perps/perps.contract';
+
+export const PACIFICA_SUPPORTED_INTERVALS = [
+  '1m',
+  '3m',
+  '5m',
+  '15m',
+  '30m',
+  '1h',
+  '2h',
+  '4h',
+  '8h',
+  '12h',
+  '1d',
+] as const satisfies readonly PerpsCandleInterval[];
+
+export const PHOENIX_SUPPORTED_INTERVALS = [
+  '1s',
+  '5s',
+  '1m',
+  '5m',
+  '15m',
+  '30m',
+  '1h',
+  '4h',
+  '1d',
+] as const satisfies readonly PerpsCandleInterval[];
+
+export const PACIFICA_VENUE_DESCRIPTOR = {
+  venueId: 'pacifica',
+  displayName: 'Pacifica',
+  shortName: 'Pacifica',
+  routeBase: '/trade',
+  apiBasePath: '/perps/pacifica',
+  env: PACIFIC_ENV,
+  integrationStatus: 'active',
+  quoteAsset: 'USDC',
+  defaultCollateralAsset: USDC_LABEL,
+  publicRestBaseUrl: PACIFIC_REST,
+  publicWsBaseUrl: PACIFIC_WS,
+  collateralMint: USDC_MINT,
+  minDepositUsdc: PACIFIC_MIN_DEPOSIT,
+  supportedIntervals: PACIFICA_SUPPORTED_INTERVALS,
+  defaultInterval: '15m',
+  capabilities: {
+    publicMarkets: true,
+    candles: true,
+    liveMarketData: true,
+    accountRead: true,
+    positionsRead: true,
+    ordersRead: true,
+    deposit: true,
+    withdraw: true,
+    marketOrder: true,
+    limitOrder: true,
+    cancelOrder: true,
+    closePosition: true,
+    takeProfitStopLoss: true,
+    history: false,
+    messageSigningExecution: true,
+    transactionSigningExecution: true,
+  },
+  notes: ['Current /trade behavior remains Pacifica-first while shared perps adapters are introduced.'],
+} as const satisfies PerpsVenueDescriptor;
+
+export const PHOENIX_VENUE_DESCRIPTOR = {
+  venueId: 'phoenix',
+  displayName: 'Phoenix',
+  shortName: 'Phoenix',
+  routeBase: '/markets/phoenix',
+  apiBasePath: '/perps/phoenix',
+  env: 'mainnet',
+  integrationStatus: 'read_only',
+  quoteAsset: 'USD',
+  defaultCollateralAsset: 'USDC',
+  publicRestBaseUrl: 'https://perp-api.phoenix.trade',
+  publicWsBaseUrl: 'wss://perp-api.phoenix.trade/v1/ws',
+  supportedIntervals: PHOENIX_SUPPORTED_INTERVALS,
+  defaultInterval: '15m',
+  capabilities: {
+    publicMarkets: true,
+    candles: true,
+    liveMarketData: false,
+    accountRead: false,
+    positionsRead: false,
+    ordersRead: false,
+    deposit: false,
+    withdraw: false,
+    marketOrder: false,
+    limitOrder: false,
+    cancelOrder: false,
+    closePosition: false,
+    takeProfitStopLoss: false,
+    history: false,
+    messageSigningExecution: false,
+    transactionSigningExecution: false,
+    accessCodeRequired: true,
+    regionRestricted: true,
+    readOnly: true,
+    incomplete: true,
+  },
+  notes: [
+    'Phoenix is registered for contract compatibility only.',
+    'Keep trading disabled until Solana execution adapters and wallet readiness are ready.',
+  ],
+} as const satisfies PerpsVenueDescriptor;
+
+export const PERPS_DEFAULT_VENUE_ID: PerpsVenueId = 'pacifica';
+
+export const PERPS_VENUE_DESCRIPTORS = {
+  pacifica: PACIFICA_VENUE_DESCRIPTOR,
+  phoenix: PHOENIX_VENUE_DESCRIPTOR,
+} as const satisfies Record<PerpsVenueId, PerpsVenueDescriptor>;
+
+export function isPerpsVenueId(value: string | null | undefined): value is PerpsVenueId {
+  return typeof value === 'string' && (PERPS_VENUE_IDS as readonly string[]).includes(value);
+}
+
+export function getPerpsVenueDescriptor(venueId: PerpsVenueId = PERPS_DEFAULT_VENUE_ID): PerpsVenueDescriptor {
+  return PERPS_VENUE_DESCRIPTORS[venueId];
+}
+
+export function listPerpsVenueDescriptors(): readonly PerpsVenueDescriptor[] {
+  return PERPS_VENUE_IDS.map((venueId) => PERPS_VENUE_DESCRIPTORS[venueId]);
+}
+
+export function getPerpsSupportedIntervals(venueId: PerpsVenueId): readonly PerpsCandleInterval[] {
+  return PERPS_VENUE_DESCRIPTORS[venueId].supportedIntervals;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,7 @@ import { logger } from 'hono/logger'
 import { serve } from '@hono/node-server'
 import { clobRoutes } from './clob.js'
 import { pacificaRoutes } from './pacifica.js'
+import { phoenixRoutes } from './phoenix.js'
 import { CURATED_GEOPOLITICS_SLUGS, deriveCategoryFromText } from './curated.js'
 import type { SupportedSport } from './curated.js'
 import {
@@ -497,6 +498,9 @@ app.route('/clob', clobRoutes)
 
 // --- Pacifica perps proxy routes ---
 app.route('/perps/pacifica', pacificaRoutes)
+
+// --- Phoenix perps read-only proxy routes ---
+app.route('/perps/phoenix', phoenixRoutes)
 
 // GET /health
 app.get('/health', (c) => {

--- a/packages/api/src/phoenix.ts
+++ b/packages/api/src/phoenix.ts
@@ -1,0 +1,517 @@
+import { Hono } from 'hono'
+
+const PHOENIX_API_BASE = process.env.PHOENIX_API_BASE || 'https://perp-api.phoenix.trade'
+const REQUEST_TIMEOUT_MS = parseEnvInt('PHOENIX_REQUEST_TIMEOUT_MS', 10_000)
+const STATUS_CACHE_TTL_MS = parseEnvInt('PHOENIX_STATUS_CACHE_TTL_MS', 15_000)
+const MARKETS_CACHE_TTL_MS = parseEnvInt('PHOENIX_MARKETS_CACHE_TTL_MS', 60_000)
+const CANDLES_CACHE_TTL_MS = parseEnvInt('PHOENIX_CANDLES_CACHE_TTL_MS', 15_000)
+const MAX_CANDLE_LIMIT = parseEnvInt('PHOENIX_MAX_CANDLE_LIMIT', 500)
+
+const SUPPORTED_CANDLE_INTERVALS = new Set(['1m', '5m', '15m', '30m', '1h', '4h', '1d'])
+
+type CacheEntry<T> = {
+  data: T
+  fetchedAt: number
+  expiresAt: number
+}
+
+interface PhoenixLeverageTier {
+  maxLeverage?: unknown
+  maxSizeBaseLots?: unknown
+  limitOrderRiskFactor?: unknown
+}
+
+interface PhoenixFundingConfig {
+  fundingIntervalSeconds?: unknown
+  fundingPeriodSeconds?: unknown
+  maxFundingRatePerInterval?: unknown
+}
+
+interface PhoenixMarketConfig {
+  symbol?: unknown
+  assetId?: unknown
+  marketStatus?: unknown
+  marketPubkey?: unknown
+  splinePubkey?: unknown
+  tickSize?: unknown
+  baseLotsDecimals?: unknown
+  takerFee?: unknown
+  makerFee?: unknown
+  leverageTiers?: PhoenixLeverageTier[]
+  riskFactors?: unknown
+  fundingIntervalSeconds?: unknown
+  fundingPeriodSeconds?: unknown
+  fundingConfig?: PhoenixFundingConfig
+  maxFundingRatePerInterval?: unknown
+  maxFundingRatePerIntervalPercentage?: unknown
+  openInterestCapBaseLots?: unknown
+  maxLiquidationSizeBaseLots?: unknown
+  isolatedOnly?: unknown
+  commodityMetadata?: unknown
+  markPriceParameters?: unknown
+}
+
+interface PhoenixExchangeSnapshot {
+  version?: unknown
+  slot?: unknown
+  slotIndex?: unknown
+  sequenceNumber?: unknown
+  exchange?: {
+    active?: unknown
+    gated?: unknown
+    exchangeStatusBits?: unknown
+    exchangeStatusFeatures?: unknown
+    programId?: unknown
+    canonicalMint?: unknown
+    usdcMint?: unknown
+  }
+  markets?: PhoenixMarketConfig[]
+}
+
+interface PhoenixCandle {
+  time?: unknown
+  open?: unknown
+  high?: unknown
+  low?: unknown
+  close?: unknown
+  volume?: unknown
+  volumeQuote?: unknown
+  tradeCount?: unknown
+  markOpen?: unknown
+  markHigh?: unknown
+  markLow?: unknown
+  markClose?: unknown
+  externalSource?: unknown
+}
+
+interface NormalizedPhoenixMarket {
+  venueId: 'phoenix'
+  symbol: string
+  venueSymbol: string
+  baseSymbol: string
+  quoteSymbol: 'USDC'
+  status: string
+  marketStatus: string
+  tradeable: boolean
+  maxLeverage: number | null
+  tickSize: string | null
+  lotSize: string | null
+  minOrderSize: string | null
+  markPrice: number | null
+  oraclePrice: number | null
+  midPrice: number | null
+  fundingRate: number | null
+  openInterest: number | null
+  volume24h: number | null
+  change24h: number | null
+  yesterdayPrice: number | null
+  iconPath: string | null
+  dataFreshness: 'partial'
+  dataFreshnessReason: string
+  configFetchedAt: string
+  precision: {
+    tickSize: string | null
+    rawTickSize: number | string | null
+    baseLotsDecimals: number | null
+  }
+  limits: {
+    openInterestCapBaseLots: string | null
+    maxLiquidationSizeBaseLots: string | null
+    leverageTiers: PhoenixLeverageTier[]
+  }
+  fees: {
+    makerFee: number | null
+    takerFee: number | null
+  }
+  funding: {
+    fundingIntervalSeconds: number | null
+    fundingPeriodSeconds: number | null
+    maxFundingRatePerInterval: string | null
+    maxFundingRatePerIntervalPercentage: number | null
+  }
+  metadata: {
+    assetId: number | null
+    marketPubkey: string | null
+    splinePubkey: string | null
+    isolatedOnly: boolean | null
+    riskFactors: unknown
+    commodityMetadata: unknown
+    markPriceParameters?: unknown
+  }
+}
+
+const statusCache = new Map<string, CacheEntry<PhoenixExchangeSnapshot>>()
+const marketsCache = new Map<string, CacheEntry<PhoenixMarketConfig[]>>()
+const candlesCache = new Map<string, CacheEntry<unknown[]>>()
+
+function parseEnvInt(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function asRecord(input: unknown): Record<string, unknown> | null {
+  return input && typeof input === 'object' ? input as Record<string, unknown> : null
+}
+
+function asString(input: unknown): string | null {
+  return typeof input === 'string' && input.length > 0 ? input : null
+}
+
+function asBoolean(input: unknown): boolean | null {
+  return typeof input === 'boolean' ? input : null
+}
+
+function parseNullableNumber(input: unknown): number | null {
+  if (typeof input === 'number') return Number.isFinite(input) ? input : null
+  if (typeof input !== 'string') return null
+  const parsed = Number.parseFloat(input)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseNullableInt(input: unknown): number | null {
+  const value = parseNullableNumber(input)
+  return value === null ? null : Math.trunc(value)
+}
+
+function stringifyNullable(input: unknown): string | null {
+  if (typeof input === 'string') return input
+  if (typeof input === 'number' && Number.isFinite(input)) return String(input)
+  if (typeof input === 'bigint') return input.toString()
+  return null
+}
+
+function rawNumberOrString(input: unknown): number | string | null {
+  if (typeof input === 'number' && Number.isFinite(input)) return input
+  if (typeof input === 'string') return input
+  return null
+}
+
+function normalizeVenueSymbol(input: string | null | undefined): string | null {
+  if (!input) return null
+  const normalized = input.trim().toUpperCase().replace(/-PERP$/, '')
+  return /^[A-Z0-9]{1,24}$/.test(normalized) ? normalized : null
+}
+
+function appSymbolFromVenueSymbol(venueSymbol: string): string {
+  return `${venueSymbol}-PERP`
+}
+
+function maxLeverage(leverageTiers: PhoenixLeverageTier[] | undefined): number | null {
+  if (!Array.isArray(leverageTiers)) return null
+  const leverages = leverageTiers
+    .map((tier) => parseNullableNumber(tier.maxLeverage))
+    .filter((value): value is number => value !== null)
+  if (leverages.length === 0) return null
+  return Math.max(...leverages)
+}
+
+function fundingConfig(market: PhoenixMarketConfig): PhoenixFundingConfig {
+  return {
+    fundingIntervalSeconds: market.fundingConfig?.fundingIntervalSeconds ?? market.fundingIntervalSeconds,
+    fundingPeriodSeconds: market.fundingConfig?.fundingPeriodSeconds ?? market.fundingPeriodSeconds,
+    maxFundingRatePerInterval: market.fundingConfig?.maxFundingRatePerInterval ?? market.maxFundingRatePerInterval,
+  }
+}
+
+async function phoenixFetchJson<T>(path: string): Promise<T> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const res = await fetch(`${PHOENIX_API_BASE}${path}`, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    })
+
+    if (!res.ok) {
+      const upstreamBody = await res.text().catch(() => '')
+      throw new PhoenixUpstreamError(res.status, upstreamBody)
+    }
+
+    return await res.json() as T
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+class PhoenixUpstreamError extends Error {
+  constructor(readonly status: number, readonly upstreamBody: string) {
+    super(`Phoenix upstream failed (${status})`)
+  }
+}
+
+async function cachedJson<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+): Promise<CacheEntry<T>> {
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > now) return cached
+
+  const data = await fetcher()
+  const entry = { data, fetchedAt: now, expiresAt: now + ttlMs }
+  cache.set(key, entry)
+  return entry
+}
+
+async function getExchangeSnapshot(): Promise<CacheEntry<PhoenixExchangeSnapshot>> {
+  return cachedJson(statusCache, 'snapshot', STATUS_CACHE_TTL_MS, () => (
+    phoenixFetchJson<PhoenixExchangeSnapshot>('/v1/exchange/snapshot')
+  ))
+}
+
+async function getRawMarkets(): Promise<CacheEntry<PhoenixMarketConfig[]>> {
+  return cachedJson(marketsCache, 'markets', MARKETS_CACHE_TTL_MS, () => (
+    phoenixFetchJson<PhoenixMarketConfig[]>('/exchange/markets')
+  ))
+}
+
+async function getMarketByVenueSymbol(venueSymbol: string): Promise<{ market: PhoenixMarketConfig; fetchedAt: number } | null> {
+  const entry = await getRawMarkets()
+  const market = entry.data.find((candidate) => normalizeVenueSymbol(asString(candidate.symbol)) === venueSymbol)
+  return market ? { market, fetchedAt: entry.fetchedAt } : null
+}
+
+function normalizeMarket(market: PhoenixMarketConfig, fetchedAt: number): NormalizedPhoenixMarket | null {
+  const venueSymbol = normalizeVenueSymbol(asString(market.symbol))
+  if (!venueSymbol) return null
+
+  const marketStatus = asString(market.marketStatus) ?? 'unknown'
+  const config = fundingConfig(market)
+
+  return {
+    venueId: 'phoenix',
+    symbol: appSymbolFromVenueSymbol(venueSymbol),
+    venueSymbol,
+    baseSymbol: venueSymbol,
+    quoteSymbol: 'USDC',
+    status: marketStatus,
+    marketStatus,
+    tradeable: marketStatus === 'active',
+    maxLeverage: maxLeverage(market.leverageTiers),
+    tickSize: stringifyNullable(market.tickSize),
+    lotSize: null,
+    minOrderSize: null,
+    markPrice: null,
+    oraclePrice: null,
+    midPrice: null,
+    fundingRate: null,
+    openInterest: null,
+    volume24h: null,
+    change24h: null,
+    yesterdayPrice: null,
+    iconPath: null,
+    dataFreshness: 'partial',
+    dataFreshnessReason: 'Phoenix REST market config does not include WS-only mark, mid, oracle, funding, open interest, or 24h volume stats in this slice.',
+    configFetchedAt: new Date(fetchedAt).toISOString(),
+    precision: {
+      tickSize: stringifyNullable(market.tickSize),
+      rawTickSize: rawNumberOrString(market.tickSize),
+      baseLotsDecimals: parseNullableInt(market.baseLotsDecimals),
+    },
+    limits: {
+      openInterestCapBaseLots: stringifyNullable(market.openInterestCapBaseLots),
+      maxLiquidationSizeBaseLots: stringifyNullable(market.maxLiquidationSizeBaseLots),
+      leverageTiers: Array.isArray(market.leverageTiers) ? market.leverageTiers : [],
+    },
+    fees: {
+      makerFee: parseNullableNumber(market.makerFee),
+      takerFee: parseNullableNumber(market.takerFee),
+    },
+    funding: {
+      fundingIntervalSeconds: parseNullableInt(config.fundingIntervalSeconds),
+      fundingPeriodSeconds: parseNullableInt(config.fundingPeriodSeconds),
+      maxFundingRatePerInterval: stringifyNullable(config.maxFundingRatePerInterval),
+      maxFundingRatePerIntervalPercentage: parseNullableNumber(market.maxFundingRatePerIntervalPercentage),
+    },
+    metadata: {
+      assetId: parseNullableInt(market.assetId),
+      marketPubkey: asString(market.marketPubkey),
+      splinePubkey: asString(market.splinePubkey),
+      isolatedOnly: asBoolean(market.isolatedOnly),
+      riskFactors: market.riskFactors ?? null,
+      commodityMetadata: market.commodityMetadata ?? null,
+      markPriceParameters: market.markPriceParameters,
+    },
+  }
+}
+
+function normalizedStatus(snapshot: CacheEntry<PhoenixExchangeSnapshot>) {
+  const exchange = snapshot.data.exchange ?? {}
+  return {
+    venueId: 'phoenix',
+    status: asBoolean(exchange.active) ? 'active' : 'inactive',
+    active: asBoolean(exchange.active) ?? false,
+    gated: asBoolean(exchange.gated) ?? null,
+    slot: parseNullableInt(snapshot.data.slot),
+    slotIndex: parseNullableInt(snapshot.data.slotIndex),
+    version: parseNullableInt(snapshot.data.version),
+    sequenceNumber: stringifyNullable(snapshot.data.sequenceNumber),
+    features: Array.isArray(exchange.exchangeStatusFeatures) ? exchange.exchangeStatusFeatures : [],
+    exchangeStatusBits: parseNullableInt(exchange.exchangeStatusBits),
+    programId: asString(exchange.programId),
+    canonicalMint: asString(exchange.canonicalMint),
+    usdcMint: asString(exchange.usdcMint),
+    dataFreshness: 'snapshot',
+    fetchedAt: new Date(snapshot.fetchedAt).toISOString(),
+  }
+}
+
+function parseCandleLimit(input: string | undefined): number {
+  const parsed = Number.parseInt(input ?? '100', 10)
+  if (!Number.isFinite(parsed) || parsed < 1) return 100
+  return Math.min(parsed, MAX_CANDLE_LIMIT)
+}
+
+function appendOptionalQuery(params: URLSearchParams, name: string, value: string | undefined): void {
+  if (value !== undefined && value.trim() !== '') params.set(name, value)
+}
+
+function normalizeCandle(raw: unknown) {
+  const candle = asRecord(raw) as PhoenixCandle | null
+  if (!candle) return null
+
+  const time = parseNullableInt(candle.time)
+  const open = parseNullableNumber(candle.open)
+  const high = parseNullableNumber(candle.high)
+  const low = parseNullableNumber(candle.low)
+  const close = parseNullableNumber(candle.close)
+  if (time === null || open === null || high === null || low === null || close === null) return null
+
+  return {
+    time,
+    open,
+    close,
+    high,
+    low,
+    volume: parseNullableNumber(candle.volume) ?? 0,
+    volumeQuote: parseNullableNumber(candle.volumeQuote),
+    tradeCount: parseNullableInt(candle.tradeCount),
+    mark: {
+      open: parseNullableNumber(candle.markOpen),
+      high: parseNullableNumber(candle.markHigh),
+      low: parseNullableNumber(candle.markLow),
+      close: parseNullableNumber(candle.markClose),
+    },
+    externalSource: asString(candle.externalSource),
+  }
+}
+
+function upstreamStatusCode(err: unknown): 429 | 502 {
+  if (err instanceof PhoenixUpstreamError && err.status === 429) return 429
+  return 502
+}
+
+function upstreamErrorPayload(err: unknown, fallback: string) {
+  if (err instanceof PhoenixUpstreamError) {
+    const upstream = err.upstreamBody ? asRecord(safeJsonParse(err.upstreamBody)) : null
+    const upstreamError = upstream?.error
+    return {
+      error: typeof upstreamError === 'string' ? upstreamError : fallback,
+      upstreamStatus: err.status,
+    }
+  }
+  return { error: fallback }
+}
+
+function safeJsonParse(input: string): unknown {
+  try {
+    return JSON.parse(input) as unknown
+  } catch {
+    return null
+  }
+}
+
+export const phoenixRoutes = new Hono()
+
+// GET /perps/phoenix/health
+phoenixRoutes.get('/health', (c) => {
+  return c.json({
+    venueId: 'phoenix',
+    status: 'ok',
+    upstreamBase: PHOENIX_API_BASE,
+    readOnly: true,
+  })
+})
+
+// GET /perps/phoenix/status
+phoenixRoutes.get('/status', async (c) => {
+  try {
+    return c.json(normalizedStatus(await getExchangeSnapshot()))
+  } catch (err) {
+    console.error('[api] Phoenix status unavailable:', err instanceof Error ? err.message : err)
+    return c.json(upstreamErrorPayload(err, 'Phoenix status unavailable'), upstreamStatusCode(err))
+  }
+})
+
+// GET /perps/phoenix/markets
+phoenixRoutes.get('/markets', async (c) => {
+  try {
+    const markets = await getRawMarkets()
+    const data = markets.data
+      .map((market) => normalizeMarket(market, markets.fetchedAt))
+      .filter((market): market is NormalizedPhoenixMarket => market !== null)
+      .sort((a, b) => a.baseSymbol.localeCompare(b.baseSymbol))
+
+    return c.json(data)
+  } catch (err) {
+    console.error('[api] Phoenix markets unavailable:', err instanceof Error ? err.message : err)
+    return c.json(upstreamErrorPayload(err, 'Phoenix markets unavailable'), upstreamStatusCode(err))
+  }
+})
+
+// GET /perps/phoenix/markets/:symbol
+phoenixRoutes.get('/markets/:symbol', async (c) => {
+  const venueSymbol = normalizeVenueSymbol(c.req.param('symbol'))
+  if (!venueSymbol) return c.json({ error: 'Invalid Phoenix market symbol' }, 400)
+
+  try {
+    const result = await getMarketByVenueSymbol(venueSymbol)
+    if (!result) return c.json({ error: 'Phoenix market not found' }, 404)
+
+    const market = normalizeMarket(result.market, result.fetchedAt)
+    if (!market) return c.json({ error: 'Phoenix market not found' }, 404)
+
+    return c.json(market)
+  } catch (err) {
+    console.error(`[api] Phoenix market ${venueSymbol} unavailable:`, err instanceof Error ? err.message : err)
+    return c.json(upstreamErrorPayload(err, 'Phoenix market unavailable'), upstreamStatusCode(err))
+  }
+})
+
+// GET /perps/phoenix/candles?symbol=&interval=&count=&startTime=&endTime=
+phoenixRoutes.get('/candles', async (c) => {
+  const venueSymbol = normalizeVenueSymbol(c.req.query('symbol'))
+  if (!venueSymbol) return c.json({ error: 'Missing or invalid symbol' }, 400)
+
+  const interval = c.req.query('interval') ?? '1h'
+  if (!SUPPORTED_CANDLE_INTERVALS.has(interval)) {
+    return c.json({
+      error: 'Unsupported Phoenix candle interval',
+      code: 'UNSUPPORTED_INTERVAL',
+      supportedIntervals: [...SUPPORTED_CANDLE_INTERVALS],
+    }, 400)
+  }
+
+  try {
+    const knownMarket = await getMarketByVenueSymbol(venueSymbol)
+    if (!knownMarket) return c.json({ error: 'Phoenix market not found' }, 404)
+
+    const limit = parseCandleLimit(c.req.query('count') ?? c.req.query('limit'))
+    const params = new URLSearchParams({ symbol: venueSymbol, timeframe: interval, limit: String(limit) })
+    appendOptionalQuery(params, 'startTime', c.req.query('startTime'))
+    appendOptionalQuery(params, 'endTime', c.req.query('endTime'))
+    appendOptionalQuery(params, 'enableExternalSource', c.req.query('enableExternalSource'))
+
+    const cacheKey = params.toString()
+    const raw = await cachedJson(candlesCache, cacheKey, CANDLES_CACHE_TTL_MS, () => (
+      phoenixFetchJson<unknown[]>(`/candles?${cacheKey}`)
+    ))
+    const candles = raw.data.map(normalizeCandle).filter((candle): candle is NonNullable<ReturnType<typeof normalizeCandle>> => candle !== null)
+    return c.json(candles)
+  } catch (err) {
+    console.error(`[api] Phoenix candles ${venueSymbol} unavailable:`, err instanceof Error ? err.message : err)
+    return c.json(upstreamErrorPayload(err, 'Phoenix candles unavailable'), upstreamStatusCode(err))
+  }
+})


### PR DESCRIPTION
## Summary

- Add an additive shared perps contract scaffold for venue-aware Pacifica/Phoenix work.
- Add perps venue descriptors for Pacifica and Phoenix, with Phoenix marked read-only for public markets/candles and trading disabled.
- Add a Phoenix backend read-only proxy mounted at `/perps/phoenix` with health/status/markets/market detail/candles routes.

## Why

This is the first implementation slice from Markets Platform v1.2.5 after the Markets launcher. It gives frontend/backend a typed venue surface and a Phoenix read-only API bridge before any execution or deposit work lands.

## Validation

- `pnpm --filter hybrid-expo exec eslint features/perps/perps.contract.ts features/perps/perps.registry.ts features/perps/perps.api.ts`
- `pnpm --filter @myboon/api exec tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext --types node src/phoenix.ts`
- `git diff --check -- apps/hybrid-expo/features/perps/perps.contract.ts apps/hybrid-expo/features/perps/perps.registry.ts apps/hybrid-expo/features/perps/perps.api.ts packages/api/src/phoenix.ts packages/api/src/index.ts`

Notes:
- Full Expo lint passed before this branch and targeted frontend lint passed after this branch.
- Full API typecheck still has pre-existing unrelated `src/index.ts` sports typing errors called out by the backend worker.

## Tracking

Related to #162, #163, #165.
Stacked on #169 while the Markets launcher PR is open.
