### PR TITLE
[codex] Track Polymarket operation lifecycle

### DIFF
--- a/apps/hybrid-expo/components/predict/DepositModal.tsx
+++ b/apps/hybrid-expo/components/predict/DepositModal.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { semantic, tokens } from '@/theme';
 import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
 import { fetchClobBalance, fetchDepositStatus } from '@/features/predict/predict.api';
@@ -67,6 +68,7 @@ interface DepositStatusView {
 const DEPOSIT_POLL_MS = 10_000;
 const DELAYED_AFTER_MS = 5 * 60_000;
 const TRANSACTION_TIME_TOLERANCE_MS = 30_000;
+const DEPOSIT_TRACKING_STORAGE_PREFIX = 'predict.deposit.tracking.v1';
 
 function transactionKey(transaction: DepositBridgeTransaction): string {
   return [
@@ -170,7 +172,11 @@ export function DepositModal({
   const [trackedDeposit, setTrackedDeposit] = useState<TrackedDeposit | null>(null);
   const [statusView, setStatusView] = useState<DepositStatusView | null>(null);
   const [statusLoading, setStatusLoading] = useState(false);
+  const [trackingStorageKey, setTrackingStorageKey] = useState<string | null>(null);
   const fundsNotifiedRef = useRef(false);
+  const storageKey = polygonAddress && depositWalletAddress
+    ? `${DEPOSIT_TRACKING_STORAGE_PREFIX}:${polygonAddress.toLowerCase()}:${depositWalletAddress.toLowerCase()}`
+    : null;
 
   useEffect(() => {
     if (!isOpen || !depositWalletAddress) return;
@@ -196,15 +202,63 @@ export function DepositModal({
   useEffect(() => {
     if (!isOpen) {
       setCopied(null);
-      setTrackedDeposit(null);
-      setStatusView(null);
       setStatusLoading(false);
-      fundsNotifiedRef.current = false;
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    let cancelled = false;
+    fundsNotifiedRef.current = false;
+    setCopied(null);
+    setStatusLoading(false);
+    setTrackingStorageKey(null);
+    setTrackedDeposit(null);
+    setStatusView(null);
+
+    if (!storageKey) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    AsyncStorage.getItem(storageKey)
+      .then((raw) => {
+        if (cancelled) return;
+        if (!raw) {
+          setTrackedDeposit(null);
+          setStatusView(null);
+          return;
+        }
+
+        const saved = JSON.parse(raw) as {
+          trackedDeposit?: TrackedDeposit | null;
+          statusView?: DepositStatusView | null;
+        };
+        setTrackedDeposit(saved.trackedDeposit ?? null);
+        setStatusView(saved.statusView ?? null);
+        setTrackingStorageKey(saved.trackedDeposit ? storageKey : null);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTrackedDeposit(null);
+          setStatusView(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (!storageKey || !trackedDeposit || trackingStorageKey !== storageKey) return;
+
+    AsyncStorage.setItem(storageKey, JSON.stringify({ trackedDeposit, statusView })).catch(() => {});
+  }, [statusView, storageKey, trackedDeposit, trackingStorageKey]);
+
   const refreshDepositStatus = useCallback(async () => {
     if (!trackedDeposit || !polygonAddress) return;
+    if (!storageKey || trackingStorageKey !== storageKey) return;
 
     setStatusLoading(true);
     try {
@@ -255,10 +309,11 @@ export function DepositModal({
     } finally {
       setStatusLoading(false);
     }
-  }, [onFundsAvailable, polygonAddress, trackedDeposit]);
+  }, [onFundsAvailable, polygonAddress, storageKey, trackedDeposit, trackingStorageKey]);
 
   useEffect(() => {
     if (!isOpen || !trackedDeposit) return;
+    if (!storageKey || trackingStorageKey !== storageKey) return;
 
     void refreshDepositStatus();
     const interval = setInterval(() => {
@@ -266,7 +321,7 @@ export function DepositModal({
     }, DEPOSIT_POLL_MS);
 
     return () => clearInterval(interval);
-  }, [isOpen, refreshDepositStatus, trackedDeposit]);
+  }, [isOpen, refreshDepositStatus, storageKey, trackedDeposit, trackingStorageKey]);
 
   const handleCopy = async (chain: string, address: string) => {
     await Clipboard.setStringAsync(address);
@@ -297,6 +352,7 @@ export function DepositModal({
       hasStatusSnapshot: existingTransactions.ok,
       startedAt,
     });
+    setTrackingStorageKey(storageKey);
     setStatusView({
       label: 'Waiting for deposit',
       detail: 'Send funds to the copied address. We will keep checking while this is open.',

--- a/apps/hybrid-expo/features/predict/pendingOpenOrders.test.ts
+++ b/apps/hybrid-expo/features/predict/pendingOpenOrders.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { mergeOpenOrders, prunePendingOpenOrders, reconcilePendingActions } from './pendingOpenOrders';
+import type { OpenOrder } from './predict.api';
+
+function order(id: string, assetId: string): OpenOrder {
+  return {
+    id,
+    status: 'local-pending',
+    market: 'market',
+    asset_id: assetId,
+    side: 'BUY',
+    original_size: '1',
+    size_matched: '0',
+    price: '0.5',
+    outcome: 'Yes',
+    created_at: Date.now(),
+    order_type: 'GTC',
+  };
+}
+
+const pending = [
+  order('op_pending_1', 'token-1'),
+  order('op_pending_2', 'token-1'),
+  order('op_pending_3', 'token-2'),
+];
+
+assert.deepEqual(
+  prunePendingOpenOrders(pending, [order('remote-order-1', 'token-1')], []).map((item) => item.id),
+  ['op_pending_2', 'op_pending_3'],
+);
+
+assert.deepEqual(
+  prunePendingOpenOrders(pending, [order('op_pending_2', 'token-1')], []).map((item) => item.id),
+  ['op_pending_1', 'op_pending_3'],
+);
+
+assert.deepEqual(
+  mergeOpenOrders(pending, [order('remote-order-1', 'token-1')]).map((item) => item.id),
+  ['op_pending_2', 'op_pending_3', 'remote-order-1'],
+);
+
+assert.deepEqual(
+  reconcilePendingActions(
+    [
+      { id: 'a1', type: 'buy', tokenId: 'token-1', marketSlug: 'market', outcome: 'Yes', amount: 1, shares: 1, createdAt: 1 },
+      { id: 'a2', type: 'buy', tokenId: 'token-1', marketSlug: 'market', outcome: 'Yes', amount: 1, shares: 1, createdAt: 1 },
+    ],
+    [{
+      id: 'remote',
+      status: 'waiting_to_match',
+      marketSlug: 'market',
+      eventSlug: null,
+      marketTitle: 'Market',
+      outcome: 'Yes',
+      tokenId: 'token-1',
+      conditionId: null,
+      putIn: 1,
+      currentValue: null,
+      pnl: null,
+      shares: 1,
+      avgPrice: null,
+      currentPrice: null,
+      createdAt: 1,
+      source: 'order',
+    }],
+  ).map((item) => item.id),
+  ['a2'],
+);
+
+console.log('pending open order tests passed');

--- a/apps/hybrid-expo/features/predict/pendingOpenOrders.ts
+++ b/apps/hybrid-expo/features/predict/pendingOpenOrders.ts
@@ -31,26 +31,57 @@ export function prunePendingOpenOrders(
   fetchedOrders: OpenOrder[],
   positions: PortfolioPosition[],
 ): OpenOrder[] {
+  const pendingIds = new Set(pending.map((order) => order.id).filter(Boolean));
+  const fetchedOrderIds = new Set(fetchedOrders.map((order) => order.id).filter(Boolean));
+  const remoteAssetCounts = new Map<string, number>();
+
+  for (const order of fetchedOrders) {
+    if (pendingIds.has(order.id)) continue;
+    const assetId = order.asset_id?.toLowerCase();
+    if (assetId) remoteAssetCounts.set(assetId, (remoteAssetCounts.get(assetId) ?? 0) + 1);
+  }
+  for (const position of positions) {
+    const assetId = position.asset?.toLowerCase();
+    if (assetId) remoteAssetCounts.set(assetId, (remoteAssetCounts.get(assetId) ?? 0) + 1);
+  }
+
   return pending.filter((order) => {
     const assetId = order.asset_id?.toLowerCase();
     if (!assetId) return false;
-    const fetchedOrder = fetchedOrders.some((candidate) =>
-      candidate.id === order.id || candidate.asset_id?.toLowerCase() === assetId
-    );
-    const fetchedPosition = positions.some((position) => position.asset?.toLowerCase() === assetId);
-    return !fetchedOrder && !fetchedPosition;
+    if (fetchedOrderIds.has(order.id)) return false;
+
+    const remoteCount = remoteAssetCounts.get(assetId) ?? 0;
+    if (remoteCount > 0) {
+      remoteAssetCounts.set(assetId, remoteCount - 1);
+      return false;
+    }
+
+    return true;
   });
 }
 
 export function mergeOpenOrders(pending: OpenOrder[], fetched: OpenOrder[]): OpenOrder[] {
+  const pendingIds = new Set(pending.map((order) => order.id).filter(Boolean));
   const fetchedIds = new Set(fetched.map((order) => order.id));
-  const fetchedAssets = new Set(fetched.map((order) => order.asset_id?.toLowerCase()).filter(Boolean));
-  return [
-    ...pending.filter((order) =>
-      !fetchedIds.has(order.id) && !fetchedAssets.has(order.asset_id?.toLowerCase())
-    ),
-    ...fetched,
-  ];
+  const fetchedAssetCounts = new Map<string, number>();
+  for (const order of fetched) {
+    if (pendingIds.has(order.id)) continue;
+    const assetId = order.asset_id?.toLowerCase();
+    if (assetId) fetchedAssetCounts.set(assetId, (fetchedAssetCounts.get(assetId) ?? 0) + 1);
+  }
+
+  const visiblePending = pending.filter((order) => {
+    if (fetchedIds.has(order.id)) return false;
+    const assetId = order.asset_id?.toLowerCase();
+    const remoteCount = assetId ? fetchedAssetCounts.get(assetId) ?? 0 : 0;
+    if (assetId && remoteCount > 0) {
+      fetchedAssetCounts.set(assetId, remoteCount - 1);
+      return false;
+    }
+    return true;
+  });
+
+  return [...visiblePending, ...fetched];
 }
 
 export interface PendingPredictAction {
@@ -69,10 +100,23 @@ export function reconcilePendingActions(
   pending: PendingPredictAction[],
   remoteItems: PredictActivityItem[],
 ): PendingPredictAction[] {
+  const pendingOrderIds = new Set(pending.map((action) => action.orderId).filter(Boolean));
+  const remoteOrderIds = new Set(remoteItems.map((item) => item.orderId).filter(Boolean));
+  const remoteTokenCounts = new Map<string, number>();
+  for (const item of remoteItems) {
+    if (item.orderId && pendingOrderIds.has(item.orderId)) continue;
+    if (item.tokenId) remoteTokenCounts.set(item.tokenId, (remoteTokenCounts.get(item.tokenId) ?? 0) + 1);
+  }
+
   return pending.filter((action) => {
-    return !remoteItems.some((item) =>
-      item.orderId === action.orderId
-      || (action.tokenId !== null && item.tokenId === action.tokenId)
-    );
+    if (action.orderId && remoteOrderIds.has(action.orderId)) return false;
+    if (action.tokenId !== null) {
+      const remoteCount = remoteTokenCounts.get(action.tokenId) ?? 0;
+      if (remoteCount > 0) {
+        remoteTokenCounts.set(action.tokenId, remoteCount - 1);
+        return false;
+      }
+    }
+    return true;
   });
 }

--- a/packages/api/src/clob.ts
+++ b/packages/api/src/clob.ts
@@ -23,6 +23,18 @@ import { RelayClient, TransactionType } from '@polymarket/builder-relayer-client
 import type { DepositWalletCall, Transaction } from '@polymarket/builder-relayer-client'
 import { BuilderConfig as RelayerBuilderConfig } from '@polymarket/builder-signing-sdk'
 import { encodeFunctionData, maxUint256 } from 'viem'
+import {
+  cancelStatusFromProviderPayload,
+  createOperationId,
+  findStoredOperation,
+  getStoredOperation,
+  storeOperation,
+  type OperationStoreLookup,
+  type PredictOperation,
+  type PredictOperationEnvelope,
+  type PredictOperationIdentifiers,
+  type PredictOperationStatus,
+} from './polymarket/lifecycle.js'
 
 // V2 is live on production URL after April 28 cutover
 const CLOB_HOST = process.env.CLOB_HOST || 'https://clob.polymarket.com'
@@ -242,63 +254,12 @@ const sessions = new Map<string, ClobSession>()
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000
 
-type PredictOperation =
-  | 'predict_setup'
-  | 'buy'
-  | 'sell'
-  | 'cancel'
-  | 'redeem'
-  | 'withdraw'
-  | 'deposit'
-  | 'wrap'
-  | 'predict_session'
-
-type PredictOperationStatus =
-  | 'submitted'
-  | 'waiting_to_match'
-  | 'filled'
-  | 'not_filled'
-  | 'cancel_requested'
-  | 'cancelled'
-  | 'collecting'
-  | 'bridging'
-  | 'completed'
-  | 'failed'
-  | 'session_expired'
-
-type PredictOperationIdentifiers = {
-  orderId?: string
-  tokenId?: string
-  conditionId?: string
-  txHash?: string
-  bridgeAddress?: string
-  relayerTransactionId?: string
-  tradingAddress?: string
-  depositWalletAddress?: string
-}
-
-type PredictOperationEnvelope = {
-  ok: boolean
-  operationId: string
-  operation: PredictOperation
-  status: PredictOperationStatus
-  userMessage: string
-  identifiers?: PredictOperationIdentifiers
-  retry?: { canRetry: boolean; retryAfterMs?: number; pollAfterMs?: number }
-  lifecycleError?: { code: string; detailsId?: string }
-}
-
-function createOperationId(operation: PredictOperation) {
-  const suffix = Math.random().toString(36).slice(2, 8)
-  return `op_${operation}_${Date.now()}_${suffix}`
-}
-
 function withOperation<T extends Record<string, unknown>>(
   payload: T,
-  args: Omit<PredictOperationEnvelope, 'operationId'> & { operationId?: string },
+  args: Omit<PredictOperationEnvelope, 'operationId'> & { operationId?: string; rawProviderPayload?: unknown },
 ): T & PredictOperationEnvelope {
   const operationId = args.operationId ?? createOperationId(args.operation)
-  return {
+  const envelope = {
     ...payload,
     ok: args.ok,
     operationId,
@@ -309,6 +270,7 @@ function withOperation<T extends Record<string, unknown>>(
     ...(args.retry ? { retry: args.retry } : {}),
     ...(args.lifecycleError ? { lifecycleError: { ...args.lifecycleError, detailsId: args.lifecycleError.detailsId ?? operationId } } : {}),
   }
+  return storeOperation(envelope, args.rawProviderPayload) as T & PredictOperationEnvelope
 }
 
 function sessionExpired(operation: PredictOperation = 'predict_session') {
@@ -328,6 +290,13 @@ function sessionExpired(operation: PredictOperation = 'predict_session') {
 function orderIdFromResult(result: any): string | undefined {
   const id = result?.orderID ?? result?.orderId ?? result?.id
   return typeof id === 'string' ? id : undefined
+}
+
+function safeOrderPayload(result: any) {
+  const orderId = orderIdFromResult(result)
+  return {
+    ...(orderId ? { orderID: orderId, orderId } : {}),
+  }
 }
 
 function stableErrorCode(operation: PredictOperation, detail: string) {
@@ -433,6 +402,67 @@ async function submitTradingWalletCalls(session: ClobSession, txs: Transaction[]
 export const clobRoutes = new Hono()
 
 console.log('[clob] Routes loaded: /auth, /order, /positions/:polygonAddress, /balance/:polygonAddress, /redeem')
+
+/**
+ * GET /clob/operation/:operationId
+ * Returns the stored, user-safe lifecycle envelope for an operation.
+ */
+clobRoutes.get('/operation/:operationId', async (c) => {
+  const operationId = c.req.param('operationId')
+  const operation = getStoredOperation(operationId)
+  if (!operation) {
+    return c.json({ ok: false, error: 'Operation not found' }, 404)
+  }
+  return c.json(operation)
+})
+
+/**
+ * POST /clob/operations/reconcile
+ * Body: { operationIds?: string[], operations?: [{ operationId?, identifiers? }], identifiers?: {...} }
+ */
+clobRoutes.post('/operations/reconcile', async (c) => {
+  let body: {
+    operationIds?: unknown
+    operations?: unknown
+    identifiers?: PredictOperationIdentifiers
+  }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ ok: false, error: 'Bad request' }, 400)
+  }
+
+  const lookups: OperationStoreLookup[] = []
+  if (Array.isArray(body.operationIds)) {
+    for (const operationId of body.operationIds) {
+      if (typeof operationId === 'string') lookups.push({ operationId })
+    }
+  }
+  if (Array.isArray(body.operations)) {
+    for (const entry of body.operations) {
+      if (!entry || typeof entry !== 'object') continue
+      const item = entry as Record<string, unknown>
+      lookups.push({
+        operationId: typeof item.operationId === 'string' ? item.operationId : undefined,
+        identifiers: item.identifiers && typeof item.identifiers === 'object'
+          ? item.identifiers as PredictOperationIdentifiers
+          : undefined,
+      })
+    }
+  }
+  if (body.identifiers && typeof body.identifiers === 'object') {
+    lookups.push({ identifiers: body.identifiers })
+  }
+
+  const operations = lookups
+    .map((lookup) => ({
+      lookup,
+      operation: findStoredOperation(lookup),
+    }))
+    .filter((result) => result.operation)
+
+  return c.json({ ok: true, operations })
+})
 
 /**
  * POST /clob/auth
@@ -691,7 +721,7 @@ clobRoutes.post('/order', async (c) => {
 
     console.log(`[clob] Deposit-wallet order posted for ${polygonAddress}: ${side}`)
     const orderId = orderIdFromResult(result)
-    const payload = result && typeof result === 'object' ? result : { raw: result }
+    const payload = safeOrderPayload(result)
     return c.json(withOperation(payload, {
       ok: true,
       operation,
@@ -704,6 +734,7 @@ clobRoutes.post('/order', async (c) => {
         tokenId: tokenID,
       },
       retry: isMarketOrder ? undefined : { canRetry: false, pollAfterMs: 5_000 },
+      rawProviderPayload: result,
     }))
   } catch (err: any) {
     console.error('[clob] Deposit-wallet order failed:', err.message || err)
@@ -752,15 +783,19 @@ clobRoutes.delete('/order/:orderId', async (c) => {
   try {
     const client = getClient(session)
     const result = await client.cancelOrder({ orderID: orderId })
-    console.log(`[clob] Order cancelled: ${orderId} for ${polygonAddress}`)
-    return c.json(withOperation({ ...result }, {
-      ok: true,
+    const cancelStatus = cancelStatusFromProviderPayload(result, orderId)
+    console.log(`[clob] Order cancel result ${cancelStatus.status}: ${orderId} for ${polygonAddress}`)
+    const payload = cancelStatus.error ? { error: cancelStatus.error } : {}
+    return c.json(withOperation(payload, {
+      ok: cancelStatus.ok,
       operation: 'cancel',
-      status: 'cancel_requested',
-      userMessage: 'Cancel requested. We will keep this pick visible until Polymarket confirms it.',
+      status: cancelStatus.status,
+      userMessage: cancelStatus.userMessage,
       identifiers: { orderId },
-      retry: { canRetry: false, pollAfterMs: 5_000 },
-    }))
+      retry: cancelStatus.status === 'cancel_requested' ? { canRetry: false, pollAfterMs: 5_000 } : undefined,
+      ...(cancelStatus.ok ? {} : { lifecycleError: { code: 'PREDICT_CANCEL_FAILED' } }),
+      rawProviderPayload: result,
+    }), cancelStatus.ok ? 200 : 400)
   } catch (err: any) {
     console.error('[clob] Cancel failed:', err.message || err)
     return c.json(failedOperation('cancel', 'Cancel failed', err.message), 500)

--- a/packages/api/src/polymarket/lifecycle.test.ts
+++ b/packages/api/src/polymarket/lifecycle.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import {
+  cancelStatusFromProviderPayload,
+  findStoredOperation,
+  storeOperation,
+  type PredictOperationEnvelope,
+} from './lifecycle.js'
+
+function operation(overrides: Partial<PredictOperationEnvelope> = {}): PredictOperationEnvelope {
+  return {
+    ok: true,
+    operationId: `op_test_${Math.random().toString(36).slice(2)}`,
+    operation: 'buy',
+    status: 'waiting_to_match',
+    userMessage: 'submitted',
+    identifiers: { orderId: 'order-1', tokenId: 'token-1' },
+    ...overrides,
+  }
+}
+
+assert.equal(
+  cancelStatusFromProviderPayload({ canceled: ['order-1'] }, 'order-1').status,
+  'cancelled',
+)
+assert.equal(
+  cancelStatusFromProviderPayload({ canceled: { 'order-1': true } }, 'order-1').status,
+  'cancelled',
+)
+
+const notCancelled = cancelStatusFromProviderPayload({ not_canceled: ['order-1'] }, 'order-1')
+assert.equal(notCancelled.ok, false)
+assert.equal(notCancelled.status, 'failed')
+
+const notCancelledMap = cancelStatusFromProviderPayload({ not_canceled: { 'order-1': 'not found' } }, 'order-1')
+assert.equal(notCancelledMap.ok, false)
+assert.equal(notCancelledMap.status, 'failed')
+
+assert.equal(
+  cancelStatusFromProviderPayload({ success: true }, 'order-1').status,
+  'cancel_requested',
+)
+
+const stored = storeOperation(
+  {
+    ...operation({ operationId: 'op_test_store_1' }),
+    orderID: 'order-1',
+    detail: 'provider detail must stay server-side',
+    error: 'provider error must stay server-side',
+    relayer: { provider: 'raw' },
+  } as PredictOperationEnvelope & Record<string, unknown>,
+  { providerSecret: 'server-only' },
+)
+assert.equal(findStoredOperation({ operationId: stored.operationId })?.operationId, stored.operationId)
+assert.equal(findStoredOperation({ identifiers: { orderId: 'order-1' } })?.operationId, stored.operationId)
+const safeStored = findStoredOperation({ operationId: stored.operationId }) as Record<string, unknown>
+assert.equal(safeStored.orderID, 'order-1')
+assert.equal(safeStored.rawProviderPayload, undefined)
+assert.equal(safeStored.detail, undefined)
+assert.equal(safeStored.error, undefined)
+assert.equal(safeStored.relayer, undefined)
+
+console.log('lifecycle tests passed')

--- a/packages/api/src/polymarket/lifecycle.ts
+++ b/packages/api/src/polymarket/lifecycle.ts
@@ -1,0 +1,223 @@
+export type PredictOperation =
+  | 'predict_setup'
+  | 'buy'
+  | 'sell'
+  | 'cancel'
+  | 'redeem'
+  | 'withdraw'
+  | 'deposit'
+  | 'wrap'
+  | 'predict_session'
+
+export type PredictOperationStatus =
+  | 'submitted'
+  | 'waiting_to_match'
+  | 'filled'
+  | 'not_filled'
+  | 'cancel_requested'
+  | 'cancelled'
+  | 'collecting'
+  | 'bridging'
+  | 'completed'
+  | 'failed'
+  | 'session_expired'
+
+export type PredictOperationIdentifiers = {
+  orderId?: string
+  tokenId?: string
+  conditionId?: string
+  txHash?: string
+  bridgeAddress?: string
+  relayerTransactionId?: string
+  tradingAddress?: string
+  depositWalletAddress?: string
+}
+
+export type PredictOperationEnvelope = {
+  ok: boolean
+  operationId: string
+  operation: PredictOperation
+  status: PredictOperationStatus
+  userMessage: string
+  identifiers?: PredictOperationIdentifiers
+  retry?: { canRetry: boolean; retryAfterMs?: number; pollAfterMs?: number }
+  lifecycleError?: { code: string; detailsId?: string }
+}
+
+export type StoredPredictOperation = PredictOperationEnvelope & Record<string, unknown> & {
+  createdAt: number
+  updatedAt: number
+  rawProviderPayload?: unknown
+}
+
+export type OperationStoreLookup = {
+  operationId?: string
+  identifiers?: PredictOperationIdentifiers
+}
+
+const OPERATION_TTL_MS = 24 * 60 * 60 * 1000
+const operationStore = new Map<string, StoredPredictOperation>()
+
+export function createOperationId(operation: PredictOperation) {
+  const suffix = Math.random().toString(36).slice(2, 8)
+  return `op_${operation}_${Date.now()}_${suffix}`
+}
+
+function compactIdentifiers(identifiers?: PredictOperationIdentifiers): PredictOperationIdentifiers | undefined {
+  if (!identifiers) return undefined
+  const entries = Object.entries(identifiers).filter(([, value]) => typeof value === 'string' && value.length > 0)
+  return entries.length > 0 ? Object.fromEntries(entries) as PredictOperationIdentifiers : undefined
+}
+
+function sanitizeOperation(operation: StoredPredictOperation): PredictOperationEnvelope {
+  const safeOperation: Record<string, unknown> = {
+    ok: operation.ok,
+    operationId: operation.operationId,
+    operation: operation.operation,
+    status: operation.status,
+    userMessage: operation.userMessage,
+    ...(operation.identifiers ? { identifiers: operation.identifiers } : {}),
+    ...(operation.retry ? { retry: operation.retry } : {}),
+    ...(operation.lifecycleError ? { lifecycleError: operation.lifecycleError } : {}),
+  }
+
+  for (const key of [
+    'orderID',
+    'orderId',
+    'polygonAddress',
+    'walletMode',
+    'tradingAddress',
+    'safeAddress',
+    'depositWalletAddress',
+    'amount',
+    'amountWrapped',
+    'bridgeAddress',
+    'solanaAddress',
+    'txHash',
+  ]) {
+    const value = operation[key]
+    if (typeof value === 'string' || typeof value === 'number' || value === null) safeOperation[key] = value
+  }
+
+  return safeOperation as PredictOperationEnvelope
+}
+
+function matchesIdentifiers(
+  operation: StoredPredictOperation,
+  identifiers?: PredictOperationIdentifiers,
+) {
+  const query = compactIdentifiers(identifiers)
+  if (!query || !operation.identifiers) return false
+
+  return Object.entries(query).every(([key, value]) => {
+    const current = operation.identifiers?.[key as keyof PredictOperationIdentifiers]
+    return typeof current === 'string' && current.toLowerCase() === value.toLowerCase()
+  })
+}
+
+export function cleanOperationStore(now = Date.now()) {
+  for (const [operationId, operation] of operationStore) {
+    if (now - operation.updatedAt > OPERATION_TTL_MS) operationStore.delete(operationId)
+  }
+}
+
+export function storeOperation(
+  envelope: PredictOperationEnvelope,
+  rawProviderPayload?: unknown,
+): PredictOperationEnvelope {
+  const now = Date.now()
+  operationStore.set(envelope.operationId, {
+    ...envelope,
+    identifiers: compactIdentifiers(envelope.identifiers),
+    createdAt: operationStore.get(envelope.operationId)?.createdAt ?? now,
+    updatedAt: now,
+    ...(rawProviderPayload === undefined ? {} : { rawProviderPayload }),
+  })
+  return envelope
+}
+
+export function getStoredOperation(operationId: string): PredictOperationEnvelope | null {
+  cleanOperationStore()
+  const operation = operationStore.get(operationId)
+  return operation ? sanitizeOperation(operation) : null
+}
+
+export function findStoredOperation(lookup: OperationStoreLookup): PredictOperationEnvelope | null {
+  cleanOperationStore()
+  if (lookup.operationId) {
+    const operation = getStoredOperation(lookup.operationId)
+    if (operation || !lookup.identifiers) return operation
+  }
+
+  for (const operation of operationStore.values()) {
+    if (matchesIdentifiers(operation, lookup.identifiers)) return sanitizeOperation(operation)
+  }
+  return null
+}
+
+function valuesFromProviderCollection(collection: unknown): string[] {
+  if (Array.isArray(collection)) {
+    return collection
+      .map((entry) => {
+        if (typeof entry === 'string') return entry
+        if (entry && typeof entry === 'object') {
+          const value = entry as Record<string, unknown>
+          return value.orderID ?? value.orderId ?? value.id
+        }
+        return null
+      })
+      .filter((value): value is string => typeof value === 'string')
+  }
+
+  if (collection && typeof collection === 'object') {
+    return Object.entries(collection as Record<string, unknown>)
+      .filter(([, value]) => value !== false && value !== null && value !== undefined)
+      .map(([key]) => key)
+  }
+
+  return []
+}
+
+export function providerCollectionIncludesOrder(collection: unknown, orderId: string) {
+  const normalized = orderId.toLowerCase()
+  return valuesFromProviderCollection(collection).some((value) => value.toLowerCase() === normalized)
+}
+
+export function cancelStatusFromProviderPayload(
+  result: unknown,
+  orderId: string,
+): { ok: boolean; status: PredictOperationStatus; userMessage: string; error?: string } {
+  const payload = result && typeof result === 'object' ? result as Record<string, unknown> : {}
+  const cancelled = providerCollectionIncludesOrder(payload.canceled ?? payload.cancelled, orderId)
+  const notCancelled = providerCollectionIncludesOrder(payload.not_canceled ?? payload.notCancelled, orderId)
+
+  if (cancelled) {
+    return {
+      ok: true,
+      status: 'cancelled',
+      userMessage: 'Pick cancelled. Reserved cash should be available again shortly.',
+    }
+  }
+
+  if (notCancelled || payload.error || payload.errorMsg || payload.success === false) {
+    const error = typeof payload.error === 'string'
+      ? payload.error
+      : typeof payload.errorMsg === 'string'
+        ? payload.errorMsg
+        : typeof payload.message === 'string'
+          ? payload.message
+          : 'Cancel was not accepted by Polymarket.'
+    return {
+      ok: false,
+      status: 'failed',
+      userMessage: 'Cancel failed. Refresh your picks and try again.',
+      error,
+    }
+  }
+
+  return {
+    ok: true,
+    status: 'cancel_requested',
+    userMessage: 'Cancel requested. We will keep this pick visible until Polymarket confirms it.',
+  }
+}


### PR DESCRIPTION
## Summary
- Add a small Polymarket operation lifecycle store and reconciliation endpoints for user-safe operation status lookups.
- Persist predict deposit tracking by wallet/deposit address so status survives modal close/reopen.
- Preserve duplicate pending order/action rows correctly while remote order data catches up, with focused tests.

## Related issues
Related: #155
Related: #134
Related: #144
Related: #121
Related: #158

## Validation
- pnpm --dir apps/hybrid-expo exec tsx features/predict/pendingOpenOrders.test.ts
- pnpm --dir packages/api exec tsx src/polymarket/lifecycle.test.ts
- pnpm --dir packages/api exec tsc --noEmit --skipLibCheck --moduleResolution Bundler --module ESNext --target ES2022 src/clob.ts src/polymarket/lifecycle.ts