### PR TITLE
[codex] Remove server-side Predict EVM key derivation

### DIFF
--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -645,6 +645,7 @@ export default function PredictProfileScreen() {
           isOpen={withdrawOpen}
           onClose={() => setWithdrawOpen(false)}
           polygonAddress={poly.polygonAddress}
+          tradingAddress={poly.tradingAddress ?? poly.polygonAddress}
           solanaAddress={solanaAddress}
           cashBalance={cashBalance}
           onSuccess={loadPortfolio}

--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -290,6 +290,7 @@ export default function PredictProfileScreen() {
       const price = Math.max(0.01, Math.round((position.curPrice * 0.9) * 100) / 100);
       const result = await placeBet({
         polygonAddress: poly.polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID: position.asset,
         price,
         size,

--- a/apps/hybrid-expo/components/predict/WithdrawModal.tsx
+++ b/apps/hybrid-expo/components/predict/WithdrawModal.tsx
@@ -16,6 +16,7 @@ interface WithdrawModalProps {
   isOpen: boolean;
   onClose: () => void;
   polygonAddress: string;
+  tradingAddress: string;
   solanaAddress: string;
   cashBalance: number | null;
   onSuccess?: () => void;
@@ -27,6 +28,7 @@ export function WithdrawModal({
   isOpen,
   onClose,
   polygonAddress,
+  tradingAddress,
   solanaAddress,
   cashBalance,
   onSuccess,
@@ -74,6 +76,7 @@ export function WithdrawModal({
     try {
       const result = await withdrawFromPolymarket({
         polygonAddress,
+        tradingAddress,
         amount: parsedAmount,
         solanaAddress: trimmedRecipientAddress,
       });

--- a/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictMarketDetailScreen.tsx
@@ -551,6 +551,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
 
       const result = await placeBet({
         polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID,
         price: quote.limitPrice,
         size: quote.shares,
@@ -615,6 +616,7 @@ export function PredictMarketDetailScreen({ slug }: PredictMarketDetailScreenPro
       const price = Math.max(0.01, Math.round((position.curPrice * 0.9) * 100) / 100);
       const result = await placeBet({
         polygonAddress: poly.polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID: position.asset,
         price,
         size,

--- a/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/PredictSportDetailScreen.tsx
@@ -589,6 +589,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
 
       const result = await placeBet({
         polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID,
         price: quote.limitPrice,
         size: quote.shares,
@@ -653,6 +654,7 @@ export function PredictSportDetailScreen({ sport, slug }: PredictSportDetailScre
       const price = Math.max(0.01, Math.round((position.curPrice * 0.9) * 100) / 100);
       const result = await placeBet({
         polygonAddress: poly.polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID: position.asset,
         price,
         size,

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -865,6 +865,7 @@ export async function fetchMarketPositions(polygonAddress: string, slug: string)
 
 export interface WithdrawParams {
   polygonAddress: string;
+  tradingAddress: string;
   amount: number;
   solanaAddress: string;
 }
@@ -874,6 +875,39 @@ export interface WithdrawResult extends PredictOperationMeta {
   amount?: number;
   txHash?: string | null;
   error?: string;
+}
+
+const SOLANA_CHAIN_ID = '1151111081099710';
+const SOLANA_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+function bridgeAddressFromPayload(data: Record<string, unknown>): string | null {
+  const address = data.address;
+  if (address && typeof address === 'object') {
+    const evm = (address as Record<string, unknown>).evm;
+    if (typeof evm === 'string') return evm;
+  }
+  if (typeof data.depositAddress === 'string') return data.depositAddress;
+  if (typeof address === 'string') return address;
+  return null;
+}
+
+async function fetchExpectedWithdrawBridgeAddress(params: WithdrawParams): Promise<string> {
+  const response = await fetchWithTimeout('https://bridge.polymarket.com/withdraw', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      address: params.tradingAddress,
+      toChainId: SOLANA_CHAIN_ID,
+      toTokenAddress: SOLANA_USDC_MINT,
+      recipientAddr: params.solanaAddress,
+    }),
+  });
+  const data = await response.json().catch(() => ({})) as Record<string, unknown>;
+  const bridgeAddress = bridgeAddressFromPayload(data);
+  if (!response.ok || !bridgeAddress) {
+    throw new Error('Could not verify withdrawal route. Try again.');
+  }
+  return bridgeAddress;
 }
 
 export async function withdrawFromPolymarket(params: WithdrawParams): Promise<WithdrawResult> {
@@ -888,7 +922,12 @@ export async function withdrawFromPolymarket(params: WithdrawParams): Promise<Wi
   const operationMeta = parseOperationMeta(data);
   const signatureRequest = getSignatureRequest(data);
   if (signatureRequest) {
-    const batch = await signDepositWalletBatch(signatureRequest, { operation: 'withdraw', amount: params.amount });
+    const bridgeAddress = await fetchExpectedWithdrawBridgeAddress(params);
+    const batch = await signDepositWalletBatch(signatureRequest, {
+      operation: 'withdraw',
+      amount: params.amount,
+      bridgeAddress,
+    });
     const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/withdraw`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -695,7 +695,7 @@ export async function wrapPolymarketCash(polygonAddress: string): Promise<Predic
   const data = await response.json() as Record<string, unknown>;
   const signatureRequest = getSignatureRequest(data);
   if (signatureRequest) {
-    const batch = await signDepositWalletBatch(signatureRequest);
+    const batch = await signDepositWalletBatch(signatureRequest, { operation: 'wrap' });
     const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/wrap`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -888,7 +888,7 @@ export async function withdrawFromPolymarket(params: WithdrawParams): Promise<Wi
   const operationMeta = parseOperationMeta(data);
   const signatureRequest = getSignatureRequest(data);
   if (signatureRequest) {
-    const batch = await signDepositWalletBatch(signatureRequest);
+    const batch = await signDepositWalletBatch(signatureRequest, { operation: 'withdraw', amount: params.amount });
     const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/withdraw`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -978,7 +978,11 @@ export async function redeemPosition(
 
   const signatureRequest = getSignatureRequest(data);
   if (signatureRequest) {
-    const batch = await signDepositWalletBatch(signatureRequest);
+    const batch = await signDepositWalletBatch(signatureRequest, {
+      operation: 'redeem',
+      conditionId: position.conditionId,
+      negativeRisk: position.negativeRisk,
+    });
     const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/redeem`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/hybrid-expo/features/predict/predict.api.ts
+++ b/apps/hybrid-expo/features/predict/predict.api.ts
@@ -18,6 +18,11 @@ import type {
   TrendingMarket,
 } from '@/features/predict/predict.types';
 import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
+import {
+  createSignedPredictOrder,
+  signDepositWalletBatch,
+  type DepositWalletSignatureRequest,
+} from './predict.signing';
 
 function toNumber(value: unknown): number | null {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
@@ -49,6 +54,7 @@ export type PredictOperationStatus =
   | 'collecting'
   | 'bridging'
   | 'completed'
+  | 'needs_signature'
   | 'failed'
   | 'session_expired';
 
@@ -81,6 +87,7 @@ function parseOperationMeta(data: Record<string, unknown>): PredictOperationMeta
       || status === 'collecting'
       || status === 'bridging'
       || status === 'completed'
+      || status === 'needs_signature'
       || status === 'failed'
       || status === 'session_expired'
       ? status
@@ -89,6 +96,24 @@ function parseOperationMeta(data: Record<string, unknown>): PredictOperationMeta
     code,
     isSessionExpired: status === 'session_expired' || code === 'PREDICT_SESSION_EXPIRED',
   };
+}
+
+function getSignatureRequest(data: Record<string, unknown>): DepositWalletSignatureRequest | null {
+  const request = data.signatureRequest;
+  if (!request || typeof request !== 'object') return null;
+  const r = request as Record<string, unknown>;
+  if (
+    r.kind !== 'deposit_wallet_batch'
+    || typeof r.ownerAddress !== 'string'
+    || typeof r.depositWalletAddress !== 'string'
+    || typeof r.chainId !== 'number'
+    || typeof r.nonce !== 'string'
+    || typeof r.deadline !== 'string'
+    || !Array.isArray(r.calls)
+  ) {
+    return null;
+  }
+  return r as unknown as DepositWalletSignatureRequest;
 }
 
 function mapGeopoliticsMarket(row: unknown): GeopoliticsMarket | null {
@@ -489,6 +514,7 @@ export async function fetchLivePrices(tokenIds: string[]): Promise<Record<string
 
 export interface PlaceBetParams {
   polygonAddress: string;
+  tradingAddress?: string | null;
   tokenID: string;
   price: number;
   size?: number;
@@ -538,11 +564,12 @@ function friendlyPlaceBetError(detail: string): string {
  */
 export async function placeBet(params: PlaceBetParams): Promise<PlaceBetResult> {
   const baseUrl = resolveApiBaseUrl();
+  const signedOrder = await createSignedPredictOrder(params);
 
   const response = await fetchWithTimeout(`${baseUrl}/clob/order`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params),
+    body: JSON.stringify({ ...params, signedOrder }),
   });
 
   const data = await response.json() as Record<string, unknown>;
@@ -632,10 +659,11 @@ export interface ClobBalance {
     amount: number;
     txHash: string | null;
     error: string | null;
+    signatureRequired?: boolean;
   };
 }
 
-export async function fetchClobBalance(polygonAddress: string): Promise<ClobBalance | null> {
+export async function fetchClobBalance(polygonAddress: string, autoWrap = true): Promise<ClobBalance | null> {
   const baseUrl = resolveApiBaseUrl();
   const response = await fetchWithTimeout(`${baseUrl}/clob/balance/${encodeURIComponent(polygonAddress)}`);
   if (!response.ok) {
@@ -643,13 +671,46 @@ export async function fetchClobBalance(polygonAddress: string): Promise<ClobBala
     return null;
   }
   const data = await response.json() as Record<string, unknown>;
+  const wrap = data.wrap && typeof data.wrap === 'object'
+    ? data.wrap as ClobBalance['wrap']
+    : undefined;
+  if (autoWrap && wrap?.signatureRequired) {
+    await wrapPolymarketCash(polygonAddress).catch(() => null);
+    return fetchClobBalance(polygonAddress, false);
+  }
   return {
     balance: typeof data.balance === 'number' ? data.balance : 0,
     allowance: typeof data.allowance === 'number' ? data.allowance : 0,
-    wrap: data.wrap && typeof data.wrap === 'object'
-      ? data.wrap as ClobBalance['wrap']
-      : undefined,
+    wrap,
   };
+}
+
+export async function wrapPolymarketCash(polygonAddress: string): Promise<PredictOperationMeta & { ok: boolean; error?: string }> {
+  const baseUrl = resolveApiBaseUrl();
+  const response = await fetchWithTimeout(`${baseUrl}/clob/wrap`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ polygonAddress }),
+  });
+  const data = await response.json() as Record<string, unknown>;
+  const signatureRequest = getSignatureRequest(data);
+  if (signatureRequest) {
+    const batch = await signDepositWalletBatch(signatureRequest);
+    const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/wrap`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ polygonAddress, batch }),
+    });
+    const signedData = await signedResponse.json() as Record<string, unknown>;
+    if (!signedResponse.ok) {
+      return { ok: false, error: typeof signedData.userMessage === 'string' ? signedData.userMessage : 'Wrap failed', ...parseOperationMeta(signedData) };
+    }
+    return { ok: true, ...parseOperationMeta(signedData) };
+  }
+  if (!response.ok) {
+    return { ok: false, error: typeof data.userMessage === 'string' ? data.userMessage : 'Wrap failed', ...parseOperationMeta(data) };
+  }
+  return { ok: true, ...parseOperationMeta(data) };
 }
 
 // --- Deposit Status ---
@@ -825,6 +886,34 @@ export async function withdrawFromPolymarket(params: WithdrawParams): Promise<Wi
 
   const data = await response.json() as Record<string, unknown>;
   const operationMeta = parseOperationMeta(data);
+  const signatureRequest = getSignatureRequest(data);
+  if (signatureRequest) {
+    const batch = await signDepositWalletBatch(signatureRequest);
+    const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/withdraw`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...params, batch }),
+    });
+    const signedData = await signedResponse.json() as Record<string, unknown>;
+    const signedMeta = parseOperationMeta(signedData);
+    if (!signedResponse.ok) {
+      return {
+        ok: false,
+        error: typeof signedData.userMessage === 'string'
+          ? signedData.userMessage
+          : typeof signedData.detail === 'string'
+            ? signedData.detail
+            : 'Withdraw failed',
+        ...signedMeta,
+      };
+    }
+    return {
+      ok: true,
+      amount: typeof signedData.amount === 'number' ? signedData.amount : undefined,
+      txHash: typeof signedData.txHash === 'string' ? signedData.txHash : null,
+      ...signedMeta,
+    };
+  }
 
   if (!response.ok) {
     const detail = typeof data.userMessage === 'string'
@@ -885,6 +974,48 @@ export async function redeemPosition(
     } catch {
       data = { error: text };
     }
+  }
+
+  const signatureRequest = getSignatureRequest(data);
+  if (signatureRequest) {
+    const batch = await signDepositWalletBatch(signatureRequest);
+    const signedResponse = await fetchWithTimeout(`${baseUrl}/clob/redeem`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        polygonAddress,
+        conditionId: position.conditionId,
+        asset: position.asset,
+        outcomeIndex: position.outcomeIndex,
+        negativeRisk: position.negativeRisk,
+        batch,
+      }),
+    });
+    const signedText = await signedResponse.text();
+    let signedData: Record<string, unknown> = {};
+    if (signedText) {
+      try {
+        signedData = JSON.parse(signedText) as Record<string, unknown>;
+      } catch {
+        signedData = { error: signedText };
+      }
+    }
+    if (!signedResponse.ok) {
+      const detail =
+        typeof signedData.userMessage === 'string'
+          ? signedData.userMessage
+          : typeof signedData.detail === 'string'
+          ? signedData.detail
+          : typeof signedData.error === 'string'
+            ? signedData.error
+            : `Redeem failed (${signedResponse.status})`;
+      return { ok: false, error: detail, ...parseOperationMeta(signedData) };
+    }
+    return {
+      ok: true,
+      txHash: typeof signedData.txHash === 'string' ? signedData.txHash : null,
+      ...parseOperationMeta(signedData),
+    };
   }
 
   if (!response.ok) {

--- a/apps/hybrid-expo/features/predict/predict.signing.ts
+++ b/apps/hybrid-expo/features/predict/predict.signing.ts
@@ -7,6 +7,33 @@ import type { PlaceBetParams } from './predict.api';
 const CLOB_HOST = process.env.EXPO_PUBLIC_CLOB_HOST || 'https://clob.polymarket.com';
 const CHAIN_ID = Chain.POLYGON;
 const BUILDER_CODE = '0xda0aa9e10ba50d0077e25e94cf9e4d9ef749821528acf6fc758df962d67b63ed';
+const DEPOSIT_WALLET_FACTORY = '0x00000000000fb5c9adea0298d729a0cb3823cc07';
+const CONTRACTS = {
+  PUSD: '0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb',
+  USDC_E: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+  COLLATERAL_ONRAMP: '0x93070a847efef7f70739046a929d47a521f5b8ee',
+  CTF_COLLATERAL_ADAPTER: '0xada100db00ca00073811820692005400218fce1f',
+  NEG_RISK_CTF_COLLATERAL_ADAPTER: '0xada2005600dec949baf300f4c6120000bdb6eaab',
+  CTF_EXCHANGE_V2: '0xe111180000d2663c0091e4f400237545b87b996b',
+  NEG_RISK_CTF_EXCHANGE_V2: '0xe2222d279d744050d28e00520010520000310f59',
+  NEG_RISK_ADAPTER: '0xd91e80cf2e7be2e162c6513ced06f1dd0da35296',
+  CTF: '0x4d97dcd97ec945f40cf65f87097ace5ea0476045',
+} as const;
+const APPROVAL_OPERATORS: Set<string> = new Set([
+  CONTRACTS.CTF_EXCHANGE_V2,
+  CONTRACTS.NEG_RISK_CTF_EXCHANGE_V2,
+  CONTRACTS.NEG_RISK_ADAPTER,
+  CONTRACTS.CTF_COLLATERAL_ADAPTER,
+  CONTRACTS.NEG_RISK_CTF_COLLATERAL_ADAPTER,
+]);
+const MAX_UINT256 = 'f'.repeat(64);
+const SELECTORS = {
+  approve: '0x095ea7b3',
+  setApprovalForAll: '0xa22cb465',
+  transfer: '0xa9059cbb',
+  wrap: '0x62355638',
+  redeemPositions: '0x01b7037c',
+} as const;
 
 export interface DepositWalletCallToSign {
   target: string;
@@ -38,6 +65,12 @@ export interface SignedDepositWalletBatch {
   };
 }
 
+export type DepositWalletSigningContext =
+  | { operation: 'predict_setup' }
+  | { operation: 'wrap' }
+  | { operation: 'withdraw'; amount: number }
+  | { operation: 'redeem'; conditionId?: string; negativeRisk?: boolean };
+
 const DEPOSIT_WALLET_TYPES = {
   Call: [
     { name: 'target', type: 'address' },
@@ -52,6 +85,196 @@ const DEPOSIT_WALLET_TYPES = {
   ],
 };
 
+function normalizeAddress(value: string): string {
+  return value.toLowerCase();
+}
+
+function ensureHexWord(data: string, index: number): string {
+  const normalized = data.toLowerCase();
+  const start = 10 + index * 64;
+  const word = normalized.slice(start, start + 64);
+  if (word.length !== 64) throw new Error('Invalid Predict wallet action calldata.');
+  return word;
+}
+
+function wordAddress(word: string): string {
+  return `0x${word.slice(24)}`;
+}
+
+function wordBigInt(word: string): bigint {
+  return BigInt(`0x${word}`);
+}
+
+function assertZeroValue(call: DepositWalletCallToSign) {
+  if (BigInt(call.value || '0') !== 0n) {
+    throw new Error('Predict refused to sign a wallet action with native token value.');
+  }
+}
+
+function assertApprove(call: DepositWalletCallToSign, token: string, spender: string, amount?: bigint) {
+  assertZeroValue(call);
+  const data = call.data.toLowerCase();
+  if (normalizeAddress(call.target) !== normalizeAddress(token) || !data.startsWith(SELECTORS.approve)) {
+    throw new Error('Predict refused to sign an unexpected token approval.');
+  }
+  if (normalizeAddress(wordAddress(ensureHexWord(data, 0))) !== normalizeAddress(spender)) {
+    throw new Error('Predict refused to sign approval for an unexpected spender.');
+  }
+  const approvedAmountWord = ensureHexWord(data, 1);
+  if (amount !== undefined) {
+    if (wordBigInt(approvedAmountWord) !== amount) {
+      throw new Error('Predict refused to sign approval for an unexpected amount.');
+    }
+  } else if (approvedAmountWord !== MAX_UINT256) {
+    throw new Error('Predict refused to sign a non-standard setup approval amount.');
+  }
+}
+
+function assertSetApprovalForAll(call: DepositWalletCallToSign, operator: string) {
+  assertZeroValue(call);
+  const data = call.data.toLowerCase();
+  if (normalizeAddress(call.target) !== CONTRACTS.CTF || !data.startsWith(SELECTORS.setApprovalForAll)) {
+    throw new Error('Predict refused to sign an unexpected CTF approval.');
+  }
+  if (normalizeAddress(wordAddress(ensureHexWord(data, 0))) !== normalizeAddress(operator)) {
+    throw new Error('Predict refused to sign CTF approval for an unexpected operator.');
+  }
+  if (wordBigInt(ensureHexWord(data, 1)) !== 1n) {
+    throw new Error('Predict refused to sign CTF approval removal.');
+  }
+}
+
+function validateSetupCalls(calls: DepositWalletCallToSign[]) {
+  if (calls.length !== APPROVAL_OPERATORS.size * 2) {
+    throw new Error('Predict refused to sign an unexpected setup action count.');
+  }
+  const approvedErc20 = new Set<string>();
+  const approvedCtf = new Set<string>();
+  for (const call of calls) {
+    const data = call.data.toLowerCase();
+    if (data.startsWith(SELECTORS.approve)) {
+      const spender = normalizeAddress(wordAddress(ensureHexWord(data, 0)));
+      if (!APPROVAL_OPERATORS.has(spender)) throw new Error('Predict refused to sign setup approval for an unknown spender.');
+      assertApprove(call, CONTRACTS.PUSD, spender);
+      approvedErc20.add(spender);
+    } else if (data.startsWith(SELECTORS.setApprovalForAll)) {
+      const operator = normalizeAddress(wordAddress(ensureHexWord(data, 0)));
+      if (!APPROVAL_OPERATORS.has(operator)) throw new Error('Predict refused to sign setup CTF approval for an unknown operator.');
+      assertSetApprovalForAll(call, operator);
+      approvedCtf.add(operator);
+    } else {
+      throw new Error('Predict refused to sign an unknown setup action.');
+    }
+  }
+  if (approvedErc20.size !== APPROVAL_OPERATORS.size || approvedCtf.size !== APPROVAL_OPERATORS.size) {
+    throw new Error('Predict refused to sign incomplete setup approvals.');
+  }
+}
+
+function validateWrapCalls(calls: DepositWalletCallToSign[], depositWalletAddress: string) {
+  if (calls.length !== 2) throw new Error('Predict refused to sign an unexpected wrap action count.');
+  const approveAmount = wordBigInt(ensureHexWord(calls[0].data, 1));
+  assertApprove(calls[0], CONTRACTS.USDC_E, CONTRACTS.COLLATERAL_ONRAMP, approveAmount);
+
+  const wrap = calls[1];
+  assertZeroValue(wrap);
+  const data = wrap.data.toLowerCase();
+  if (normalizeAddress(wrap.target) !== CONTRACTS.COLLATERAL_ONRAMP || !data.startsWith(SELECTORS.wrap)) {
+    throw new Error('Predict refused to sign an unexpected wrap action.');
+  }
+  if (normalizeAddress(wordAddress(ensureHexWord(data, 0))) !== CONTRACTS.USDC_E) {
+    throw new Error('Predict refused to sign wrap for an unexpected asset.');
+  }
+  if (normalizeAddress(wordAddress(ensureHexWord(data, 1))) !== normalizeAddress(depositWalletAddress)) {
+    throw new Error('Predict refused to sign wrap to an unexpected wallet.');
+  }
+  if (wordBigInt(ensureHexWord(data, 2)) !== approveAmount || approveAmount <= 0n) {
+    throw new Error('Predict refused to sign wrap for an unexpected amount.');
+  }
+}
+
+function validateWithdrawCalls(calls: DepositWalletCallToSign[], amount: number) {
+  if (calls.length !== 1) throw new Error('Predict refused to sign an unexpected withdraw action count.');
+  const call = calls[0];
+  assertZeroValue(call);
+  const data = call.data.toLowerCase();
+  if (normalizeAddress(call.target) !== CONTRACTS.PUSD || !data.startsWith(SELECTORS.transfer)) {
+    throw new Error('Predict refused to sign an unexpected withdraw transfer.');
+  }
+  const expectedAmount = BigInt(Math.floor(amount * 1_000_000));
+  if (expectedAmount <= 0n || wordBigInt(ensureHexWord(data, 1)) !== expectedAmount) {
+    throw new Error('Predict refused to sign withdraw for an unexpected amount.');
+  }
+}
+
+function validateRedeemCalls(calls: DepositWalletCallToSign[], context: Extract<DepositWalletSigningContext, { operation: 'redeem' }>) {
+  if (calls.length === 0 || calls.length > 3) throw new Error('Predict refused to sign an unexpected collect action count.');
+  for (const call of calls) {
+    const data = call.data.toLowerCase();
+    if (data.startsWith(SELECTORS.setApprovalForAll)) {
+      const operator = normalizeAddress(wordAddress(ensureHexWord(data, 0)));
+      if (operator !== CONTRACTS.CTF_COLLATERAL_ADAPTER && operator !== CONTRACTS.NEG_RISK_CTF_COLLATERAL_ADAPTER) {
+        throw new Error('Predict refused to sign collect approval for an unknown operator.');
+      }
+      assertSetApprovalForAll(call, operator);
+      continue;
+    }
+    if (!data.startsWith(SELECTORS.redeemPositions)) {
+      throw new Error('Predict refused to sign an unknown collect action.');
+    }
+    const target = normalizeAddress(call.target);
+    const allowedTarget = target === CONTRACTS.CTF
+      || target === CONTRACTS.CTF_COLLATERAL_ADAPTER
+      || target === CONTRACTS.NEG_RISK_CTF_COLLATERAL_ADAPTER;
+    if (!allowedTarget) throw new Error('Predict refused to sign collect for an unexpected contract.');
+    if (context.conditionId && ensureHexWord(data, 2) !== context.conditionId.toLowerCase().replace(/^0x/, '')) {
+      throw new Error('Predict refused to sign collect for an unexpected market.');
+    }
+    assertZeroValue(call);
+  }
+}
+
+function validateDepositWalletSignatureRequest(
+  request: DepositWalletSignatureRequest,
+  context: DepositWalletSigningContext,
+) {
+  if (request.operation !== context.operation) {
+    throw new Error('Predict refused to sign a mismatched wallet action.');
+  }
+  if (request.chainId !== CHAIN_ID) {
+    throw new Error('Predict refused to sign a wallet action for an unexpected chain.');
+  }
+  switch (context.operation) {
+    case 'predict_setup':
+      validateSetupCalls(request.calls);
+      break;
+    case 'wrap':
+      validateWrapCalls(request.calls, request.depositWalletAddress);
+      break;
+    case 'withdraw':
+      validateWithdrawCalls(request.calls, context.amount);
+      break;
+    case 'redeem':
+      validateRedeemCalls(request.calls, context);
+      break;
+  }
+}
+
+export async function createPredictSessionProof(address: string): Promise<{ authTimestamp: number; authSignature: string }> {
+  const wallet = requireActiveEvmWallet();
+  const signerAddress = (await wallet.getAddress()).toLowerCase();
+  if (signerAddress !== address.toLowerCase()) {
+    throw new Error('Predict signer changed. Reconnect Predict and try again.');
+  }
+  const authTimestamp = Date.now();
+  const authSignature = await wallet.signMessage([
+    'myboon:predict:server-session',
+    `address:${address.toLowerCase()}`,
+    `timestamp:${authTimestamp}`,
+  ].join('\n'));
+  return { authTimestamp, authSignature };
+}
+
 export async function createPolymarketApiCreds(): Promise<ApiKeyCreds> {
   const wallet = requireActiveEvmWallet();
   const client = new ClobClient({
@@ -64,12 +287,14 @@ export async function createPolymarketApiCreds(): Promise<ApiKeyCreds> {
 
 export async function signDepositWalletBatch(
   request: DepositWalletSignatureRequest,
+  context: DepositWalletSigningContext,
 ): Promise<SignedDepositWalletBatch> {
   const wallet = requireActiveEvmWallet();
   const signerAddress = (await wallet.getAddress()).toLowerCase();
   if (signerAddress !== request.ownerAddress.toLowerCase()) {
     throw new Error('Predict signer changed. Reconnect Predict and try again.');
   }
+  validateDepositWalletSignatureRequest(request, context);
 
   const domain = {
     name: 'DepositWallet',
@@ -88,7 +313,7 @@ export async function signDepositWalletBatch(
   return {
     type: 'WALLET',
     from: request.ownerAddress,
-    to: '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07',
+    to: DEPOSIT_WALLET_FACTORY,
     nonce: request.nonce,
     signature,
     depositWalletParams: {
@@ -102,8 +327,9 @@ export async function signDepositWalletBatch(
 export async function signAndSubmitDepositWalletBatch(
   polygonAddress: string,
   request: DepositWalletSignatureRequest,
+  context: DepositWalletSigningContext,
 ): Promise<Record<string, unknown>> {
-  const batch = await signDepositWalletBatch(request);
+  const batch = await signDepositWalletBatch(request, context);
   const baseUrl = resolveApiBaseUrl();
   const response = await fetchWithTimeout(`${baseUrl}/clob/wallet-batch`, {
     method: 'POST',

--- a/apps/hybrid-expo/features/predict/predict.signing.ts
+++ b/apps/hybrid-expo/features/predict/predict.signing.ts
@@ -1,0 +1,177 @@
+import { ClobClient, OrderType, Side, SignatureTypeV2, Chain } from '@polymarket/clob-client-v2';
+import type { ApiKeyCreds, SignedOrder } from '@polymarket/clob-client-v2';
+import { requireActiveEvmWallet } from '@/hooks/useEvmSigner';
+import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
+import type { PlaceBetParams } from './predict.api';
+
+const CLOB_HOST = process.env.EXPO_PUBLIC_CLOB_HOST || 'https://clob.polymarket.com';
+const CHAIN_ID = Chain.POLYGON;
+const BUILDER_CODE = '0xda0aa9e10ba50d0077e25e94cf9e4d9ef749821528acf6fc758df962d67b63ed';
+
+export interface DepositWalletCallToSign {
+  target: string;
+  value: string;
+  data: string;
+}
+
+export interface DepositWalletSignatureRequest {
+  kind: 'deposit_wallet_batch';
+  operation: string;
+  ownerAddress: string;
+  depositWalletAddress: string;
+  chainId: number;
+  nonce: string;
+  deadline: string;
+  calls: DepositWalletCallToSign[];
+}
+
+export interface SignedDepositWalletBatch {
+  type: 'WALLET';
+  from: string;
+  to: string;
+  nonce: string;
+  signature: string;
+  depositWalletParams: {
+    depositWallet: string;
+    deadline: string;
+    calls: DepositWalletCallToSign[];
+  };
+}
+
+const DEPOSIT_WALLET_TYPES = {
+  Call: [
+    { name: 'target', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'data', type: 'bytes' },
+  ],
+  Batch: [
+    { name: 'wallet', type: 'address' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+    { name: 'calls', type: 'Call[]' },
+  ],
+};
+
+export async function createPolymarketApiCreds(): Promise<ApiKeyCreds> {
+  const wallet = requireActiveEvmWallet();
+  const client = new ClobClient({
+    host: CLOB_HOST,
+    chain: CHAIN_ID,
+    signer: wallet,
+  });
+  return client.createOrDeriveApiKey();
+}
+
+export async function signDepositWalletBatch(
+  request: DepositWalletSignatureRequest,
+): Promise<SignedDepositWalletBatch> {
+  const wallet = requireActiveEvmWallet();
+  const signerAddress = (await wallet.getAddress()).toLowerCase();
+  if (signerAddress !== request.ownerAddress.toLowerCase()) {
+    throw new Error('Predict signer changed. Reconnect Predict and try again.');
+  }
+
+  const domain = {
+    name: 'DepositWallet',
+    version: '1',
+    chainId: request.chainId,
+    verifyingContract: request.depositWalletAddress,
+  };
+  const message = {
+    wallet: request.depositWalletAddress,
+    nonce: request.nonce,
+    deadline: request.deadline,
+    calls: request.calls,
+  };
+  const signature = await wallet._signTypedData(domain, DEPOSIT_WALLET_TYPES, message);
+
+  return {
+    type: 'WALLET',
+    from: request.ownerAddress,
+    to: '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07',
+    nonce: request.nonce,
+    signature,
+    depositWalletParams: {
+      depositWallet: request.depositWalletAddress,
+      deadline: request.deadline,
+      calls: request.calls,
+    },
+  };
+}
+
+export async function signAndSubmitDepositWalletBatch(
+  polygonAddress: string,
+  request: DepositWalletSignatureRequest,
+): Promise<Record<string, unknown>> {
+  const batch = await signDepositWalletBatch(request);
+  const baseUrl = resolveApiBaseUrl();
+  const response = await fetchWithTimeout(`${baseUrl}/clob/wallet-batch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ polygonAddress, batch }),
+  });
+  const data = await response.json().catch(() => ({})) as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(
+      typeof data.userMessage === 'string'
+        ? data.userMessage
+        : typeof data.detail === 'string'
+          ? data.detail
+          : 'Failed to submit signed Predict wallet action',
+    );
+  }
+  return data;
+}
+
+export async function createSignedPredictOrder(params: PlaceBetParams): Promise<SignedOrder> {
+  const wallet = requireActiveEvmWallet();
+  const client = new ClobClient({
+    host: CLOB_HOST,
+    chain: CHAIN_ID,
+    signer: wallet,
+    signatureType: SignatureTypeV2.POLY_1271,
+    funderAddress: params.tradingAddress ?? params.polygonAddress,
+    builderConfig: { builderCode: BUILDER_CODE },
+  });
+
+  const side = params.side === 'BUY' ? Side.BUY : Side.SELL;
+  const orderType = params.orderType === 'FAK'
+    ? OrderType.FAK
+    : params.orderType === 'FOK'
+      ? OrderType.FOK
+      : params.orderType === 'GTC'
+        ? OrderType.GTC
+        : OrderType.GTC;
+
+  if (orderType === OrderType.FOK || orderType === OrderType.FAK) {
+    const amount = typeof params.amount === 'number'
+      ? params.amount
+      : typeof params.size === 'number'
+        ? params.size * params.price
+        : null;
+    if (!amount || amount <= 0) throw new Error('Missing order amount');
+    return client.createMarketOrder(
+      {
+        tokenID: params.tokenID,
+        price: params.price,
+        amount,
+        side,
+        orderType,
+        builderCode: BUILDER_CODE,
+      },
+      { tickSize: '0.01', negRisk: !!params.negRisk },
+    );
+  }
+
+  if (typeof params.size !== 'number') throw new Error('Missing order size');
+  return client.createOrder(
+    {
+      tokenID: params.tokenID,
+      price: params.price,
+      size: params.size,
+      side,
+      builderCode: BUILDER_CODE,
+    },
+    { tickSize: '0.01', negRisk: !!params.negRisk },
+  );
+}

--- a/apps/hybrid-expo/features/predict/predict.signing.ts
+++ b/apps/hybrid-expo/features/predict/predict.signing.ts
@@ -68,7 +68,7 @@ export interface SignedDepositWalletBatch {
 export type DepositWalletSigningContext =
   | { operation: 'predict_setup' }
   | { operation: 'wrap' }
-  | { operation: 'withdraw'; amount: number }
+  | { operation: 'withdraw'; amount: number; bridgeAddress: string }
   | { operation: 'redeem'; conditionId?: string; negativeRisk?: boolean };
 
 const DEPOSIT_WALLET_TYPES = {
@@ -193,13 +193,16 @@ function validateWrapCalls(calls: DepositWalletCallToSign[], depositWalletAddres
   }
 }
 
-function validateWithdrawCalls(calls: DepositWalletCallToSign[], amount: number) {
+function validateWithdrawCalls(calls: DepositWalletCallToSign[], amount: number, bridgeAddress: string) {
   if (calls.length !== 1) throw new Error('Predict refused to sign an unexpected withdraw action count.');
   const call = calls[0];
   assertZeroValue(call);
   const data = call.data.toLowerCase();
   if (normalizeAddress(call.target) !== CONTRACTS.PUSD || !data.startsWith(SELECTORS.transfer)) {
     throw new Error('Predict refused to sign an unexpected withdraw transfer.');
+  }
+  if (normalizeAddress(wordAddress(ensureHexWord(data, 0))) !== normalizeAddress(bridgeAddress)) {
+    throw new Error('Predict refused to sign withdraw to an unverified bridge address.');
   }
   const expectedAmount = BigInt(Math.floor(amount * 1_000_000));
   if (expectedAmount <= 0n || wordBigInt(ensureHexWord(data, 1)) !== expectedAmount) {
@@ -252,7 +255,7 @@ function validateDepositWalletSignatureRequest(
       validateWrapCalls(request.calls, request.depositWalletAddress);
       break;
     case 'withdraw':
-      validateWithdrawCalls(request.calls, context.amount);
+      validateWithdrawCalls(request.calls, context.amount, context.bridgeAddress);
       break;
     case 'redeem':
       validateRedeemCalls(request.calls, context);

--- a/apps/hybrid-expo/features/predict/profile/PositionDetailScreen.tsx
+++ b/apps/hybrid-expo/features/predict/profile/PositionDetailScreen.tsx
@@ -122,6 +122,7 @@ export function PositionDetailScreen({ conditionId, slug, outcomeIndex }: Positi
 
       const result = await placeBet({
         polygonAddress: poly.polygonAddress,
+        tradingAddress: poly.tradingAddress,
         tokenID,
         price: orderPrice,
         size: shares,

--- a/apps/hybrid-expo/hooks/useEvmSigner.ts
+++ b/apps/hybrid-expo/hooks/useEvmSigner.ts
@@ -4,13 +4,15 @@
  * The EVM private key is derived deterministically: keccak256(solana_signature).
  * This key lives ONLY in memory on the phone — never persisted to disk.
  *
- * The same derivation runs on the server for deposit-wallet relay operations.
- * Both sides get the same key from the same Solana signature.
+ * The derived key is exposed to other client modules through an in-memory module variable
+ * so Predict actions can sign orders and deposit-wallet batches locally.
  */
 
 import { useCallback, useRef, useState } from 'react';
 import { Wallet } from '@ethersproject/wallet';
 import { keccak256 } from '@ethersproject/keccak256';
+
+let activeEvmWallet: Wallet | null = null;
 
 export function deriveEvmSignerFromSignature(
   solanaSignature: Uint8Array,
@@ -18,8 +20,24 @@ export function deriveEvmSignerFromSignature(
   const sigHex = '0x' + Array.from(solanaSignature, (b: number) => b.toString(16).padStart(2, '0')).join('');
   const evmPrivateKey = keccak256(sigHex);
   const wallet = new Wallet(evmPrivateKey);
+  activeEvmWallet = wallet;
   if (__DEV__) console.log('[evm-signer] Derived EOA:', wallet.address);
   return { eoaAddress: wallet.address, wallet };
+}
+
+export function getActiveEvmWallet(): Wallet | null {
+  return activeEvmWallet;
+}
+
+export function requireActiveEvmWallet(): Wallet {
+  if (!activeEvmWallet) {
+    throw new Error('Predict wallet needs a fresh signature. Reconnect Predict and try again.');
+  }
+  return activeEvmWallet;
+}
+
+export function clearActiveEvmWallet() {
+  activeEvmWallet = null;
 }
 
 export function useEvmSigner() {
@@ -28,7 +46,7 @@ export function useEvmSigner() {
   const [eoaAddr, setEoaAddr] = useState<string | null>(null);
 
   /**
-   * Derive EVM wallet from Solana signature (same derivation as server).
+   * Derive EVM wallet from Solana signature.
    * Call this after Solana wallet signs the enable message.
    * Key stays in memory only — never persisted.
    */
@@ -41,6 +59,7 @@ export function useEvmSigner() {
   }, []);
 
   const clear = useCallback(() => {
+    clearActiveEvmWallet();
     walletRef.current = null;
     setReady(false);
     setEoaAddr(null);

--- a/apps/hybrid-expo/hooks/usePolymarketWallet.ts
+++ b/apps/hybrid-expo/hooks/usePolymarketWallet.ts
@@ -230,13 +230,14 @@ export function usePolymarketWallet(): PolymarketWallet {
       // Step 3: Create/derive CLOB credentials locally, then send only public
       // address + CLOB L2 credentials to the server. The server cannot recreate
       // the EVM private key from this payload.
-      const { createPolymarketApiCreds, signAndSubmitDepositWalletBatch } = await import('@/features/predict/predict.signing');
+      const { createPolymarketApiCreds, createPredictSessionProof, signAndSubmitDepositWalletBatch } = await import('@/features/predict/predict.signing');
       const creds = await createPolymarketApiCreds();
+      const authProof = await createPredictSessionProof(eoaAddress);
 
       const res = await fetchWithTimeout(`${API_BASE}/clob/auth`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ polygonAddress: eoaAddress, creds }),
+        body: JSON.stringify({ polygonAddress: eoaAddress, creds, ...authProof }),
       });
       assertWalletUnchanged();
 
@@ -252,7 +253,7 @@ export function usePolymarketWallet(): PolymarketWallet {
         throw new Error('Deposit wallet setup incomplete - please try again');
       }
       if (data.signatureRequest) {
-        await signAndSubmitDepositWalletBatch(eoaAddress, data.signatureRequest);
+        await signAndSubmitDepositWalletBatch(eoaAddress, data.signatureRequest, { operation: 'predict_setup' });
       }
       if (loadGenerationRef.current !== enableGeneration) {
         throw new Error(WALLET_CHANGED_MESSAGE);

--- a/apps/hybrid-expo/hooks/usePolymarketWallet.ts
+++ b/apps/hybrid-expo/hooks/usePolymarketWallet.ts
@@ -2,11 +2,11 @@
  * usePolymarketWallet — Derives a Polymarket-compatible Polygon wallet from a Solana signature.
  *
  * Architecture:
- * - The EVM private key is NEVER stored on the device. It lives only on the server, in-memory.
+ * - The EVM private key is derived and kept only in-memory on the phone.
  * - The phone stores public Polygon/deposit-wallet addresses in AsyncStorage so the UI
  *   remembers the user is "enabled" across app restarts.
- * - On enable: Phantom signs a message -> signature sent to server -> server derives EVM key,
- *   creates CLOB session, returns polygon address.
+ * - On enable: Phantom signs a message -> phone derives EVM key, creates CLOB creds,
+ *   then sends only public address + CLOB creds to the server.
  * - On app reopen: phone reads stored address from AsyncStorage. If the server session expired,
  *   the next CLOB operation will fail and the user re-signs with Phantom.
  * - On disable: clears both local storage and server session.
@@ -47,7 +47,7 @@ export interface PolymarketWallet {
   tradingAddress: string | null;
   isReady: boolean;
   isLoading: boolean;
-  /** Sign with Solana wallet, derive EVM key locally, send sig to server for deposit-wallet setup */
+  /** Sign with Solana wallet, derive EVM key locally, and set up deposit-wallet trading */
   enable: () => Promise<void>;
   /** Clear session (server + local + EVM key) */
   disable: () => void;
@@ -88,6 +88,7 @@ export function usePolymarketWallet(): PolymarketWallet {
   }, []);
 
   const clearWalletSessionState = useCallback(() => {
+    import('./useEvmSigner').then(({ clearActiveEvmWallet }) => clearActiveEvmWallet()).catch(() => {});
     setPolygonAddress(null);
     setSafeAddress(null);
     setDepositWalletAddress(null);
@@ -220,19 +221,22 @@ export function usePolymarketWallet(): PolymarketWallet {
       const signature = await startSignMessage(messageBytes);
       assertWalletUnchanged();
 
-      // Step 2: Derive EVM key locally (same derivation as server)
+      // Step 2: Derive EVM key locally. The signature never leaves the device.
       const { deriveEvmSignerFromSignature } = await import('./useEvmSigner');
-      await deriveEvmSignerFromSignature(signature);
+      const { eoaAddress } = deriveEvmSignerFromSignature(signature);
       assertWalletUnchanged();
       setCanSignLocally(true);
 
-      // Step 3: Send hex-encoded signature to server for deposit wallet setup + CLOB API creds
-      const sigHex = Array.from(signature, (b: number) => b.toString(16).padStart(2, '0')).join('');
+      // Step 3: Create/derive CLOB credentials locally, then send only public
+      // address + CLOB L2 credentials to the server. The server cannot recreate
+      // the EVM private key from this payload.
+      const { createPolymarketApiCreds, signAndSubmitDepositWalletBatch } = await import('@/features/predict/predict.signing');
+      const creds = await createPolymarketApiCreds();
 
       const res = await fetchWithTimeout(`${API_BASE}/clob/auth`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ signature: sigHex }),
+        body: JSON.stringify({ polygonAddress: eoaAddress, creds }),
       });
       assertWalletUnchanged();
 
@@ -246,6 +250,9 @@ export function usePolymarketWallet(): PolymarketWallet {
       assertWalletUnchanged();
       if (!data.depositWalletAddress) {
         throw new Error('Deposit wallet setup incomplete - please try again');
+      }
+      if (data.signatureRequest) {
+        await signAndSubmitDepositWalletBatch(eoaAddress, data.signatureRequest);
       }
       if (loadGenerationRef.current !== enableGeneration) {
         throw new Error(WALLET_CHANGED_MESSAGE);

--- a/apps/hybrid-expo/package.json
+++ b/apps/hybrid-expo/package.json
@@ -27,6 +27,7 @@
     "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@lazorkit/wallet": "^2.0.1",
+    "@polymarket/clob-client-v2": "1.0.3-canary.0",
     "@privy-io/expo": "^0.65.1",
     "@privy-io/expo-native-extensions": "0.0.10",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/api/src/clob.ts
+++ b/packages/api/src/clob.ts
@@ -69,6 +69,7 @@ const CONTRACTS = {
 
 const DEPOSIT_WALLET_FACTORY = '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07'
 const DEPOSIT_WALLET_IMPLEMENTATION = '0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB'
+const DEPOSIT_WALLET_BATCH_DEADLINE_SECONDS = 60 * 60
 
 const ERC20_APPROVE_ABI = [{
   name: 'approve', type: 'function',
@@ -331,7 +332,7 @@ async function prepareTradingWalletCalls(session: ClobSession, txs: Transaction[
   }
 
   if (!session.depositWalletAddress) throw new Error('Missing deposit wallet address')
-  const deadline = Math.floor(Date.now() / 1000 + 240).toString()
+  const deadline = Math.floor(Date.now() / 1000 + DEPOSIT_WALLET_BATCH_DEADLINE_SECONDS).toString()
   const relay = getReadOnlyRelay()
   const noncePayload = await relay.getNonce(session.eoaAddress, TransactionType.WALLET)
   const calls = txs.map(toDepositWalletCall)

--- a/packages/api/src/clob.ts
+++ b/packages/api/src/clob.ts
@@ -16,7 +16,7 @@
  */
 
 import { Hono } from 'hono'
-import { providers } from 'ethers'
+import { providers, utils } from 'ethers'
 import { AssetType, ClobClient, OrderType, Side, SignatureTypeV2, Chain } from '@polymarket/clob-client-v2'
 import type { ApiKeyCreds, SignedOrder } from '@polymarket/clob-client-v2'
 import { deriveDepositWallet, RelayClient, TransactionType } from '@polymarket/builder-relayer-client'
@@ -70,6 +70,7 @@ const CONTRACTS = {
 const DEPOSIT_WALLET_FACTORY = '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07'
 const DEPOSIT_WALLET_IMPLEMENTATION = '0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB'
 const DEPOSIT_WALLET_BATCH_DEADLINE_SECONDS = 60 * 60
+const AUTH_PROOF_MAX_AGE_MS = 5 * 60 * 1000
 
 const ERC20_APPROVE_ABI = [{
   name: 'approve', type: 'function',
@@ -200,6 +201,25 @@ interface ClobSession {
   tradingAddress: string
   depositWalletAddress?: string
   createdAt: number
+}
+
+function predictSessionMessage(address: string, timestamp: number): string {
+  return [
+    'myboon:predict:server-session',
+    `address:${address.toLowerCase()}`,
+    `timestamp:${timestamp}`,
+  ].join('\n')
+}
+
+function verifyPredictSessionProof(ownerAddress: string, timestamp: number | undefined, signature: string | undefined): boolean {
+  if (!timestamp || !Number.isFinite(timestamp) || !signature) return false
+  if (Math.abs(Date.now() - timestamp) > AUTH_PROOF_MAX_AGE_MS) return false
+  try {
+    const recovered = utils.verifyMessage(predictSessionMessage(ownerAddress, timestamp), signature)
+    return recovered.toLowerCase() === ownerAddress.toLowerCase()
+  } catch {
+    return false
+  }
 }
 
 const sessions = new Map<string, ClobSession>()
@@ -472,7 +492,13 @@ clobRoutes.post('/operations/reconcile', async (c) => {
  * credentials. It never receives Solana signature material or an EVM private key.
  */
 clobRoutes.post('/auth', async (c) => {
-  let body: { polygonAddress?: string; ownerAddress?: string; creds?: ApiKeyCreds }
+  let body: {
+    polygonAddress?: string
+    ownerAddress?: string
+    creds?: ApiKeyCreds
+    authTimestamp?: number
+    authSignature?: string
+  }
   try {
     body = await c.req.json()
   } catch {
@@ -486,6 +512,9 @@ clobRoutes.post('/auth', async (c) => {
   }
   if (!creds?.key || !creds.secret || !creds.passphrase) {
     return c.json(failedOperation('predict_setup', 'Missing CLOB API credentials', null), 400)
+  }
+  if (!verifyPredictSessionProof(ownerAddress, body.authTimestamp, body.authSignature)) {
+    return c.json(failedOperation('predict_setup', 'Invalid Predict session proof', null), 401)
   }
 
   if (!relayerBuilderConfig) {
@@ -1060,6 +1089,30 @@ clobRoutes.post('/wrap', async (c) => {
 clobRoutes.post('/withdraw', async (c) => {
   let body: { polygonAddress?: string; amount?: number; solanaAddress?: string; batch?: DepositWalletBatchRequest }
   try {
+    body = await c.req.json()
+  } catch {
+    return c.json(failedOperation('withdraw', 'Bad request', null), 400)
+  }
+
+  const { polygonAddress, amount, solanaAddress } = body
+  if (!polygonAddress || !amount || !solanaAddress) {
+    return c.json(failedOperation('withdraw', 'Missing required fields: polygonAddress, amount, solanaAddress', null), 400)
+  }
+
+  if (amount <= 0) {
+    return c.json(failedOperation('withdraw', 'Amount must be positive', null), 400)
+  }
+
+  if (!relayerBuilderConfig) {
+    return c.json(failedOperation('withdraw', 'Builder not configured', null), 500)
+  }
+
+  const session = sessions.get(polygonAddress.toLowerCase())
+  if (!session) {
+    return c.json(sessionExpired('withdraw'), 401)
+  }
+
+  try {
     if (body.batch) {
       const { relayInfo, execResult } = await submitSignedDepositWalletBatch(session, body.batch)
       const txHash = execResult?.transactionHash ?? relayInfo.transactionHash ?? null
@@ -1085,30 +1138,6 @@ clobRoutes.post('/withdraw', async (c) => {
       }))
     }
 
-    body = await c.req.json()
-  } catch {
-    return c.json(failedOperation('withdraw', 'Bad request', null), 400)
-  }
-
-  const { polygonAddress, amount, solanaAddress } = body
-  if (!polygonAddress || !amount || !solanaAddress) {
-    return c.json(failedOperation('withdraw', 'Missing required fields: polygonAddress, amount, solanaAddress', null), 400)
-  }
-
-  if (amount <= 0) {
-    return c.json(failedOperation('withdraw', 'Amount must be positive', null), 400)
-  }
-
-  if (!relayerBuilderConfig) {
-    return c.json(failedOperation('withdraw', 'Builder not configured', null), 500)
-  }
-
-  const session = sessions.get(polygonAddress.toLowerCase())
-  if (!session) {
-    return c.json(sessionExpired('withdraw'), 401)
-  }
-
-  try {
     // 1. Get bridge deposit addresses from Polymarket Bridge API
     const SOLANA_CHAIN_ID = '1151111081099710'
     const SOLANA_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'

--- a/packages/api/src/clob.ts
+++ b/packages/api/src/clob.ts
@@ -2,10 +2,10 @@
  * Server-side CLOB V2 session management and order routing.
  *
  * Flow (gasless via Builder Relayer + trading wallet):
- * 1. Phone derives EVM key from Solana wallet signature (Phantom MWA)
- * 2. Phone sends the raw Solana signature to POST /clob/auth
- * 3. Server derives EVM key, deploys/uses the user's deposit wallet
- * 4. Orders are signed server-side by the CLOB SDK with POLY_1271
+ * 1. Phone derives EVM key from Solana wallet signature (Phantom/Privy)
+ * 2. Phone creates CLOB API creds and signs POLY_1271 orders locally
+ * 3. Server deploys/uses the user's deposit wallet from the public EOA
+ * 4. Server submits client-signed orders and client-signed wallet batches
  *
  * V2 changes (April 2026):
  * - Collateral: pUSD (0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB) replaces USDC.e
@@ -16,11 +16,11 @@
  */
 
 import { Hono } from 'hono'
-import { Wallet, utils, providers } from 'ethers'
+import { providers } from 'ethers'
 import { AssetType, ClobClient, OrderType, Side, SignatureTypeV2, Chain } from '@polymarket/clob-client-v2'
-import type { ApiKeyCreds } from '@polymarket/clob-client-v2'
-import { RelayClient, TransactionType } from '@polymarket/builder-relayer-client'
-import type { DepositWalletCall, Transaction } from '@polymarket/builder-relayer-client'
+import type { ApiKeyCreds, SignedOrder } from '@polymarket/clob-client-v2'
+import { deriveDepositWallet, RelayClient, TransactionType } from '@polymarket/builder-relayer-client'
+import type { DepositWalletBatchRequest, DepositWalletCall, Transaction } from '@polymarket/builder-relayer-client'
 import { BuilderConfig as RelayerBuilderConfig } from '@polymarket/builder-signing-sdk'
 import { encodeFunctionData, maxUint256 } from 'viem'
 import {
@@ -66,6 +66,9 @@ const CONTRACTS = {
   NEG_RISK_ADAPTER: '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
   CTF: '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
 } as const
+
+const DEPOSIT_WALLET_FACTORY = '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07'
+const DEPOSIT_WALLET_IMPLEMENTATION = '0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB'
 
 const ERC20_APPROVE_ABI = [{
   name: 'approve', type: 'function',
@@ -151,56 +154,6 @@ async function getUsdceBalance(walletAddress: string): Promise<bigint> {
   return BigInt(res)
 }
 
-type AutoWrapResult = { wrapped: boolean; amount: number; txHash: string | null }
-
-async function autoWrapUsdce(session: ClobSession): Promise<AutoWrapResult> {
-  if (session.wrapInFlight) return session.wrapInFlight
-
-  session.wrapInFlight = doAutoWrapUsdce(session).finally(() => {
-    session.wrapInFlight = undefined
-  })
-
-  return session.wrapInFlight
-}
-
-async function doAutoWrapUsdce(session: ClobSession): Promise<AutoWrapResult> {
-  if (!relayerBuilderConfig) return { wrapped: false, amount: 0, txHash: null }
-
-  const usdceBalance = await getUsdceBalance(session.tradingAddress)
-  if (usdceBalance === 0n) return { wrapped: false, amount: 0, txHash: null }
-
-  const tradingAddr = session.tradingAddress as `0x${string}`
-  const onramp = CONTRACTS.COLLATERAL_ONRAMP as `0x${string}`
-  const usdceContract = CONTRACTS.USDC_E as `0x${string}`
-
-  const approveTx = {
-    to: usdceContract,
-    data: encodeFunctionData({
-      abi: ERC20_APPROVE_ABI,
-      functionName: 'approve',
-      args: [onramp, usdceBalance],
-    }),
-    value: '0',
-  }
-
-  const wrapTx = {
-    to: onramp,
-    data: encodeFunctionData({
-      abi: [{ name: 'wrap', type: 'function', inputs: [{ name: '_asset', type: 'address' }, { name: '_to', type: 'address' }, { name: '_amount', type: 'uint256' }], outputs: [] }] as const,
-      functionName: 'wrap',
-      args: [usdceContract, tradingAddr, usdceBalance],
-    }),
-    value: '0',
-  }
-
-  const execResult = await executeTradingWalletCalls(session, [approveTx, wrapTx], `Auto-wrap ${Number(usdceBalance) / 1e6} USDC.e to pUSD`)
-
-  const amount = Number(usdceBalance) / 1e6
-  const txHash = execResult?.transactionHash ?? null
-  console.log(`[clob] Auto-wrapped ${amount} USDC.e to pUSD for ${session.walletMode}${txHash ? ` tx=${txHash}` : ''}`)
-  return { wrapped: true, amount, txHash }
-}
-
 // --- Approval helpers ---
 
 function buildApprovalTxs() {
@@ -240,13 +193,11 @@ function buildApprovalTxs() {
 // --- In-memory session store ---
 
 interface ClobSession {
-  wallet: Wallet
   creds: ApiKeyCreds
   eoaAddress: string
   walletMode: WalletMode
   tradingAddress: string
   depositWalletAddress?: string
-  wrapInFlight?: Promise<AutoWrapResult>
   createdAt: number
 }
 
@@ -341,11 +292,20 @@ function cleanSessions() {
 
 setInterval(cleanSessions, 60 * 60 * 1000)
 
+function addressOnlySigner(address: string) {
+  return {
+    getAddress: async () => address,
+    _signTypedData: async () => {
+      throw new Error('Server-side user signing is disabled')
+    },
+  }
+}
+
 function getClient(session: ClobSession): ClobClient {
   return new ClobClient({
     host: CLOB_HOST,
     chain: Chain.POLYGON,
-    signer: session.wallet,
+    signer: addressOnlySigner(session.eoaAddress),
     creds: session.creds,
     signatureType: SignatureTypeV2.POLY_1271,
     funderAddress: session.tradingAddress,
@@ -353,8 +313,8 @@ function getClient(session: ClobSession): ClobClient {
   })
 }
 
-function getRelay(session: ClobSession): RelayClient {
-  return new RelayClient(RELAYER_URL, CHAIN_ID, session.wallet, relayerBuilderConfig as any)
+function getReadOnlyRelay(): RelayClient {
+  return new RelayClient(RELAYER_URL, CHAIN_ID)
 }
 
 function toDepositWalletCall(tx: Transaction): DepositWalletCall {
@@ -365,36 +325,75 @@ function toDepositWalletCall(tx: Transaction): DepositWalletCall {
   }
 }
 
-async function executeTradingWalletCalls(session: ClobSession, txs: Transaction[], metadata: string) {
-  const { execResult } = await submitTradingWalletCalls(session, txs, metadata)
-  return execResult
-}
-
-async function submitTradingWalletCalls(session: ClobSession, txs: Transaction[], metadata: string) {
+async function prepareTradingWalletCalls(session: ClobSession, txs: Transaction[], operation: PredictOperation | 'predict_setup') {
   if (!relayerBuilderConfig) {
     throw new Error('Builder not configured')
   }
 
-  let relay: RelayClient
-  let res: any
-
   if (!session.depositWalletAddress) throw new Error('Missing deposit wallet address')
   const deadline = Math.floor(Date.now() / 1000 + 240).toString()
-  relay = getRelay(session)
-  res = await relay.executeDepositWalletBatch(
-    txs.map(toDepositWalletCall),
-    session.depositWalletAddress,
-    deadline,
-  )
+  const relay = getReadOnlyRelay()
+  const noncePayload = await relay.getNonce(session.eoaAddress, TransactionType.WALLET)
+  const calls = txs.map(toDepositWalletCall)
+
+  return {
+    signatureRequest: {
+      kind: 'deposit_wallet_batch' as const,
+      operation,
+      ownerAddress: session.eoaAddress,
+      depositWalletAddress: session.depositWalletAddress,
+      chainId: CHAIN_ID,
+      nonce: noncePayload.nonce,
+      deadline,
+      calls,
+    },
+  }
+}
+
+async function submitSignedDepositWalletBatch(session: ClobSession, batch: DepositWalletBatchRequest) {
+  if (!relayerBuilderConfig) {
+    throw new Error('Builder not configured')
+  }
+
+  if (!session.depositWalletAddress) throw new Error('Missing deposit wallet address')
+  if (batch.type !== TransactionType.WALLET) throw new Error('Invalid batch type')
+  if (batch.from.toLowerCase() !== session.eoaAddress) throw new Error('Batch owner mismatch')
+  if (batch.depositWalletParams.depositWallet.toLowerCase() !== session.depositWalletAddress) {
+    throw new Error('Batch deposit wallet mismatch')
+  }
+
+  const body = JSON.stringify(batch)
+  const headers = await relayerBuilderConfig.generateBuilderHeaders('POST', '/submit', body)
+  const res = await fetch(`${RELAYER_URL}/submit`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers ?? {}),
+    },
+    body,
+  })
+  const payload = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error(payload?.error || payload?.message || `Relayer submit failed (${res.status})`)
+  }
 
   const relayInfo = {
-    transactionID: res?.transactionID ?? null,
-    transactionHash: res?.transactionHash ?? null,
-    hash: res?.hash ?? null,
-    state: res?.state ?? null,
+    transactionID: payload?.transactionID ?? null,
+    transactionHash: payload?.transactionHash ?? null,
+    hash: payload?.hash ?? null,
+    state: payload?.state ?? null,
   }
-  const execResult = await res.wait()
-  return { relay, relayInfo, execResult, response: res }
+  const relay = getReadOnlyRelay()
+  const execResult = relayInfo.transactionID
+    ? await relay.pollUntilState(
+        relayInfo.transactionID,
+        ['STATE_MINED', 'STATE_CONFIRMED'],
+        'STATE_FAILED',
+        100,
+      )
+    : undefined
+
+  return { relay, relayInfo, execResult, response: payload }
 }
 
 // --- Routes ---
@@ -466,22 +465,26 @@ clobRoutes.post('/operations/reconcile', async (c) => {
 
 /**
  * POST /clob/auth
- * Body: { signature: string } — hex-encoded 64-byte Solana signature
+ * Body: { polygonAddress: string, creds: ApiKeyCreds }
  *
- * Server derives EVM key, prepares the deposit wallet, creates CLOB API
- * credentials, and returns the EOA plus deposit wallet address.
+ * Server accepts the client-derived EOA address plus client-created CLOB API
+ * credentials. It never receives Solana signature material or an EVM private key.
  */
 clobRoutes.post('/auth', async (c) => {
-  let body: { signature?: string }
+  let body: { polygonAddress?: string; ownerAddress?: string; creds?: ApiKeyCreds }
   try {
     body = await c.req.json()
   } catch {
     return c.json(failedOperation('predict_setup', 'Bad request', null), 400)
   }
 
-  const { signature } = body
-  if (!signature || typeof signature !== 'string') {
-    return c.json(failedOperation('predict_setup', 'Missing signature', null), 400)
+  const ownerAddress = (body.ownerAddress ?? body.polygonAddress)?.toLowerCase()
+  const { creds } = body
+  if (!ownerAddress || !/^0x[a-f0-9]{40}$/iu.test(ownerAddress)) {
+    return c.json(failedOperation('predict_setup', 'Missing or invalid polygonAddress', null), 400)
+  }
+  if (!creds?.key || !creds.secret || !creds.passphrase) {
+    return c.json(failedOperation('predict_setup', 'Missing CLOB API credentials', null), 400)
   }
 
   if (!relayerBuilderConfig) {
@@ -489,29 +492,41 @@ clobRoutes.post('/auth', async (c) => {
   }
 
   try {
-    // 1. Derive EVM private key: keccak256(solana_signature)
-    const sigBytes = Buffer.from(signature, 'hex')
-    if (sigBytes.length !== 64) {
-      return c.json(failedOperation('predict_setup', 'Invalid signature length — expected 64 bytes', null), 400)
-    }
-
-    const evmPrivateKey = utils.keccak256(sigBytes)
-    const wallet = new Wallet(evmPrivateKey, polygonProvider)
-    const eoaAddress = wallet.address
-
-    console.log(`[clob] EOA derived: ${eoaAddress}`)
-
-    const relay = new RelayClient(RELAYER_URL, CHAIN_ID, wallet, relayerBuilderConfig as any)
+    const eoaAddress = ownerAddress
+    const relay = getReadOnlyRelay()
     console.log(`[clob] Using deposit wallet signatureType=3`)
-    const depositWalletAddress = await relay.deriveDepositWalletAddress()
+    const depositWalletAddress = deriveDepositWallet(
+      eoaAddress,
+      DEPOSIT_WALLET_FACTORY,
+      DEPOSIT_WALLET_IMPLEMENTATION,
+    )
     console.log(`[clob] Deposit wallet address (derived): ${depositWalletAddress}`)
 
     try {
       const deployed = await relay.getDeployed(depositWalletAddress, TransactionType.WALLET)
       if (!deployed) {
         console.log(`[clob] Deploying deposit wallet for ${eoaAddress}...`)
-        const deployRes = await relay.deployDepositWallet()
-        const deployResult = await deployRes.wait()
+        const createBody = JSON.stringify({
+          type: TransactionType.WALLET_CREATE,
+          from: eoaAddress,
+          to: DEPOSIT_WALLET_FACTORY,
+        })
+        const headers = await relayerBuilderConfig.generateBuilderHeaders('POST', '/submit', createBody)
+        const deployRes = await fetch(`${RELAYER_URL}/submit`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(headers ?? {}),
+          },
+          body: createBody,
+        })
+        const deployPayload = await deployRes.json().catch(() => ({}))
+        if (!deployRes.ok) {
+          throw new Error(deployPayload?.error || deployPayload?.message || `Deposit wallet deploy failed (${deployRes.status})`)
+        }
+        const deployResult = deployPayload?.transactionID
+          ? await relay.pollUntilState(deployPayload.transactionID, ['STATE_MINED', 'STATE_CONFIRMED'], 'STATE_FAILED', 100)
+          : undefined
         if (deployResult) {
           console.log(`[clob] Deposit wallet deployed: tx=${deployResult.transactionHash}`)
         } else {
@@ -529,43 +544,14 @@ clobRoutes.post('/auth', async (c) => {
     }
 
     const sessionDraft: Omit<ClobSession, 'creds' | 'createdAt'> = {
-      wallet,
       eoaAddress: eoaAddress.toLowerCase(),
       walletMode: 'deposit_wallet',
       tradingAddress: depositWalletAddress.toLowerCase(),
       depositWalletAddress: depositWalletAddress.toLowerCase(),
     }
 
-    // 5. Run approvals for V2 contracts from the active trading wallet.
-    console.log(`[clob] Running V2 approvals for ${sessionDraft.walletMode}...`)
-    try {
-      const approvalTxs = buildApprovalTxs()
-      const approvalResult = await executeTradingWalletCalls(
-        { ...sessionDraft, creds: {} as ApiKeyCreds, createdAt: Date.now() },
-        approvalTxs,
-        `Approve pUSD + CTF for V2 exchanges (${eoaAddress})`,
-      )
-      if (approvalResult) {
-        console.log(`[clob] V2 approvals confirmed: tx=${approvalResult.transactionHash}`)
-      } else {
-        console.warn(`[clob] V2 approvals may have failed`)
-      }
-    } catch (err: any) {
-      // Approvals may already be set from a previous auth
-      console.warn(`[clob] Approval error (may already be approved): ${err.message}`)
-    }
-
-    // 6. Create CLOB API credentials (L1 auth — EIP-712 signature from EOA)
-    const tempClient = new ClobClient({
-      host: CLOB_HOST,
-      chain: Chain.POLYGON,
-      signer: wallet,
-      signatureType: SignatureTypeV2.POLY_1271,
-      funderAddress: sessionDraft.tradingAddress,
-    })
-    const creds = await tempClient.createOrDeriveApiKey()
-
-    // 7. Store session
+    // Store session. Approval signing is returned to the client as a typed-data
+    // batch request, then submitted via /clob/wallet-batch.
     const session: ClobSession = {
       ...sessionDraft,
       creds,
@@ -573,12 +559,7 @@ clobRoutes.post('/auth', async (c) => {
     }
     sessions.set(eoaAddress.toLowerCase(), session)
 
-    try {
-      const client = getClient(session)
-      await client.updateBalanceAllowance({ asset_type: AssetType.COLLATERAL })
-    } catch (balanceErr: any) {
-      console.warn(`[clob] Balance allowance sync failed (non-fatal): ${balanceErr.message}`)
-    }
+    const approval = await prepareTradingWalletCalls(session, buildApprovalTxs(), 'predict_setup')
 
     console.log(`[clob] Session created — EOA: ${eoaAddress}, ${session.walletMode}: ${session.tradingAddress}`)
 
@@ -588,6 +569,7 @@ clobRoutes.post('/auth', async (c) => {
       tradingAddress: session.tradingAddress,
       safeAddress: null,
       depositWalletAddress: session.depositWalletAddress ?? null,
+      signatureRequest: approval.signatureRequest,
     }, {
       ok: true,
       operation: 'predict_setup',
@@ -601,6 +583,66 @@ clobRoutes.post('/auth', async (c) => {
   } catch (err: any) {
     console.error('[clob] Auth failed:', err.message || err)
     return c.json(failedOperation('predict_setup', 'CLOB auth failed', err.message), 500)
+  }
+})
+
+/**
+ * POST /clob/wallet-batch
+ * Body: { polygonAddress, batch }
+ *
+ * Submits a client-signed deposit-wallet WALLET batch. The backend adds only
+ * builder auth; it does not sign as the user.
+ */
+clobRoutes.post('/wallet-batch', async (c) => {
+  let body: { polygonAddress?: string; batch?: DepositWalletBatchRequest }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json(failedOperation('predict_session', 'Bad request', null), 400)
+  }
+
+  const { polygonAddress, batch } = body
+  if (!polygonAddress || !batch) {
+    return c.json(failedOperation('predict_session', 'Missing polygonAddress or batch', null), 400)
+  }
+
+  const session = sessions.get(polygonAddress.toLowerCase())
+  if (!session) {
+    return c.json(sessionExpired('predict_session'), 401)
+  }
+
+  try {
+    const { relayInfo, execResult } = await submitSignedDepositWalletBatch(session, batch)
+    const txHash = execResult?.transactionHash ?? relayInfo.transactionHash ?? null
+
+    try {
+      const client = getClient(session)
+      await client.updateBalanceAllowance({ asset_type: AssetType.COLLATERAL })
+    } catch (balanceErr: any) {
+      console.warn(`[clob] Balance allowance sync failed after signed batch (non-fatal): ${balanceErr.message}`)
+    }
+
+    return c.json(withOperation({
+      txHash,
+      relayerTransactionId: relayInfo.transactionID ?? undefined,
+      tradingAddress: session.tradingAddress,
+      depositWalletAddress: session.depositWalletAddress ?? null,
+    }, {
+      ok: true,
+      operation: 'predict_setup',
+      status: txHash ? 'completed' : 'syncing',
+      userMessage: txHash ? 'Predict wallet is ready.' : 'Predict wallet setup submitted.',
+      identifiers: {
+        txHash: txHash ?? undefined,
+        relayerTransactionId: relayInfo.transactionID ?? undefined,
+        tradingAddress: session.tradingAddress,
+        depositWalletAddress: session.depositWalletAddress ?? undefined,
+      },
+      retry: txHash ? undefined : { canRetry: false, pollAfterMs: 10_000 },
+    }))
+  } catch (err: any) {
+    console.error('[clob] Signed wallet batch failed:', err.message || err)
+    return c.json(failedOperation('predict_setup', 'Wallet batch failed', err.message), 500)
   }
 })
 
@@ -625,6 +667,7 @@ clobRoutes.post('/order', async (c) => {
     side?: 'BUY' | 'SELL'
     negRisk?: boolean
     orderType?: 'GTC' | 'GTD' | 'FOK' | 'FAK'
+    signedOrder?: SignedOrder
   }
   try {
     body = await c.req.json()
@@ -632,7 +675,7 @@ clobRoutes.post('/order', async (c) => {
     return c.json(failedOperation('buy', 'Bad request', null), 400)
   }
 
-  const { polygonAddress, tokenID, price, size, amount, side, negRisk, orderType } = body
+  const { polygonAddress, tokenID, price, size, amount, side, negRisk, orderType, signedOrder } = body
   const operation: PredictOperation = side === 'SELL' ? 'sell' : 'buy'
   const resolvedOrderType = orderType === 'FAK'
     ? OrderType.FAK
@@ -643,11 +686,11 @@ clobRoutes.post('/order', async (c) => {
         : OrderType.GTC
   const isMarketOrder = resolvedOrderType === OrderType.FOK || resolvedOrderType === OrderType.FAK
 
-  if (!polygonAddress || !tokenID || typeof price !== 'number' || !side) {
+  if (!polygonAddress || !side || (!signedOrder && (!tokenID || typeof price !== 'number'))) {
     return c.json(failedOperation(operation, 'Missing required fields: polygonAddress, tokenID, price, side', null), 400)
   }
 
-  if (!isMarketOrder && typeof size !== 'number') {
+  if (!signedOrder && !isMarketOrder && typeof size !== 'number') {
     return c.json(failedOperation(operation, 'Missing required field: size', null), 400)
   }
 
@@ -659,7 +702,7 @@ clobRoutes.post('/order', async (c) => {
         : size
     : null
 
-  if (isMarketOrder && (typeof marketAmount !== 'number' || !Number.isFinite(marketAmount) || marketAmount <= 0)) {
+  if (!signedOrder && isMarketOrder && (typeof marketAmount !== 'number' || !Number.isFinite(marketAmount) || marketAmount <= 0)) {
     return c.json(failedOperation(operation, 'Missing required field: amount', null), 400)
   }
 
@@ -672,7 +715,9 @@ clobRoutes.post('/order', async (c) => {
     const client = getClient(session)
     const clobSide = side === 'BUY' ? Side.BUY : Side.SELL
     let result: any
-    if (isMarketOrder) {
+    if (signedOrder) {
+      result = await client.postOrder(signedOrder, resolvedOrderType)
+    } else if (isMarketOrder) {
       const marketOrderType = resolvedOrderType === OrderType.FAK ? OrderType.FAK : OrderType.FOK
       // Polymarket FOK/FAK BUY orders are market orders: amount is dollars to
       // spend and price is the worst acceptable fill price. Do not convert BUY
@@ -731,7 +776,7 @@ clobRoutes.post('/order', async (c) => {
         : 'Pick submitted and waiting to match.',
       identifiers: {
         orderId,
-        tokenId: tokenID,
+        tokenId: tokenID ?? signedOrder?.tokenId,
       },
       retry: isMarketOrder ? undefined : { canRetry: false, pollAfterMs: 5_000 },
       rawProviderPayload: result,
@@ -879,18 +924,19 @@ clobRoutes.get('/balance/:polygonAddress', async (c) => {
       amount: number
       txHash: string | null
       error: string | null
+      signatureRequired?: boolean
     } = { attempted: false, wrapped: false, amount: 0, txHash: null, error: null }
 
-    // Auto-wrap any USDC.e sitting in the trading wallet (bridge deposits arrive as USDC.e)
-    try {
-      const wrapResult = await autoWrapUsdce(session)
-      wrapMeta = { attempted: wrapResult.amount > 0, wrapped: wrapResult.wrapped, amount: wrapResult.amount, txHash: wrapResult.txHash, error: null }
-      if (wrapResult.wrapped) {
-        console.log(`[clob] Auto-wrapped ${wrapResult.amount} USDC.e before balance check`)
+    const usdceBalance = await getUsdceBalance(session.tradingAddress).catch(() => 0n)
+    if (usdceBalance > 0n) {
+      wrapMeta = {
+        attempted: false,
+        wrapped: false,
+        amount: Number(usdceBalance) / 1e6,
+        txHash: null,
+        error: null,
+        signatureRequired: true,
       }
-    } catch (wrapErr: any) {
-      wrapMeta = { attempted: true, wrapped: false, amount: 0, txHash: null, error: wrapErr.message ?? 'Auto-wrap failed' }
-      console.warn(`[clob] Auto-wrap failed (non-fatal): ${wrapErr.message}`)
     }
 
     const client = getClient(session)
@@ -917,7 +963,7 @@ clobRoutes.get('/balance/:polygonAddress', async (c) => {
  * Gasless — relayer pays gas. Two batched txs: approve + wrap.
  */
 clobRoutes.post('/wrap', async (c) => {
-  let body: { polygonAddress?: string }
+  let body: { polygonAddress?: string; batch?: DepositWalletBatchRequest }
   try {
     body = await c.req.json()
   } catch {
@@ -939,21 +985,61 @@ clobRoutes.post('/wrap', async (c) => {
   }
 
   try {
-    const result = await autoWrapUsdce(session)
-    if (!result.wrapped) {
+    if (body.batch) {
+      const { relayInfo, execResult } = await submitSignedDepositWalletBatch(session, body.batch)
+      const txHash = execResult?.transactionHash ?? relayInfo.transactionHash ?? null
+      return c.json(withOperation({ txHash }, {
+        ok: true,
+        operation: 'wrap',
+        status: txHash ? 'completed' : 'syncing',
+        userMessage: 'Cash is ready for Predict.',
+        identifiers: {
+          txHash: txHash ?? undefined,
+          tradingAddress: session.tradingAddress,
+          depositWalletAddress: session.depositWalletAddress ?? undefined,
+        },
+        retry: txHash ? undefined : { canRetry: false, pollAfterMs: 10_000 },
+      }))
+    }
+
+    const usdceBalance = await getUsdceBalance(session.tradingAddress)
+    if (usdceBalance === 0n) {
       return c.json(failedOperation('wrap', 'No USDC.e to wrap', null, 'failed'), 400)
     }
 
-    return c.json(withOperation({ amountWrapped: result.amount, txHash: result.txHash }, {
-      ok: true,
-      operation: 'wrap',
-      status: 'completed',
-      userMessage: 'Cash is ready for Predict.',
-      identifiers: {
-        txHash: result.txHash ?? undefined,
-        tradingAddress: session.tradingAddress,
-        depositWalletAddress: session.depositWalletAddress ?? undefined,
+    const tradingAddr = session.tradingAddress as `0x${string}`
+    const onramp = CONTRACTS.COLLATERAL_ONRAMP as `0x${string}`
+    const usdceContract = CONTRACTS.USDC_E as `0x${string}`
+    const wrapTxs = [
+      {
+        to: usdceContract,
+        data: encodeFunctionData({
+          abi: ERC20_APPROVE_ABI,
+          functionName: 'approve',
+          args: [onramp, usdceBalance],
+        }),
+        value: '0',
       },
+      {
+        to: onramp,
+        data: encodeFunctionData({
+          abi: [{ name: 'wrap', type: 'function', inputs: [{ name: '_asset', type: 'address' }, { name: '_to', type: 'address' }, { name: '_amount', type: 'uint256' }], outputs: [] }] as const,
+          functionName: 'wrap',
+          args: [usdceContract, tradingAddr, usdceBalance],
+        }),
+        value: '0',
+      },
+    ]
+    const { signatureRequest } = await prepareTradingWalletCalls(session, wrapTxs, 'wrap')
+    return c.json(withOperation({
+      signatureRequest,
+      amount: Number(usdceBalance) / 1e6,
+    }, {
+      ok: false,
+      operation: 'wrap',
+      status: 'needs_signature',
+      userMessage: 'Sign once to prepare deposited cash for Predict.',
+      retry: { canRetry: true },
     }))
   } catch (err: any) {
     console.error('[clob] Wrap failed:', err.message || err)
@@ -971,8 +1057,33 @@ clobRoutes.post('/wrap', async (c) => {
  * 3. Bridge auto-unwraps pUSD → USDC and bridges to Solana
  */
 clobRoutes.post('/withdraw', async (c) => {
-  let body: { polygonAddress?: string; amount?: number; solanaAddress?: string }
+  let body: { polygonAddress?: string; amount?: number; solanaAddress?: string; batch?: DepositWalletBatchRequest }
   try {
+    if (body.batch) {
+      const { relayInfo, execResult } = await submitSignedDepositWalletBatch(session, body.batch)
+      const txHash = execResult?.transactionHash ?? relayInfo.transactionHash ?? null
+      return c.json(withOperation({
+        ok: true,
+        amount,
+        tradingAddress: session.tradingAddress,
+        safeAddress: null,
+        depositWalletAddress: session.depositWalletAddress ?? null,
+        solanaAddress,
+        txHash,
+      }, {
+        ok: true,
+        operation: 'withdraw',
+        status: 'bridging',
+        userMessage: 'Withdraw submitted. Bridge confirmation can take a few minutes.',
+        identifiers: {
+          txHash: txHash ?? undefined,
+          tradingAddress: session.tradingAddress,
+          depositWalletAddress: session.depositWalletAddress ?? undefined,
+        },
+        retry: { canRetry: false, pollAfterMs: 15_000 },
+      }))
+    }
+
     body = await c.req.json()
   } catch {
     return c.json(failedOperation('withdraw', 'Bad request', null), 400)
@@ -1042,37 +1153,28 @@ clobRoutes.post('/withdraw', async (c) => {
       value: '0',
     }
 
-    // 3. Execute via relayer (gasless)
-    const execResult = await executeTradingWalletCalls(
-      session,
-      [transferTx],
-      `Withdraw ${amount} pUSD to Solana ${solanaAddress.slice(0, 8)}...`,
-    )
-
-    const txHash = execResult?.transactionHash ?? null
-    console.log(`[clob] Withdraw ${amount}: pUSD -> bridge ${bridgeEvmAddress} -> Solana ${solanaAddress}${txHash ? ` tx=${txHash}` : ''}`)
+    const { signatureRequest } = await prepareTradingWalletCalls(session, [transferTx], 'withdraw')
+    console.log(`[clob] Withdraw ${amount}: signature required for pUSD -> bridge ${bridgeEvmAddress} -> Solana ${solanaAddress}`)
 
     return c.json(withOperation({
-      ok: true,
       amount,
       tradingAddress: session.tradingAddress,
       safeAddress: null,
       depositWalletAddress: session.depositWalletAddress ?? null,
       bridgeAddress: bridgeEvmAddress,
       solanaAddress,
-      txHash,
+      signatureRequest,
     }, {
-      ok: true,
+      ok: false,
       operation: 'withdraw',
-      status: 'bridging',
-      userMessage: 'Withdraw submitted. Bridge confirmation can take a few minutes.',
+      status: 'needs_signature',
+      userMessage: 'Sign once to submit this withdrawal.',
       identifiers: {
-        txHash: txHash ?? undefined,
         bridgeAddress: bridgeEvmAddress,
         tradingAddress: session.tradingAddress,
         depositWalletAddress: session.depositWalletAddress ?? undefined,
       },
-      retry: { canRetry: false, pollAfterMs: 15_000 },
+      retry: { canRetry: true },
     }))
   } catch (err: any) {
     console.error('[clob] Withdraw failed:', err.message || err)
@@ -1328,6 +1430,7 @@ clobRoutes.post('/redeem', async (c) => {
     asset?: string
     outcomeIndex?: number
     negativeRisk?: boolean
+    batch?: DepositWalletBatchRequest
   }
   try {
     body = await c.req.json()
@@ -1365,6 +1468,51 @@ clobRoutes.post('/redeem', async (c) => {
   }
 
   try {
+    if (body.batch) {
+      const { relay, relayInfo, execResult } = await submitSignedDepositWalletBatch(session, body.batch)
+      const txHash = execResult?.transactionHash ?? null
+      if (!txHash) {
+        let relayerTransaction: unknown = null
+        if (relayInfo.transactionID) {
+          try {
+            relayerTransaction = await relay.getTransaction(relayInfo.transactionID)
+          } catch (lookupErr: any) {
+            relayerTransaction = {
+              error: lookupErr?.message ?? 'Relayer transaction lookup failed',
+              response: lookupErr?.response?.data ?? null,
+            }
+          }
+        }
+        return c.json(withOperation({
+          error: 'Redeem not confirmed',
+          detail: 'Relayer completed without returning a transaction hash',
+          relayer: relayInfo,
+          relayerTransaction,
+        }, {
+          ok: false,
+          operation: 'redeem',
+          status: 'failed',
+          userMessage: 'Collect was submitted but not confirmed. Refresh before trying again.',
+          retry: { canRetry: true, pollAfterMs: 10_000 },
+          lifecycleError: { code: 'PREDICT_REDEEM_FAILED' },
+        }), 502)
+      }
+
+      return c.json(withOperation({ txHash }, {
+        ok: true,
+        operation: 'redeem',
+        status: 'collecting',
+        userMessage: 'Collect submitted. We will keep this pick visible until it confirms.',
+        identifiers: {
+          txHash,
+          conditionId,
+          tokenId: asset,
+          relayerTransactionId: relayInfo.transactionID ?? undefined,
+        },
+        retry: { canRetry: false, pollAfterMs: 10_000 },
+      }))
+    }
+
     console.log(`[clob] Redeem building tx: EOA=${session.eoaAddress}, ${session.walletMode}=${session.tradingAddress}, condition=${conditionId.slice(0, 10)}...`)
 
     let redeemMode: 'ctf' | 'neg-risk' = 'ctf'
@@ -1531,70 +1679,24 @@ clobRoutes.post('/redeem', async (c) => {
       txCount: redeemTxs.length,
       ...redeemContext,
     })
-    const { relay, relayInfo, execResult, response: execRes } = await submitTradingWalletCalls(
-      session,
-      redeemTxs,
-      `Redeem positions for condition ${conditionId.slice(0, 10)}...`,
-    )
-    console.log('[clob] Redeem relay response:', {
-      type: typeof execRes,
-      keys: execRes && typeof execRes === 'object' ? Object.keys(execRes as unknown as Record<string, unknown>) : [],
-      ...relayInfo,
-    })
-    console.log('[clob] Redeem relay wait result:', execResult ?? null)
-
-    const txHash = execResult?.transactionHash ?? null
-    if (!txHash) {
-      let relayerTransaction: unknown = null
-      if (relayInfo.transactionID) {
-        try {
-          relayerTransaction = await relay.getTransaction(relayInfo.transactionID)
-          console.warn('[clob] Redeem failed relayer transaction:', relayerTransaction)
-        } catch (lookupErr: any) {
-          relayerTransaction = {
-            error: lookupErr?.message ?? 'Relayer transaction lookup failed',
-            response: lookupErr?.response?.data ?? null,
-          }
-        }
-      }
-
-      console.warn('[clob] Redeem relay completed without transaction hash; treating as not confirmed')
-      return c.json(withOperation({
-        error: 'Redeem not confirmed',
-        detail: 'Relayer completed without returning a transaction hash',
-        relayer: relayInfo,
-        relayerTransaction,
-        redeemContext,
-        collateralBalances,
-      }, {
-        ok: false,
-        operation: 'redeem',
-        status: 'failed',
-        userMessage: 'Collect was submitted but not confirmed. Refresh before trying again.',
-        retry: { canRetry: true, pollAfterMs: 10_000 },
-        lifecycleError: { code: 'PREDICT_REDEEM_FAILED' },
-      }), 502)
-    }
-
-    console.log(`[clob] Redeemed positions for ${polygonAddress} condition=${conditionId.slice(0, 10)}... tx=${txHash}`)
+    const { signatureRequest } = await prepareTradingWalletCalls(session, redeemTxs, 'redeem')
+    console.log(`[clob] Redeem signature required for ${polygonAddress} condition=${conditionId.slice(0, 10)}...`)
 
     return c.json(withOperation({
-      txHash,
+      signatureRequest,
       redeemContext,
       collateralBalances,
       redeemedCollaterals: redeemableCollaterals,
     }, {
-      ok: true,
+      ok: false,
       operation: 'redeem',
-      status: 'collecting',
-      userMessage: 'Collect submitted. We will keep this pick visible until it confirms.',
+      status: 'needs_signature',
+      userMessage: 'Sign once to collect this payout.',
       identifiers: {
-        txHash,
         conditionId,
         tokenId: asset,
-        relayerTransactionId: relayInfo.transactionID ?? undefined,
       },
-      retry: { canRetry: false, pollAfterMs: 10_000 },
+      retry: { canRetry: true },
     }))
   } catch (err: any) {
     console.error('[clob] Redeem failed:', {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -299,6 +299,11 @@ type ActivityFallbackGroup = {
   outcomeIndex: number
 }
 
+type ActivityCostBasis = {
+  totalSize: number
+  totalUsdc: number
+}
+
 function activityDedupeKey(input: unknown): string {
   const activity = asRecord(input)
   if (!activity) return JSON.stringify(input)
@@ -326,6 +331,92 @@ function dedupeActivity(input: unknown[]): unknown[] {
     deduped.push(item)
   }
   return deduped
+}
+
+function activityCostBasisKey(input: {
+  asset?: unknown
+  conditionId?: unknown
+  outcomeIndex?: unknown
+}): string | null {
+  const asset = typeof input.asset === 'string' ? input.asset.toLowerCase() : ''
+  const conditionId = typeof input.conditionId === 'string' ? input.conditionId.toLowerCase() : ''
+  const outcomeIndex = parseNullableNumber(input.outcomeIndex)
+  if (!asset || !conditionId || outcomeIndex === null) return null
+  return `${conditionId}:${outcomeIndex}:${asset}`
+}
+
+function buildActivityCostBasis(activity: unknown[]): Map<string, ActivityCostBasis> {
+  const basis = new Map<string, ActivityCostBasis>()
+  const seenTrades = new Set<string>()
+
+  for (const raw of activity) {
+    const trade = asRecord(raw)
+    if (!trade) continue
+    if (trade.type !== 'TRADE' || trade.side !== 'BUY') continue
+
+    const key = activityCostBasisKey(trade)
+    const size = parseNullableNumber(trade.size) ?? parseNullableNumber(trade.amount) ?? 0
+    const usdcSize = parseNullableNumber(trade.usdcSize) ?? 0
+    if (!key || size <= 0 || usdcSize <= 0) continue
+
+    const dedupeKey = [
+      trade.transactionHash,
+      trade.asset,
+      trade.conditionId,
+      trade.outcomeIndex,
+      size,
+      usdcSize,
+      trade.price,
+    ].join(':')
+    if (seenTrades.has(dedupeKey)) continue
+    seenTrades.add(dedupeKey)
+
+    const existing = basis.get(key)
+    if (existing) {
+      existing.totalSize += size
+      existing.totalUsdc += usdcSize
+    } else {
+      basis.set(key, { totalSize: size, totalUsdc: usdcSize })
+    }
+  }
+
+  return basis
+}
+
+function hydrateMissingPositionCostBasis(positions: unknown[], activity: unknown[]): unknown[] {
+  if (positions.length === 0 || activity.length === 0) return positions
+
+  const basis = buildActivityCostBasis(activity)
+  if (basis.size === 0) return positions
+
+  return positions.map((raw) => {
+    const position = asRecord(raw)
+    if (!position) return raw
+
+    const key = activityCostBasisKey(position)
+    const costBasis = key ? basis.get(key) : undefined
+    if (!costBasis || costBasis.totalSize <= 0 || costBasis.totalUsdc <= 0) return raw
+
+    const avgPrice = parseNullableNumber(position.avgPrice) ?? 0
+    const size = parseNullableNumber(position.size) ?? 0
+    const existingCost = avgPrice * size
+    if (avgPrice > 0 && existingCost > 0) return raw
+
+    const hydratedAvgPrice = Math.round((costBasis.totalUsdc / costBasis.totalSize) * 100) / 100
+    const currentValue = parseNullableNumber(position.currentValue)
+    const hydrated: Record<string, unknown> = {
+      ...position,
+      avgPrice: hydratedAvgPrice,
+    }
+
+    if (currentValue !== null) {
+      const cost = hydratedAvgPrice * size
+      hydrated.cashPnl = Math.round((currentValue - cost) * 100) / 100
+      hydrated.percentPnl = cost > 0 ? Math.round(((currentValue - cost) / cost) * 10_000) / 100 : position.percentPnl
+    }
+
+    return hydrated
+  })
 }
 
 async function fetchGammaMarketsForSlug(slug: string): Promise<Record<string, unknown>[]> {
@@ -1517,6 +1608,9 @@ app.get('/predict/portfolio/:address', async (c) => {
       activity = Array.isArray(body) ? dedupeActivity(body) : []
     }
 
+    positions = hydrateMissingPositionCostBasis(positions, activity)
+    redeemablePositions = hydrateMissingPositionCostBasis(redeemablePositions, activity)
+
     // Some deposit-wallet trades appear in data-api /activity before they appear in
     // /positions or /closed-positions. If portfolio state is otherwise empty, expose
     // closed historical picks reconstructed from activity and final Gamma prices.
@@ -1723,9 +1817,15 @@ app.get('/predict/positions/:address/market/:slug', async (c) => {
   if (!address?.trim() || !slug?.trim()) return c.json({ error: 'Bad request' }, 400)
 
   try {
-    const res = await dataApiFetch(
-      `positions?user=${encodeURIComponent(address)}&redeemable=false&sizeThreshold=0.1&limit=100&sortBy=CURRENT&sortDirection=DESC`
-    )
+    const [positionsRes, activityRes] = await Promise.allSettled([
+      dataApiFetch(`positions?user=${encodeURIComponent(address)}&redeemable=false&sizeThreshold=0.1&limit=100&sortBy=CURRENT&sortDirection=DESC`),
+      dataApiFetch(`activity?user=${encodeURIComponent(address)}&limit=500&sortBy=TIMESTAMP&sortDirection=DESC`),
+    ])
+    if (positionsRes.status !== 'fulfilled') {
+      console.error(`[api] data-api /positions request failed`, positionsRes.reason)
+      return c.json({ error: 'Failed to fetch positions' }, 502)
+    }
+    const res = positionsRes.value
     if (!res.ok) {
       console.error(`[api] data-api /positions error ${res.status}`)
       return c.json({ error: 'Failed to fetch positions' }, 502)
@@ -1733,8 +1833,14 @@ app.get('/predict/positions/:address/market/:slug', async (c) => {
     const body = await res.json() as unknown
     if (!Array.isArray(body)) return c.json([])
 
+    let activity: unknown[] = []
+    if (activityRes.status === 'fulfilled' && activityRes.value.ok) {
+      const activityBody = await activityRes.value.json() as unknown
+      activity = Array.isArray(activityBody) ? dedupeActivity(activityBody) : []
+    }
+
     // Filter positions matching this market's slug or eventSlug
-    const filtered = body.filter((p: unknown) => {
+    const filtered = hydrateMissingPositionCostBasis(body, activity).filter((p: unknown) => {
       const pos = p as Record<string, unknown>
       return pos.slug === slug || pos.eventSlug === slug
     })

--- a/packages/api/src/polymarket/lifecycle.ts
+++ b/packages/api/src/polymarket/lifecycle.ts
@@ -19,6 +19,7 @@ export type PredictOperationStatus =
   | 'collecting'
   | 'bridging'
   | 'completed'
+  | 'needs_signature'
   | 'failed'
   | 'session_expired'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@lazorkit/wallet':
         specifier: ^2.0.1
         version: 2.0.1(17ead120ad251825c008fcd7899b3d31)
+      '@polymarket/clob-client-v2':
+        specifier: 1.0.3-canary.0
+        version: 1.0.3-canary.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@privy-io/expo':
         specifier: ^0.65.1
         version: 0.65.1(81f869a6a72ad1f6962ef31583c1e5ee)


### PR DESCRIPTION
## Summary
- Remove server-side Predict EVM private-key derivation and user signing
- Move Polymarket CLOB credential creation, order signing, and deposit-wallet batch signing to the Expo client
- Keep the server responsible for builder-authenticated relay submission, session metadata, and Polymarket proxy calls
- Extend deposit-wallet batch deadlines to avoid live relayer `deadline too soon` failures
- Hydrate missing Predict position entry prices from recent trade activity when Polymarket data-api initially returns `avgPrice: 0`

## Why
The previous Predict wallet flow derived the user's EVM signer on the server from Solana signature material. This PR removes that server custody path. The server no longer receives the raw Solana signature or user EVM private key and cannot sign EVM typed data as the user.

## Validation
- `pnpm --filter hybrid-expo exec expo lint --max-warnings=0`
- `pnpm --filter hybrid-expo exec expo export --platform web --output-dir /tmp/myboon-predict-export`
- `pnpm --filter @myboon/api exec tsx -e "import('./src/clob.ts').then(() => { console.log('clob import ok'); process.exit(0); })"`
- `SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=dummy pnpm --filter @myboon/api exec tsx -e "import('./src/index.ts').then(() => { console.log('api import ok'); process.exit(0); })"`
- `git diff --check`

## Notes
- Expo `tsc` still has existing unrelated failures in `e2e/predict-live.spec.ts` and `playwright.predict.config.ts`.
- `apps/hybrid-expo/.expo/types/router.d.ts` was already dirty/generated locally and is intentionally not included.
