### PR TITLE
[codex] Add Predict wallet export UX

### DIFF
--- a/apps/hybrid-expo/app/predict-profile.tsx
+++ b/apps/hybrid-expo/app/predict-profile.tsx
@@ -18,6 +18,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppTopBar, AppTopBarIconButton, AppTopBarTitle } from '@/components/AppTopBar';
 import { DepositModal } from '@/components/predict/DepositModal';
 import { WithdrawModal } from '@/components/predict/WithdrawModal';
+import { PredictOwnerKeyExportModal } from '@/features/predict/components/PredictOwnerKeyExportModal';
 import { fetchPortfolio, fetchClobBalance, fetchOpenOrders, cancelOrder, placeBet } from '@/features/predict/predict.api';
 import type { OpenOrder, PortfolioData, PortfolioPosition } from '@/features/predict/predict.api';
 import { truncateUsd } from '@/features/predict/formatPredictMoney';
@@ -39,6 +40,7 @@ const PREDICT_PROFILE_FALLBACK_USD_TO_INR = 95.67;
 const USD_INR_RATE_URL = 'https://open.er-api.com/v6/latest/USD';
 const PREDICT_PROFILE_CURRENCY_KEY = 'predict-profile-currency-format';
 type PredictProfileCurrency = 'USD' | 'INR';
+type PredictSettingsView = 'menu' | 'currency' | 'wallet';
 
 function formatProfileCurrency(
   value: number | null | undefined,
@@ -75,7 +77,7 @@ function getOrderCost(order: OpenOrder): number {
 export default function PredictProfileScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { connected, address: solanaAddress, source, sessionKey } = useWallet();
+  const { connected, address: solanaAddress, source, sessionKey, signMessage } = useWallet();
   const poly = usePolymarketWallet();
   const { open: openDrawer } = useDrawer();
   const [busy, setBusy] = useState(false);
@@ -98,6 +100,8 @@ export default function PredictProfileScreen() {
   const [usdToInrRate, setUsdToInrRate] = useState(PREDICT_PROFILE_FALLBACK_USD_TO_INR);
   const [currencyFormat, setCurrencyFormat] = useState<PredictProfileCurrency>('INR');
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsView, setSettingsView] = useState<PredictSettingsView>('menu');
+  const [predictExportOpen, setPredictExportOpen] = useState(false);
   const [cashOutPosition, setCashOutPosition] = useState<PortfolioPosition | null>(null);
   const [cashOutSubmitting, setCashOutSubmitting] = useState(false);
 
@@ -124,7 +128,13 @@ export default function PredictProfileScreen() {
   const selectCurrencyFormat = useCallback((next: PredictProfileCurrency) => {
     setCurrencyFormat(next);
     setSettingsOpen(false);
+    setSettingsView('menu');
     AsyncStorage.setItem(PREDICT_PROFILE_CURRENCY_KEY, next).catch(() => {});
+  }, []);
+
+  const closeSettings = useCallback(() => {
+    setSettingsOpen(false);
+    setSettingsView('menu');
   }, []);
 
   useEffect(() => {
@@ -661,39 +671,138 @@ export default function PredictProfileScreen() {
         formatMoney={formatProfileMoney}
       />
 
-      <Modal visible={settingsOpen} transparent animationType="fade" onRequestClose={() => setSettingsOpen(false)}>
+      <PredictOwnerKeyExportModal
+        visible={predictExportOpen}
+        onClose={() => setPredictExportOpen(false)}
+        solanaAddress={solanaAddress}
+        polygonAddress={poly.polygonAddress}
+        depositWalletAddress={poly.tradingAddress ?? poly.depositWalletAddress}
+        signMessage={signMessage}
+      />
+
+      <Modal visible={settingsOpen} transparent animationType="fade" onRequestClose={closeSettings}>
         <View style={styles.settingsBackdrop}>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Close Predict profile settings"
             style={StyleSheet.absoluteFill}
-            onPress={() => setSettingsOpen(false)}
+            onPress={closeSettings}
           />
           <View style={styles.settingsCard} accessibilityViewIsModal>
             <Text style={styles.settingsEyebrow}>Predict settings</Text>
-            <Text style={styles.settingsTitle}>Currency display</Text>
-            <Text style={styles.settingsCopy}>Choose how money shows on your Predict profile.</Text>
-            {(['USD', 'INR'] as const).map((currency) => {
-              const selected = currencyFormat === currency;
-              return (
+            {settingsView !== 'menu' && (
+              <Pressable style={styles.settingsBackRow} onPress={() => setSettingsView('menu')} accessibilityRole="button" accessibilityLabel="Back to Predict settings">
+                <MaterialIcons name="chevron-left" size={16} color={semantic.text.dim} />
+                <Text style={styles.settingsBackText}>Back</Text>
+              </Pressable>
+            )}
+
+            {settingsView === 'menu' && (
+              <>
+                <Text style={styles.settingsTitle}>Settings</Text>
+                <Text style={styles.settingsCopy}>Manage display and wallet controls for Predict.</Text>
                 <Pressable
-                  key={currency}
                   accessibilityRole="button"
-                  accessibilityLabel={`Show Predict profile values in ${currency}`}
-                  accessibilityState={{ selected }}
-                  style={[styles.currencyOption, selected && styles.currencyOptionSelected]}
-                  onPress={() => selectCurrencyFormat(currency)}
+                  accessibilityLabel="Open currency display settings"
+                  style={styles.settingsOption}
+                  onPress={() => setSettingsView('currency')}
                 >
-                  <View>
-                    <Text style={styles.currencyOptionTitle}>{currency}</Text>
-                    <Text style={styles.currencyOptionSub}>
-                      {currency === 'USD' ? '$ US dollars' : `₹ Indian rupees · live rate ${usdToInrRate.toFixed(2)}`}
-                    </Text>
+                  <View style={styles.settingsOptionIcon}>
+                    <MaterialIcons name="payments" size={15} color={tokens.colors.primary} />
                   </View>
-                  {selected && <MaterialIcons name="check-circle" size={20} color={tokens.colors.primary} />}
+                  <View style={styles.settingsOptionCopy}>
+                    <Text style={styles.settingsOptionTitle}>Currency display</Text>
+                    <Text style={styles.settingsOptionSub}>{currencyFormat} selected</Text>
+                  </View>
+                  <MaterialIcons name="chevron-right" size={18} color={semantic.text.faint} />
                 </Pressable>
-              );
-            })}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Open Predict wallet settings"
+                  style={styles.settingsOption}
+                  onPress={() => setSettingsView('wallet')}
+                >
+                  <View style={styles.settingsOptionIcon}>
+                    <MaterialIcons name="vpn-key" size={15} color={tokens.colors.viridian} />
+                  </View>
+                  <View style={styles.settingsOptionCopy}>
+                    <Text style={styles.settingsOptionTitle}>Predict wallet</Text>
+                    <Text style={styles.settingsOptionSub}>{poly.polygonAddress ? truncate(poly.polygonAddress) : 'Not connected'}</Text>
+                  </View>
+                  <MaterialIcons name="chevron-right" size={18} color={semantic.text.faint} />
+                </Pressable>
+              </>
+            )}
+
+            {settingsView === 'currency' && (
+              <>
+                <Text style={styles.settingsTitle}>Currency display</Text>
+                <Text style={styles.settingsCopy}>Choose how money shows on your Predict profile.</Text>
+                {(['USD', 'INR'] as const).map((currency) => {
+                  const selected = currencyFormat === currency;
+                  return (
+                    <Pressable
+                      key={currency}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Show Predict profile values in ${currency}`}
+                      accessibilityState={{ selected }}
+                      style={[styles.currencyOption, selected && styles.currencyOptionSelected]}
+                      onPress={() => selectCurrencyFormat(currency)}
+                    >
+                      <View>
+                        <Text style={styles.currencyOptionTitle}>{currency}</Text>
+                        <Text style={styles.currencyOptionSub}>
+                          {currency === 'USD' ? '$ US dollars' : `₹ Indian rupees · live rate ${usdToInrRate.toFixed(2)}`}
+                        </Text>
+                      </View>
+                      {selected && <MaterialIcons name="check-circle" size={20} color={tokens.colors.primary} />}
+                    </Pressable>
+                  );
+                })}
+              </>
+            )}
+
+            {settingsView === 'wallet' && (
+              <>
+                <Text style={styles.settingsTitle}>Predict wallet</Text>
+                <Text style={styles.settingsCopy}>
+                  Export the Polygon owner key that controls your Predict deposit wallet. Your Solana wallet signs once so the key can be derived locally.
+                </Text>
+                <View style={styles.walletInfoBox}>
+                  <View style={styles.walletInfoRow}>
+                    <Text style={styles.walletInfoLabel}>Solana</Text>
+                    <Text style={styles.walletInfoValue}>{solanaAddress ? truncate(solanaAddress) : '--'}</Text>
+                  </View>
+                  <View style={styles.walletInfoRow}>
+                    <Text style={styles.walletInfoLabel}>Owner EOA</Text>
+                    <Text style={styles.walletInfoValue}>{poly.polygonAddress ? truncate(poly.polygonAddress) : '--'}</Text>
+                  </View>
+                  <View style={styles.walletInfoRow}>
+                    <Text style={styles.walletInfoLabel}>Deposit wallet</Text>
+                    <Text style={styles.walletInfoValue}>{poly.tradingAddress ? truncate(poly.tradingAddress) : '--'}</Text>
+                  </View>
+                </View>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Export Predict owner key"
+                  style={[styles.exportOwnerButton, !isEnabled && styles.exportOwnerButtonDisabled]}
+                  disabled={!isEnabled}
+                  onPress={() => {
+                    setSettingsOpen(false);
+                    setSettingsView('menu');
+                    setPredictExportOpen(true);
+                  }}
+                >
+                  <MaterialIcons name="key" size={16} color={tokens.colors.backgroundDark} />
+                  <Text style={styles.exportOwnerButtonText}>Export Predict owner key</Text>
+                </Pressable>
+                <Text style={styles.settingsFinePrint}>
+                  {source === 'privy'
+                    ? 'Your Privy Solana wallet export lives in the main wallet drawer.'
+                    : 'This does not export your external Solana wallet. Export that from your wallet app.'}
+                </Text>
+              </>
+            )}
           </View>
         </View>
       </Modal>
@@ -743,6 +852,105 @@ const styles = StyleSheet.create({
     color: semantic.text.dim,
     lineHeight: 15,
     marginBottom: 4,
+  },
+  settingsBackRow: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    marginBottom: -2,
+    paddingVertical: 3,
+  },
+  settingsBackText: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    fontWeight: '800',
+    color: semantic.text.dim,
+  },
+  settingsOption: {
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 12,
+    padding: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: semantic.background.surface,
+  },
+  settingsOptionIcon: {
+    width: 30,
+    height: 30,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.04)',
+  },
+  settingsOptionCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  settingsOptionTitle: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  settingsOptionSub: {
+    marginTop: 3,
+    fontFamily: 'monospace',
+    fontSize: 9,
+    color: semantic.text.faint,
+  },
+  walletInfoBox: {
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    borderRadius: 12,
+    padding: 12,
+    gap: 9,
+    backgroundColor: semantic.background.surface,
+  },
+  walletInfoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  walletInfoLabel: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  walletInfoValue: {
+    flexShrink: 1,
+    fontFamily: 'monospace',
+    fontSize: 10,
+    color: semantic.text.primary,
+    textAlign: 'right',
+  },
+  exportOwnerButton: {
+    minHeight: 42,
+    borderRadius: 12,
+    backgroundColor: tokens.colors.primary,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  exportOwnerButtonDisabled: {
+    opacity: 0.45,
+  },
+  exportOwnerButtonText: {
+    fontFamily: 'monospace',
+    fontSize: 11,
+    fontWeight: '800',
+    color: tokens.colors.backgroundDark,
+  },
+  settingsFinePrint: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    color: semantic.text.faint,
+    lineHeight: 14,
   },
   currencyOption: {
     borderWidth: 1,

--- a/apps/hybrid-expo/components/drawer/WalletDrawer.tsx
+++ b/apps/hybrid-expo/components/drawer/WalletDrawer.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Animated,
   Keyboard,
+  Linking,
   Pressable,
   StyleSheet,
   Text,
@@ -24,6 +25,7 @@ import { fetchPhoenixTraderState } from '@/features/perps/phoenix.api';
 import { semantic, tokens } from '@/theme';
 
 const DRAWER_WIDTH = 280;
+const PRIVY_EXPORT_URL = process.env.EXPO_PUBLIC_PRIVY_EXPORT_URL;
 
 type WalletOption = {
   name: string;
@@ -176,6 +178,30 @@ export function WalletDrawer() {
       },
     ]);
   }, [source, poly, privy, walletDisconnect, close]);
+
+  const handleExportSolanaWallet = useCallback(async () => {
+    if (source !== 'privy') {
+      Alert.alert('External wallet', 'This Solana wallet is external. Export it from your wallet app.');
+      return;
+    }
+    if (!PRIVY_EXPORT_URL) {
+      Alert.alert(
+        'Export wallet',
+        'Privy Solana wallet export requires a hosted secure export page. Once configured, this button will open that flow.',
+      );
+      return;
+    }
+    try {
+      const separator = PRIVY_EXPORT_URL.includes('?') ? '&' : '?';
+      const url = address
+        ? `${PRIVY_EXPORT_URL}${separator}address=${encodeURIComponent(address)}`
+        : PRIVY_EXPORT_URL;
+      await Linking.openURL(url);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not open wallet export.';
+      Alert.alert('Export failed', msg);
+    }
+  }, [address, source]);
 
   const handleSendEmail = useCallback(async () => {
     if (!emailInput.trim() || busy) return;
@@ -370,6 +396,20 @@ export function WalletDrawer() {
             </View>
 
             <View style={styles.footer}>
+              {source === 'privy' && (
+                <TouchableOpacity
+                  onPress={handleExportSolanaWallet}
+                  activeOpacity={0.7}
+                  style={styles.exportWalletRow}
+                >
+                  <MaterialIcons
+                    name="file-download"
+                    size={12}
+                    color={semantic.text.dim}
+                  />
+                  <Text style={styles.exportWalletText}>Export wallet</Text>
+                </TouchableOpacity>
+              )}
               <TouchableOpacity
                 onPress={handleDisconnect}
                 activeOpacity={0.6}
@@ -795,6 +835,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 6,
     paddingVertical: 4,
+  },
+  exportWalletRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 4,
+  },
+  exportWalletText: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '600',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: semantic.text.dim,
   },
   disconnectText: {
     fontFamily: 'monospace',

--- a/apps/hybrid-expo/features/predict/components/PredictOwnerKeyExportModal.tsx
+++ b/apps/hybrid-expo/features/predict/components/PredictOwnerKeyExportModal.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { deriveEvmSignerFromSignature, PREDICT_DERIVE_MESSAGE } from '@/hooks/useEvmSigner';
+import { deriveReadonlyEvmSignerFromSignature, PREDICT_DERIVE_MESSAGE } from '@/hooks/useEvmSigner';
 import { semantic, tokens } from '@/theme';
 
 interface PredictOwnerKeyExportModalProps {
@@ -36,6 +36,7 @@ export function PredictOwnerKeyExportModal({
   const [privateKey, setPrivateKey] = useState<string | null>(null);
   const [derivedAddress, setDerivedAddress] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const exportRequestRef = useRef(0);
 
   const canStart = useMemo(
     () => acknowledged && !!signMessage && !!polygonAddress && !!solanaAddress,
@@ -43,6 +44,7 @@ export function PredictOwnerKeyExportModal({
   );
 
   const reset = useCallback(() => {
+    exportRequestRef.current += 1;
     setState('idle');
     setAcknowledged(false);
     setRevealed(false);
@@ -71,21 +73,25 @@ export function PredictOwnerKeyExportModal({
   const handleExport = useCallback(async () => {
     if (!canStart || !signMessage || !polygonAddress) return;
     setState('signing');
+    const requestId = ++exportRequestRef.current;
     setError(null);
     setPrivateKey(null);
     setDerivedAddress(null);
     setRevealed(false);
     try {
       const signature = await signMessage(new TextEncoder().encode(PREDICT_DERIVE_MESSAGE));
-      const { eoaAddress, wallet } = deriveEvmSignerFromSignature(signature);
+      if (exportRequestRef.current !== requestId) return;
+      const { eoaAddress, wallet } = deriveReadonlyEvmSignerFromSignature(signature);
       if (eoaAddress.toLowerCase() !== polygonAddress.toLowerCase()) {
         throw new Error('This Solana wallet derives a different Predict owner key.');
       }
+      if (exportRequestRef.current !== requestId) return;
       setDerivedAddress(eoaAddress);
       setPrivateKey(wallet.privateKey);
       setState('ready');
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     } catch (err) {
+      if (exportRequestRef.current !== requestId) return;
       setError(err instanceof Error ? err.message : 'Could not export Predict owner key.');
       setState('error');
     }

--- a/apps/hybrid-expo/features/predict/components/PredictOwnerKeyExportModal.tsx
+++ b/apps/hybrid-expo/features/predict/components/PredictOwnerKeyExportModal.tsx
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, AppState, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import * as Haptics from 'expo-haptics';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { deriveEvmSignerFromSignature, PREDICT_DERIVE_MESSAGE } from '@/hooks/useEvmSigner';
+import { semantic, tokens } from '@/theme';
+
+interface PredictOwnerKeyExportModalProps {
+  visible: boolean;
+  onClose: () => void;
+  solanaAddress: string | null;
+  polygonAddress: string | null;
+  depositWalletAddress: string | null;
+  signMessage: ((message: Uint8Array) => Promise<Uint8Array>) | null;
+}
+
+type ExportState = 'idle' | 'signing' | 'ready' | 'error';
+
+function truncateAddress(address: string | null | undefined, start = 8, end = 6): string {
+  if (!address) return '--';
+  return `${address.slice(0, start)}...${address.slice(-end)}`;
+}
+
+export function PredictOwnerKeyExportModal({
+  visible,
+  onClose,
+  solanaAddress,
+  polygonAddress,
+  depositWalletAddress,
+  signMessage,
+}: PredictOwnerKeyExportModalProps) {
+  const [state, setState] = useState<ExportState>('idle');
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+  const [privateKey, setPrivateKey] = useState<string | null>(null);
+  const [derivedAddress, setDerivedAddress] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const canStart = useMemo(
+    () => acknowledged && !!signMessage && !!polygonAddress && !!solanaAddress,
+    [acknowledged, signMessage, polygonAddress, solanaAddress],
+  );
+
+  const reset = useCallback(() => {
+    setState('idle');
+    setAcknowledged(false);
+    setRevealed(false);
+    setPrivateKey(null);
+    setDerivedAddress(null);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) reset();
+  }, [visible, reset]);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'active') reset();
+    });
+    return () => subscription.remove();
+  }, [reset, visible]);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [onClose, reset]);
+
+  const handleExport = useCallback(async () => {
+    if (!canStart || !signMessage || !polygonAddress) return;
+    setState('signing');
+    setError(null);
+    setPrivateKey(null);
+    setDerivedAddress(null);
+    setRevealed(false);
+    try {
+      const signature = await signMessage(new TextEncoder().encode(PREDICT_DERIVE_MESSAGE));
+      const { eoaAddress, wallet } = deriveEvmSignerFromSignature(signature);
+      if (eoaAddress.toLowerCase() !== polygonAddress.toLowerCase()) {
+        throw new Error('This Solana wallet derives a different Predict owner key.');
+      }
+      setDerivedAddress(eoaAddress);
+      setPrivateKey(wallet.privateKey);
+      setState('ready');
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not export Predict owner key.');
+      setState('error');
+    }
+  }, [canStart, polygonAddress, signMessage]);
+
+  const copyPrivateKey = useCallback(async () => {
+    if (!privateKey || !revealed) return;
+    await Clipboard.setStringAsync(privateKey);
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+  }, [privateKey, revealed]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+      <View style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleClose} accessibilityRole="button" accessibilityLabel="Close export Predict owner key" />
+        <View style={styles.card} accessibilityViewIsModal>
+          <View style={styles.header}>
+            <View>
+              <Text style={styles.eyebrow}>Predict wallet</Text>
+              <Text style={styles.title}>Export owner key</Text>
+            </View>
+            <Pressable accessibilityRole="button" accessibilityLabel="Close" onPress={handleClose} style={styles.iconButton}>
+              <MaterialIcons name="close" size={16} color={semantic.text.dim} />
+            </Pressable>
+          </View>
+
+          <Text style={styles.copy}>
+            This exports the Polygon owner key that controls your Predict deposit wallet. The deposit wallet is a smart contract wallet and does not have its own private key.
+          </Text>
+
+          <View style={styles.addressBox}>
+            <AddressRow label="Solana wallet" value={truncateAddress(solanaAddress)} />
+            <AddressRow label="Owner EOA" value={truncateAddress(derivedAddress ?? polygonAddress)} />
+            <AddressRow label="Deposit wallet" value={truncateAddress(depositWalletAddress)} />
+          </View>
+
+          <View style={styles.warningBox}>
+            <MaterialIcons name="warning" size={15} color={tokens.colors.vermillion} />
+            <Text style={styles.warningText}>
+              Anyone with this key can control your Predict owner wallet. Do not share it or paste it into a site you do not trust.
+            </Text>
+          </View>
+
+          {state !== 'ready' && (
+            <Pressable
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: acknowledged }}
+              style={styles.checkRow}
+              onPress={() => setAcknowledged((current) => !current)}
+            >
+              <View style={[styles.checkbox, acknowledged && styles.checkboxOn]}>
+                {acknowledged && <MaterialIcons name="check" size={12} color={tokens.colors.backgroundDark} />}
+              </View>
+              <Text style={styles.checkText}>I understand this private key gives full control of my Predict owner wallet.</Text>
+            </Pressable>
+          )}
+
+          {state === 'ready' && privateKey && (
+            <View style={styles.secretBox}>
+              <Text style={styles.secretLabel}>Private key</Text>
+              <Text style={styles.secretValue} numberOfLines={revealed ? 4 : 1}>
+                {revealed ? privateKey : '************************************************'}
+              </Text>
+              <View style={styles.secretActions}>
+                <Pressable style={styles.secondaryAction} onPress={() => setRevealed((current) => !current)}>
+                  <Text style={styles.secondaryActionText}>{revealed ? 'Hide' : 'Reveal'}</Text>
+                </Pressable>
+                <Pressable style={[styles.secondaryAction, !revealed && styles.disabledAction]} onPress={copyPrivateKey} disabled={!revealed}>
+                  <Text style={styles.secondaryActionText}>Copy key</Text>
+                </Pressable>
+              </View>
+            </View>
+          )}
+
+          {state === 'error' && error && <Text style={styles.errorText}>{error}</Text>}
+
+          {state !== 'ready' ? (
+            <Pressable
+              style={[styles.primaryAction, !canStart && styles.disabledAction]}
+              onPress={handleExport}
+              disabled={!canStart || state === 'signing'}
+            >
+              {state === 'signing' ? (
+                <ActivityIndicator size="small" color={tokens.colors.backgroundDark} />
+              ) : (
+                <Text style={styles.primaryActionText}>Sign to export</Text>
+              )}
+            </Pressable>
+          ) : (
+            <Pressable style={styles.primaryAction} onPress={handleClose}>
+              <Text style={styles.primaryActionText}>Done</Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function AddressRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.addressRow}>
+      <Text style={styles.addressLabel}>{label}</Text>
+      <Text style={styles.addressValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.66)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 360,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: tokens.colors.ground,
+    padding: 18,
+    gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  eyebrow: {
+    fontFamily: 'monospace',
+    fontSize: 8,
+    fontWeight: '800',
+    color: semantic.text.faint,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  title: {
+    marginTop: 3,
+    fontFamily: 'monospace',
+    fontSize: 18,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  iconButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.04)',
+  },
+  copy: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    lineHeight: 15,
+    color: semantic.text.dim,
+  },
+  addressBox: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: semantic.background.surface,
+    padding: 12,
+    gap: 9,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  addressLabel: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  addressValue: {
+    flexShrink: 1,
+    fontFamily: 'monospace',
+    fontSize: 10,
+    color: semantic.text.primary,
+    textAlign: 'right',
+  },
+  warningBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(244,88,78,0.34)',
+    backgroundColor: 'rgba(244,88,78,0.10)',
+    padding: 11,
+  },
+  warningText: {
+    flex: 1,
+    fontFamily: 'monospace',
+    fontSize: 9,
+    lineHeight: 14,
+    color: semantic.text.primary,
+  },
+  checkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 9,
+  },
+  checkbox: {
+    width: 20,
+    height: 20,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxOn: {
+    borderColor: tokens.colors.primary,
+    backgroundColor: tokens.colors.primary,
+  },
+  checkText: {
+    flex: 1,
+    fontFamily: 'monospace',
+    fontSize: 9,
+    lineHeight: 14,
+    color: semantic.text.dim,
+  },
+  secretBox: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    backgroundColor: 'rgba(0,0,0,0.16)',
+    padding: 12,
+    gap: 8,
+  },
+  secretLabel: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    fontWeight: '800',
+    color: semantic.text.faint,
+    textTransform: 'uppercase',
+  },
+  secretValue: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    lineHeight: 15,
+    color: semantic.text.primary,
+  },
+  secretActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  primaryAction: {
+    minHeight: 44,
+    borderRadius: 12,
+    backgroundColor: tokens.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    fontWeight: '800',
+    color: tokens.colors.backgroundDark,
+  },
+  secondaryAction: {
+    flex: 1,
+    minHeight: 34,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: semantic.border.muted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryActionText: {
+    fontFamily: 'monospace',
+    fontSize: 10,
+    fontWeight: '800',
+    color: semantic.text.primary,
+  },
+  disabledAction: {
+    opacity: 0.45,
+  },
+  errorText: {
+    fontFamily: 'monospace',
+    fontSize: 9,
+    lineHeight: 14,
+    color: tokens.colors.vermillion,
+  },
+});

--- a/apps/hybrid-expo/hooks/useEvmSigner.ts
+++ b/apps/hybrid-expo/hooks/useEvmSigner.ts
@@ -15,15 +15,26 @@ import { keccak256 } from '@ethersproject/keccak256';
 let activeEvmWallet: Wallet | null = null;
 export const PREDICT_DERIVE_MESSAGE = 'myboon:polymarket:enable';
 
+function walletFromSolanaSignature(solanaSignature: Uint8Array): Wallet {
+  const sigHex = '0x' + Array.from(solanaSignature, (b: number) => b.toString(16).padStart(2, '0')).join('');
+  const evmPrivateKey = keccak256(sigHex);
+  return new Wallet(evmPrivateKey);
+}
+
+export function deriveReadonlyEvmSignerFromSignature(
+  solanaSignature: Uint8Array,
+): { eoaAddress: string; wallet: Wallet } {
+  const wallet = walletFromSolanaSignature(solanaSignature);
+  return { eoaAddress: wallet.address, wallet };
+}
+
 export function deriveEvmSignerFromSignature(
   solanaSignature: Uint8Array,
 ): { eoaAddress: string; wallet: Wallet } {
-  const sigHex = '0x' + Array.from(solanaSignature, (b: number) => b.toString(16).padStart(2, '0')).join('');
-  const evmPrivateKey = keccak256(sigHex);
-  const wallet = new Wallet(evmPrivateKey);
-  activeEvmWallet = wallet;
-  if (__DEV__) console.log('[evm-signer] Derived EOA:', wallet.address);
-  return { eoaAddress: wallet.address, wallet };
+  const signer = deriveReadonlyEvmSignerFromSignature(solanaSignature);
+  activeEvmWallet = signer.wallet;
+  if (__DEV__) console.log('[evm-signer] Derived EOA:', signer.eoaAddress);
+  return signer;
 }
 
 export function getActiveEvmWallet(): Wallet | null {

--- a/apps/hybrid-expo/hooks/useEvmSigner.ts
+++ b/apps/hybrid-expo/hooks/useEvmSigner.ts
@@ -13,6 +13,7 @@ import { Wallet } from '@ethersproject/wallet';
 import { keccak256 } from '@ethersproject/keccak256';
 
 let activeEvmWallet: Wallet | null = null;
+export const PREDICT_DERIVE_MESSAGE = 'myboon:polymarket:enable';
 
 export function deriveEvmSignerFromSignature(
   solanaSignature: Uint8Array,

--- a/apps/hybrid-expo/hooks/usePolymarketWallet.ts
+++ b/apps/hybrid-expo/hooks/usePolymarketWallet.ts
@@ -15,9 +15,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useWallet } from '@/hooks/useWallet';
+import { PREDICT_DERIVE_MESSAGE } from '@/hooks/useEvmSigner';
 import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
 
-const DERIVE_MESSAGE = 'myboon:polymarket:enable';
 const STORAGE_KEY = 'polymarket_polygon_address'; // Public address only, not a secret
 const DEPOSIT_WALLET_STORAGE_KEY = 'polymarket_deposit_wallet_address';
 const WALLET_MODE_STORAGE_KEY = 'polymarket_wallet_mode';
@@ -217,7 +217,7 @@ export function usePolymarketWallet(): PolymarketWallet {
     setIsLoading(true);
     try {
       // Step 1: Sign deterministic message with Solana wallet (MWA prompt)
-      const messageBytes = new TextEncoder().encode(DERIVE_MESSAGE);
+      const messageBytes = new TextEncoder().encode(PREDICT_DERIVE_MESSAGE);
       const signature = await startSignMessage(messageBytes);
       assertWalletUnchanged();
 


### PR DESCRIPTION
## Summary
- Add a Predict settings wallet section with an export flow for the derived Polygon owner key
- Require acknowledgement, fresh Solana signature, local re-derivation, and owner address verification before revealing the private key
- Clear exported key material when the modal closes or the app backgrounds
- Add a Privy-only main wallet drawer export entry that opens a hosted Privy export page when `EXPO_PUBLIC_PRIVY_EXPORT_URL` is configured

## Why
Users need a safe way to export the wallet/key that controls their Predict account. This keeps Predict owner-key export fully client-side and clearly distinguishes the Polygon owner EOA from the Polymarket deposit smart wallet.

## Validation
- `pnpm --filter hybrid-expo exec expo lint --max-warnings=0`
- `pnpm --filter hybrid-expo exec expo export --platform web --output-dir /tmp/myboon-export-wallet-2`
- `git diff --check`

## Notes
- `pnpm --filter hybrid-expo exec tsc --noEmit --pretty false` still reports existing unrelated failures in `e2e/predict-live.spec.ts` and `playwright.predict.config.ts`.
- `apps/hybrid-expo/.expo/types/router.d.ts` is generated/dirty locally and intentionally not included.
- Privy embedded Solana wallet export on mobile requires a hosted React export page/WebView flow per Privy docs; this PR wires the app entry point and URL config rather than attempting native private-key export.

Closes #175.
