### PR TITLE
Build Publisher V1 from editor drafts

### DIFF
--- a/apps/hybrid-expo/features/feed/feed.api.ts
+++ b/apps/hybrid-expo/features/feed/feed.api.ts
@@ -4,10 +4,13 @@ import { resolveApiBaseUrl, fetchWithTimeout } from '@/lib/api';
 interface PublishedNarrativeListItem {
   id: string;
   narrative_id: string;
+  title?: string | null;
   content_small: string;
   tags: string[];
   priority: number;
   actions: unknown;
+  entity_category?: string | null;
+  published_at?: string | null;
   created_at: string;
 }
 
@@ -80,12 +83,13 @@ function extractHeadline(content: string): { headline: string; body: string } {
 function mapNarrativeToFeedItem(item: PublishedNarrativeListItem, index: number): FeedItem {
   const raw = item.content_small?.trim() ?? '';
   const { headline, body } = extractHeadline(raw);
+  const title = item.title?.trim();
   return {
     id: item.id,
-    category: item.tags?.[0] ?? 'macro',
-    createdAt: item.created_at,
-    headline,
-    description: body,
+    category: item.entity_category?.trim() || item.tags?.[0] || 'macro',
+    createdAt: item.published_at ?? item.created_at,
+    headline: title || headline,
+    description: title ? raw : body,
     isTop: index === 0,
     actions: parseActions(item.actions),
   };
@@ -112,11 +116,18 @@ export async function fetchFeedItems(limit = 20, offset = 0): Promise<FeedItem[]
 
 export interface NarrativeDetail {
   id: string;
+  title?: string | null;
   content_full: string;
   content_small: string;
   tags: string[];
   priority: number;
   actions: unknown;
+  entity_id?: string | null;
+  entity_slug?: string | null;
+  entity_name?: string | null;
+  entity_type?: string | null;
+  entity_category?: string | null;
+  published_at?: string | null;
   created_at: string;
 }
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -9,7 +9,7 @@
 | `myboon-polymarket-researcher` | `packages/collectors` | Polymarket Researcher |
 | `myboon-editor-draft` | `packages/collectors` | Entity Memory to Editor Draft |
 | `myboon-polymarket-editor` | `packages/collectors` | Polymarket Editor |
-| `myboon-polymarket-publisher` | `packages/collectors` | Polymarket Publisher |
+| `myboon-publisher` | `packages/collectors` | Generic Editor Draft Publisher |
 
 ---
 
@@ -62,7 +62,7 @@ pm2 restart myboon-polymarket-data-engineer
 pm2 restart myboon-polymarket-researcher
 pm2 restart myboon-editor-draft
 pm2 restart myboon-polymarket-editor
-pm2 restart myboon-polymarket-publisher
+pm2 restart myboon-publisher
 
 # Stop everything
 pm2 stop all
@@ -91,10 +91,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 POLYMARKET_MARKETS_RUN_ONCE=0
 POLYMARKET_RESEARCHER_RUN_ONCE=0
 POLYMARKET_EDITOR_RUN_ONCE=0
-POLYMARKET_PUBLISHER_RUN_ONCE=0
 EDITOR_DRAFT_RUN_ONCE=0
 EDITOR_DRAFT_INTERVAL_MS=3600000
 EDITOR_DRAFT_BATCH_SIZE=2
+PUBLISHER_RUN_ONCE=0
+PUBLISHER_INTERVAL_MS=300000
+PUBLISHER_BATCH_SIZE=10
+PUBLISHER_PREVIEW_ONLY=0
 ```
 
 ---

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -70,5 +70,22 @@ module.exports = {
         EDITOR_DRAFT_PUBLISHED_HISTORY_LIMIT: '10',
       },
     },
+    {
+      name: 'myboon-publisher',
+      script: 'src/publisher/run.ts',
+      interpreter: TSX,
+      cwd: `${ROOT}/packages/collectors`,
+      watch: false,
+      autorestart: true,
+      max_restarts: 10,
+      restart_delay: 5000,
+      log_date_format: 'YYYY-MM-DD HH:mm:ss',
+      env: {
+        PUBLISHER_RUN_ONCE: '0',
+        PUBLISHER_INTERVAL_MS: '300000',
+        PUBLISHER_BATCH_SIZE: '10',
+        PUBLISHER_PREVIEW_ONLY: '0',
+      },
+    },
   ],
 }

--- a/infra/vps/deploy.sh
+++ b/infra/vps/deploy.sh
@@ -23,6 +23,7 @@ echo "Building workspace packages..."
 pnpm --filter @myboon/shared build
 pnpm --filter @myboon/entity-memory build
 pnpm --filter @myboon/tx-parser build
+pnpm --filter @myboon/collectors build
 pnpm --filter @myboon/brain build
 
 echo "Restarting services..."

--- a/infra/vps/systemd/myboon-publisher.service
+++ b/infra/vps/systemd/myboon-publisher.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/myboon/packages/brain
+WorkingDirectory=/opt/myboon/packages/collectors
 ExecStart=/usr/bin/env pnpm publisher
 Restart=always
 RestartSec=3

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -86,6 +86,34 @@ async function supabaseFetch(path: string): Promise<Response> {
   return fetch(`${SUPABASE_URL}/rest/v1/${path}`, { headers: supabaseHeaders() })
 }
 
+function looksLikePublishedNarrativesV1SchemaMiss(status: number, body: string): boolean {
+  if (status !== 400) return false
+  return /published_narratives/i.test(body)
+    && /(status|published_at|title|entity_id|entity_slug|entity_name|entity_type|entity_category)/i.test(body)
+}
+
+async function supabaseFetchWithSchemaFallback(
+  primaryPath: string,
+  fallbackPath: string,
+  context: string
+): Promise<Response> {
+  const primary = await supabaseFetch(primaryPath)
+  if (primary.ok) return primary
+
+  const body = await primary.text()
+  if (!looksLikePublishedNarrativesV1SchemaMiss(primary.status, body)) {
+    console.error(`[api] Supabase error ${primary.status}: ${body}`)
+    return new Response(body, {
+      status: primary.status,
+      statusText: primary.statusText,
+      headers: primary.headers,
+    })
+  }
+
+  console.warn(`[api] ${context} falling back to legacy published_narratives shape; apply publisher V1 migration to remove this fallback.`)
+  return supabaseFetch(fallbackPath)
+}
+
 async function supabaseWrite(path: string, method: 'POST' | 'PATCH', body: unknown, extraHeaders: Record<string, string> = {}): Promise<Response> {
   return fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
     method,
@@ -666,8 +694,10 @@ app.get('/narratives', async (c) => {
   const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
 
   try {
-    const res = await supabaseFetch(
-      `published_narratives?select=id,narrative_id,title,content_small,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&status=eq.published&order=published_at.desc,priority.desc&limit=${limit}&offset=${offset}`
+    const res = await supabaseFetchWithSchemaFallback(
+      `published_narratives?select=id,narrative_id,title,content_small,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&status=eq.published&order=published_at.desc,priority.desc&limit=${limit}&offset=${offset}`,
+      `published_narratives?select=id,narrative_id,content_small,tags,priority,actions,thread_id,created_at&order=created_at.desc,priority.desc&limit=${limit}&offset=${offset}`,
+      'GET /narratives'
     )
 
     if (!res.ok) {
@@ -692,8 +722,10 @@ app.get('/narratives/:id', async (c) => {
   }
 
   try {
-    const res = await supabaseFetch(
-      `published_narratives?id=eq.${encodeURIComponent(id)}&status=eq.published&select=id,narrative_id,title,content_small,content_full,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&limit=1`
+    const res = await supabaseFetchWithSchemaFallback(
+      `published_narratives?id=eq.${encodeURIComponent(id)}&status=eq.published&select=id,narrative_id,title,content_small,content_full,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&limit=1`,
+      `published_narratives?id=eq.${encodeURIComponent(id)}&select=id,narrative_id,content_small,content_full,tags,priority,actions,thread_id,created_at&limit=1`,
+      'GET /narratives/:id'
     )
 
     if (!res.ok) {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -667,7 +667,7 @@ app.get('/narratives', async (c) => {
 
   try {
     const res = await supabaseFetch(
-      `published_narratives?select=id,narrative_id,content_small,tags,priority,actions,thread_id,created_at&order=created_at.desc,priority.desc&limit=${limit}&offset=${offset}`
+      `published_narratives?select=id,narrative_id,title,content_small,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&status=eq.published&order=published_at.desc,priority.desc&limit=${limit}&offset=${offset}`
     )
 
     if (!res.ok) {
@@ -693,7 +693,7 @@ app.get('/narratives/:id', async (c) => {
 
   try {
     const res = await supabaseFetch(
-      `published_narratives?id=eq.${encodeURIComponent(id)}&select=*&limit=1`
+      `published_narratives?id=eq.${encodeURIComponent(id)}&status=eq.published&select=id,narrative_id,title,content_small,content_full,tags,priority,actions,thread_id,entity_id,entity_slug,entity_name,entity_type,entity_category,published_at,created_at&limit=1`
     )
 
     if (!res.ok) {

--- a/packages/collectors/.env.example
+++ b/packages/collectors/.env.example
@@ -25,3 +25,9 @@ POLYMARKET_MARKETS_CANDIDATE_COOLDOWN_HOURS=6
 
 # Read-only VPS preflight
 POLYMARKET_DOCTOR_SLUG=will-the-fed-increase-interest-rates-by-25-bps-after-the-july-2026-meeting
+
+# Generic publisher from editor_drafts to published_narratives
+PUBLISHER_RUN_ONCE=0
+PUBLISHER_INTERVAL_MS=300000
+PUBLISHER_BATCH_SIZE=10
+PUBLISHER_PREVIEW_ONLY=0

--- a/packages/collectors/package.json
+++ b/packages/collectors/package.json
@@ -10,13 +10,16 @@
     "entity-manager:polymarket": "tsx src/entity-manager/run-polymarket.ts",
     "editor-draft": "tsx src/editor-draft/run.ts",
     "editor-draft:preview": "tsx src/editor-draft/preview.ts",
+    "publisher": "tsx src/publisher/run.ts",
+    "publisher:preview": "tsx src/publisher/preview.ts",
     "world-cup:pre-match": "tsx src/world-cup/run-pre-match.ts",
     "build": "tsc",
     "test:world-cup": "tsx --test src/world-cup/*.test.ts",
     "test:markets-data-engineer": "tsx --test src/polymarket/markets-data-engineer.test.ts",
     "test:researcher": "tsx --test src/polymarket/researcher.test.ts",
     "test:entity-manager": "tsx --test src/entity-manager/*.test.ts",
-    "test:editor-draft": "tsx --test src/editor-draft/*.test.ts"
+    "test:editor-draft": "tsx --test src/editor-draft/*.test.ts",
+    "test:publisher": "tsx --test src/publisher/*.test.ts"
   },
   "dependencies": {
     "@myboon/shared": "workspace:*",

--- a/packages/collectors/src/editor-draft/types.ts
+++ b/packages/collectors/src/editor-draft/types.ts
@@ -13,6 +13,7 @@ export type EditorDraftStatus =
   | 'skipped'
   | 'needs_more_research'
   | 'merged'
+  | 'published'
 
 export type EvidenceQuality = 'strong' | 'medium' | 'weak'
 

--- a/packages/collectors/src/publisher/actions.ts
+++ b/packages/collectors/src/publisher/actions.ts
@@ -1,0 +1,116 @@
+import type { PublishedAction, PublisherMemoryRecord } from './types'
+
+const POLYMARKET_HOST_RE = /(^|\.)polymarket\.com$/i
+const MARKET_PATH_RE = /^\/(?:event|market)\/([^/?#]+)/
+const MAX_PUBLIC_ACTIONS = 3
+const MARKET_SLUG_KEYS = new Set([
+  'source_market_slug',
+  'source_market_event_slug',
+  'source_event_slug',
+  'market_slug',
+  'event_slug',
+])
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function normalizeSlug(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^https?:\/\//i.test(trimmed)) return slugFromPolymarketUrl(trimmed)
+  if (!/^[a-z0-9][a-z0-9-]{2,}$/i.test(trimmed)) return null
+  return trimmed.toLowerCase()
+}
+
+function slugFromPolymarketUrl(value: string): string | null {
+  try {
+    const url = new URL(value)
+    if (!POLYMARKET_HOST_RE.test(url.hostname)) return null
+    const match = MARKET_PATH_RE.exec(url.pathname)
+    return match ? normalizeSlug(decodeURIComponent(match[1])) : null
+  } catch {
+    return null
+  }
+}
+
+function collectExplicitSlugsFromValue(value: unknown, out: string[], keyHint = ''): void {
+  if (typeof value === 'string') {
+    if (MARKET_SLUG_KEYS.has(keyHint.toLowerCase())) {
+      const directSlug = normalizeSlug(value)
+      if (directSlug) out.push(directSlug)
+    }
+    return
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectExplicitSlugsFromValue(item, out, keyHint)
+    return
+  }
+
+  const record = asRecord(value)
+  if (!record) return
+
+  for (const [key, nested] of Object.entries(record)) {
+    collectExplicitSlugsFromValue(nested, out, key)
+  }
+}
+
+function collectUrlSlugsFromValue(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    const urlSlug = slugFromPolymarketUrl(value)
+    if (urlSlug) out.push(urlSlug)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectUrlSlugsFromValue(item, out)
+    return
+  }
+
+  const record = asRecord(value)
+  if (!record) return
+
+  for (const nested of Object.values(record)) {
+    collectUrlSlugsFromValue(nested, out)
+  }
+}
+
+function takeUnique(values: string[], limit: number): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) continue
+    seen.add(value)
+    out.push(value)
+    if (out.length >= limit) break
+  }
+  return out
+}
+
+export function deriveActionsFromMemories(memories: PublisherMemoryRecord[]): PublishedAction[] {
+  const sourceRefSlugs: string[] = []
+  const explicitSlugs: string[] = []
+  const evidenceUrlSlugs: string[] = []
+
+  for (const memory of memories) {
+    if (memory.source.toLowerCase() === 'polymarket') {
+      const refSlug = normalizeSlug(memory.source_ref_id)
+      if (refSlug) sourceRefSlugs.push(refSlug)
+    }
+
+    collectExplicitSlugsFromValue(memory.context, explicitSlugs)
+    collectUrlSlugsFromValue(memory.evidence, evidenceUrlSlugs)
+  }
+
+  return takeUnique(
+    [...sourceRefSlugs, ...explicitSlugs, ...evidenceUrlSlugs],
+    MAX_PUBLIC_ACTIONS
+  ).map((slug) => ({
+    type: 'predict' as const,
+    label: 'Open market',
+    slug,
+  }))
+}

--- a/packages/collectors/src/publisher/preview.ts
+++ b/packages/collectors/src/publisher/preview.ts
@@ -1,0 +1,34 @@
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '.env' })
+loadEnv({ path: '../../.env' })
+loadEnv()
+
+import { createClient } from '@supabase/supabase-js'
+import { publisherCliConfig, runPublisher } from './runner'
+import { SupabasePublisherStore } from './supabase-store'
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env var: ${name}`)
+  return value
+}
+
+async function main(): Promise<void> {
+  const config = publisherCliConfig()
+  const supabase = createClient(
+    requiredEnv('SUPABASE_URL'),
+    requiredEnv('SUPABASE_SERVICE_ROLE_KEY')
+  )
+  const result = await runPublisher({
+    store: new SupabasePublisherStore(supabase),
+    batchSize: config.batchSize,
+    dryRun: true,
+  })
+  console.log(JSON.stringify(result, null, 2))
+}
+
+main().catch((err) => {
+  console.error('[publisher:preview] fatal:', err)
+  process.exit(1)
+})

--- a/packages/collectors/src/publisher/publisher.test.ts
+++ b/packages/collectors/src/publisher/publisher.test.ts
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveActionsFromMemories } from './actions'
+import { buildPublication, runPublisher } from './runner'
+import type {
+  PublishedNarrativeInput,
+  PublishedNarrativeRecord,
+  PublisherDraftRecord,
+  PublisherEntityRecord,
+  PublisherMemoryRecord,
+  PublisherStore,
+  PublisherWriteResult,
+} from './types'
+
+function draft(overrides: Partial<PublisherDraftRecord> = {}): PublisherDraftRecord {
+  return {
+    id: 'draft-1',
+    entity_id: 'entity-1',
+    entity_slug: 'ethereum',
+    entity_name: 'Ethereum',
+    entity_type: 'asset',
+    source_memory_ids: ['memory-1'],
+    source_memory_hash: 'hash-1',
+    source: 'polymarket',
+    source_area: 'markets',
+    action: 'draft_post',
+    status: 'drafted',
+    title: 'ETH repricing gets a clean catalyst',
+    angle: 'Prediction markets moved after ETF flow context changed.',
+    summary: 'Polymarket odds moved as traders repriced the Ethereum ETF timeline.',
+    body: 'The editor draft body is already the final public narrative. Publisher should persist it without rewriting.',
+    reasoning: 'Editor approved this draft from a new market memory.',
+    evidence_quality: 'medium',
+    priority: 72,
+    confidence: 0.81,
+    created_at: '2026-07-03T00:00:00.000Z',
+    updated_at: '2026-07-03T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function memory(overrides: Partial<PublisherMemoryRecord> = {}): PublisherMemoryRecord {
+  return {
+    id: 'memory-1',
+    source: 'polymarket',
+    source_area: 'markets',
+    source_type: 'market_signal',
+    source_ref_id: 'will-ethereum-etf-flows-top-10b-in-2026',
+    source_research_id: 'research-1',
+    title: 'ETH market moved',
+    summary: 'Market summary',
+    evidence: [{ url: 'https://polymarket.com/event/will-ethereum-etf-flows-top-10b-in-2026' }],
+    context: { source_market_slug: 'will-ethereum-etf-flows-top-10b-in-2026' },
+    ...overrides,
+  }
+}
+
+function entity(overrides: Partial<PublisherEntityRecord> = {}): PublisherEntityRecord {
+  return {
+    id: 'entity-1',
+    slug: 'ethereum',
+    name: 'Ethereum',
+    type: 'asset',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+class InMemoryPublisherStore implements PublisherStore {
+  narratives = new Map<string, PublishedNarrativeRecord>()
+  publications: PublishedNarrativeInput[] = []
+  history: Array<{ published_narrative_id: string, title: string, content: string }> = []
+
+  constructor(
+    public drafts: PublisherDraftRecord[],
+    private readonly memories: PublisherMemoryRecord[],
+    private readonly entities: PublisherEntityRecord[] = [],
+    private readonly markPublished = false
+  ) {}
+
+  async fetchEligibleDrafts(batchSize: number): Promise<PublisherDraftRecord[]> {
+    return this.drafts.slice(0, batchSize)
+  }
+
+  async fetchMemories(memoryIds: string[]): Promise<PublisherMemoryRecord[]> {
+    return this.memories.filter((item) => memoryIds.includes(item.id))
+  }
+
+  async fetchEntity(entityId: string): Promise<PublisherEntityRecord | null> {
+    return this.entities.find((item) => item.id === entityId) ?? null
+  }
+
+  async publishDraft(publication: PublishedNarrativeInput): Promise<PublisherWriteResult> {
+    const existing = this.narratives.get(publication.editor_draft_id)
+    if (existing) {
+      this.upsertHistory(existing.id, publication)
+      return { narrative: existing, existing: true }
+    }
+
+    const narrative = { id: `narrative-${this.narratives.size + 1}`, editor_draft_id: publication.editor_draft_id, published_at: publication.published_at }
+    this.narratives.set(publication.editor_draft_id, narrative)
+    this.publications.push(publication)
+    this.upsertHistory(narrative.id, publication)
+    if (this.markPublished) {
+      const row = this.drafts.find((item) => item.id === publication.editor_draft_id)
+      if (row) row.status = 'published'
+    }
+    return { narrative, existing: false }
+  }
+
+  private upsertHistory(narrativeId: string, publication: PublishedNarrativeInput): void {
+    const existing = this.history.find((item) => item.published_narrative_id === narrativeId)
+    const row = {
+      published_narrative_id: narrativeId,
+      title: publication.title,
+      content: publication.content_full,
+    }
+    if (existing) Object.assign(existing, row)
+    else this.history.push(row)
+  }
+}
+
+test('buildPublication maps editor draft content without rewriting', () => {
+  const publication = buildPublication(
+    draft(),
+    entity({ metadata: { category: 'crypto' } }),
+    [memory()],
+    '2026-07-03T01:00:00.000Z'
+  )
+
+  assert.equal(publication.title, 'ETH repricing gets a clean catalyst')
+  assert.equal(publication.content_small, 'Polymarket odds moved as traders repriced the Ethereum ETF timeline.')
+  assert.equal(publication.content_full, 'The editor draft body is already the final public narrative. Publisher should persist it without rewriting.')
+  assert.equal(publication.priority, 72)
+  assert.deepEqual(publication.tags, ['crypto'])
+  assert.equal(publication.entity_category, 'crypto')
+  assert.equal(publication.status, 'published')
+})
+
+test('runPublisher skips non-draft actions and invalid drafted rows', async () => {
+  const store = new InMemoryPublisherStore([
+    draft({ id: 'watch-1', action: 'watch', status: 'watching' }),
+    draft({ id: 'invalid-1', title: null }),
+  ], [memory()])
+
+  const result = await runPublisher({
+    store,
+    now: '2026-07-03T01:00:00.000Z',
+  })
+
+  assert.equal(result.publicationsWritten, 0)
+  assert.equal(result.skipped, 2)
+  assert.deepEqual(store.publications, [])
+})
+
+test('deriveActionsFromMemories creates Polymarket predict actions from source evidence and context', () => {
+  const actions = deriveActionsFromMemories([
+    memory({
+      source_ref_id: 'will-arc-launch-a-token-by-december-31-2026',
+      context: {
+        source_market_slug: 'will-arc-launch-a-token-by-december-31-2026',
+        nested: { url: 'https://polymarket.com/event/will-arc-launch-a-token-by-december-31-2026?tid=abc' },
+      },
+      evidence: [{ source_url: 'https://polymarket.com/market/will-ethereum-hit-5000-in-2026' }],
+    }),
+  ])
+
+  assert.deepEqual(actions, [
+    { type: 'predict', label: 'Open market', slug: 'will-arc-launch-a-token-by-december-31-2026' },
+    { type: 'predict', label: 'Open market', slug: 'will-ethereum-hit-5000-in-2026' },
+  ])
+})
+
+test('deriveActionsFromMemories ignores generic slug fields like tag_slug', () => {
+  const actions = deriveActionsFromMemories([
+    memory({
+      source: 'news',
+      source_ref_id: 'article-1',
+      evidence: [],
+      context: {
+        tag_slug: 'crypto',
+        research_cluster_key: 'market:crypto',
+        source_market_slug: 'will-ethereum-hit-5000-in-2026',
+      },
+    }),
+  ])
+
+  assert.deepEqual(actions, [
+    { type: 'predict', label: 'Open market', slug: 'will-ethereum-hit-5000-in-2026' },
+  ])
+})
+
+test('deriveActionsFromMemories caps actions and prioritizes primary source slug first', () => {
+  const actions = deriveActionsFromMemories([
+    memory({
+      source: 'polymarket',
+      source_ref_id: 'primary-market-slug',
+      context: {
+        source_market_slug: 'context-market-slug',
+      },
+      evidence: [
+        { url: 'https://polymarket.com/event/evidence-market-one' },
+        { url: 'https://polymarket.com/event/evidence-market-two' },
+        { url: 'https://polymarket.com/event/evidence-market-three' },
+        { url: 'https://polymarket.com/event/evidence-market-four' },
+      ],
+    }),
+  ])
+
+  assert.deepEqual(actions, [
+    { type: 'predict', label: 'Open market', slug: 'primary-market-slug' },
+    { type: 'predict', label: 'Open market', slug: 'context-market-slug' },
+    { type: 'predict', label: 'Open market', slug: 'evidence-market-one' },
+  ])
+})
+
+test('buildPublication keeps actions empty when no inspectable source exists', () => {
+  const publication = buildPublication(
+    draft({ source: 'news', source_area: 'articles' }),
+    entity(),
+    [memory({ source: 'news', source_ref_id: 'article-1', evidence: [{ url: 'https://example.com/story' }], context: {} })],
+    '2026-07-03T01:00:00.000Z'
+  )
+
+  assert.deepEqual(publication.actions, [])
+  assert.deepEqual(publication.tags, [])
+  assert.equal(publication.entity_category, 'asset')
+})
+
+test('runPublisher is idempotent by editor draft id', async () => {
+  const store = new InMemoryPublisherStore([draft()], [memory()], [entity()])
+
+  const first = await runPublisher({ store, now: '2026-07-03T01:00:00.000Z' })
+  const second = await runPublisher({ store, now: '2026-07-03T01:01:00.000Z' })
+
+  assert.equal(first.publicationsWritten, 1)
+  assert.equal(second.publicationsExisting, 1)
+  assert.equal(store.narratives.size, 1)
+  assert.equal(store.publications.length, 1)
+})
+
+test('runPublisher writes entity history and marks drafts published through the store', async () => {
+  const row = draft()
+  const store = new InMemoryPublisherStore([row], [memory()], [entity()], true)
+
+  const result = await runPublisher({ store, now: '2026-07-03T01:00:00.000Z' })
+
+  assert.equal(result.publicationsWritten, 1)
+  assert.equal(row.status, 'published')
+  assert.equal(store.history.length, 1)
+  assert.equal(store.history[0].title, row.title)
+  assert.equal(store.history[0].content, row.body)
+})
+
+test('runPublisher preview does not write', async () => {
+  const store = new InMemoryPublisherStore([draft()], [memory()], [entity()])
+
+  const result = await runPublisher({
+    store,
+    now: '2026-07-03T01:00:00.000Z',
+    dryRun: true,
+  })
+
+  assert.equal(result.dryRun, true)
+  assert.equal(result.publications.length, 1)
+  assert.equal(result.publicationsWritten, 0)
+  assert.equal(store.narratives.size, 0)
+})

--- a/packages/collectors/src/publisher/run.ts
+++ b/packages/collectors/src/publisher/run.ts
@@ -1,0 +1,51 @@
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '.env' })
+loadEnv({ path: '../../.env' })
+loadEnv()
+
+import { createClient } from '@supabase/supabase-js'
+import { publisherCliConfig, runPublisher } from './runner'
+import { SupabasePublisherStore } from './supabase-store'
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env var: ${name}`)
+  return value
+}
+
+function previewOnly(env: NodeJS.ProcessEnv): boolean {
+  return env.PUBLISHER_PREVIEW_ONLY === '1' || env.PUBLISHER_DRY_RUN === '1'
+}
+
+async function runOnce(): Promise<void> {
+  const config = publisherCliConfig()
+  const supabase = createClient(
+    requiredEnv('SUPABASE_URL'),
+    requiredEnv('SUPABASE_SERVICE_ROLE_KEY')
+  )
+  const result = await runPublisher({
+    store: new SupabasePublisherStore(supabase),
+    batchSize: config.batchSize,
+    dryRun: previewOnly(process.env),
+  })
+  console.log(JSON.stringify(result, null, 2))
+}
+
+async function main(): Promise<void> {
+  const config = publisherCliConfig()
+  await runOnce()
+
+  if (config.runOnce) return
+
+  setInterval(() => {
+    runOnce().catch((err) => {
+      console.error('[publisher] run failed:', err)
+    })
+  }, config.intervalMs)
+}
+
+main().catch((err) => {
+  console.error('[publisher] fatal:', err)
+  process.exit(1)
+})

--- a/packages/collectors/src/publisher/runner.ts
+++ b/packages/collectors/src/publisher/runner.ts
@@ -1,0 +1,179 @@
+import { deriveActionsFromMemories } from './actions'
+import type {
+  PublishedNarrativeInput,
+  PublisherDraftRecord,
+  PublisherEntityRecord,
+  PublisherMemoryRecord,
+  PublisherStore,
+} from './types'
+
+const DEFAULT_BATCH_SIZE = 10
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+
+export interface PublisherCliConfig {
+  batchSize: number
+  intervalMs: number
+  runOnce: boolean
+}
+
+export interface RunPublisherOptions {
+  now?: string
+  batchSize?: number
+  store: PublisherStore
+  dryRun?: boolean
+}
+
+export interface PublisherRunResult {
+  observedAt: string
+  dryRun: boolean
+  draftsFetched: number
+  publicationsWritten: number
+  publicationsExisting: number
+  skipped: number
+  publications: Array<{
+    id: string | null
+    editorDraftId: string
+    entitySlug: string
+    title: string
+    actionCount: number
+    existing: boolean
+  }>
+  skips: Array<{ editorDraftId: string, reason: string }>
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function envFlag(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true'
+}
+
+function directString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+export function publisherCliConfig(env: NodeJS.ProcessEnv = process.env): PublisherCliConfig {
+  return {
+    batchSize: positiveInteger(env.PUBLISHER_BATCH_SIZE, DEFAULT_BATCH_SIZE),
+    intervalMs: positiveInteger(env.PUBLISHER_INTERVAL_MS, DEFAULT_INTERVAL_MS),
+    runOnce: envFlag(env.PUBLISHER_RUN_ONCE),
+  }
+}
+
+export function isEligibleDraft(draft: PublisherDraftRecord): boolean {
+  return draft.action === 'draft_post'
+    && draft.status === 'drafted'
+    && Boolean(draft.title?.trim())
+    && Boolean(draft.body?.trim())
+}
+
+export function entityCategory(entity: PublisherEntityRecord | null, draft: PublisherDraftRecord): string | null {
+  const metadataCategory = entity
+    ? directString(entity.metadata, ['category', 'entity_category', 'primary_category'])
+    : null
+  return metadataCategory ?? (draft.entity_type.trim() || null)
+}
+
+export function tagsForEntity(entity: PublisherEntityRecord | null): string[] {
+  if (!entity) return []
+  const metadataCategory = directString(entity.metadata, ['category', 'entity_category', 'primary_category'])
+  return metadataCategory ? [metadataCategory] : []
+}
+
+export function buildPublication(
+  draft: PublisherDraftRecord,
+  entity: PublisherEntityRecord | null,
+  memories: PublisherMemoryRecord[],
+  observedAt: string
+): PublishedNarrativeInput {
+  if (!isEligibleDraft(draft)) {
+    throw new Error(`draft ${draft.id} is not eligible for publishing`)
+  }
+
+  return {
+    editor_draft_id: draft.id,
+    title: draft.title?.trim() ?? '',
+    content_small: draft.summary?.trim() ?? '',
+    content_full: draft.body?.trim() ?? '',
+    priority: draft.priority ?? 0,
+    actions: deriveActionsFromMemories(memories),
+    tags: tagsForEntity(entity),
+    status: 'published',
+    published_at: observedAt,
+    entity_id: draft.entity_id,
+    entity_slug: draft.entity_slug,
+    entity_name: draft.entity_name,
+    entity_type: draft.entity_type,
+    entity_category: entityCategory(entity, draft),
+    source_memory_ids: draft.source_memory_ids,
+    source_memory_hash: draft.source_memory_hash,
+    source: draft.source,
+    source_area: draft.source_area,
+    angle: draft.angle,
+    reasoning: draft.reasoning,
+    evidence_quality: draft.evidence_quality,
+    confidence: draft.confidence,
+  }
+}
+
+export async function runPublisher(options: RunPublisherOptions): Promise<PublisherRunResult> {
+  const observedAt = options.now ?? new Date().toISOString()
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE
+  const dryRun = options.dryRun ?? false
+  const drafts = await options.store.fetchEligibleDrafts(batchSize)
+  const publications: PublisherRunResult['publications'] = []
+  const skips: PublisherRunResult['skips'] = []
+
+  for (const draft of drafts) {
+    if (!isEligibleDraft(draft)) {
+      skips.push({ editorDraftId: draft.id, reason: 'not_eligible' })
+      continue
+    }
+
+    const [entity, memories] = await Promise.all([
+      options.store.fetchEntity(draft.entity_id),
+      options.store.fetchMemories(draft.source_memory_ids),
+    ])
+    const publication = buildPublication(draft, entity, memories, observedAt)
+
+    if (dryRun) {
+      publications.push({
+        id: null,
+        editorDraftId: draft.id,
+        entitySlug: draft.entity_slug,
+        title: publication.title,
+        actionCount: publication.actions.length,
+        existing: false,
+      })
+      continue
+    }
+
+    const written = await options.store.publishDraft(publication)
+    publications.push({
+      id: written.narrative.id,
+      editorDraftId: draft.id,
+      entitySlug: draft.entity_slug,
+      title: publication.title,
+      actionCount: publication.actions.length,
+      existing: written.existing,
+    })
+  }
+
+  return {
+    observedAt,
+    dryRun,
+    draftsFetched: drafts.length,
+    publicationsWritten: publications.filter((item) => item.id && !item.existing).length,
+    publicationsExisting: publications.filter((item) => item.id && item.existing).length,
+    skipped: skips.length,
+    publications,
+    skips,
+  }
+}

--- a/packages/collectors/src/publisher/supabase-store.ts
+++ b/packages/collectors/src/publisher/supabase-store.ts
@@ -1,0 +1,246 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  PublishedNarrativeInput,
+  PublishedNarrativeRecord,
+  PublisherDraftRecord,
+  PublisherEntityRecord,
+  PublisherMemoryRecord,
+  PublisherStore,
+  PublisherWriteResult,
+} from './types'
+
+const DRAFT_SELECT = 'id, entity_id, entity_slug, entity_name, entity_type, source_memory_ids, source_memory_hash, source, source_area, action, status, title, angle, summary, body, reasoning, evidence_quality, priority, confidence, created_at, updated_at'
+const MEMORY_SELECT = 'id, source, source_area, source_type, source_ref_id, source_research_id, title, summary, evidence, context'
+const ENTITY_SELECT = 'id, slug, name, type, metadata'
+const NARRATIVE_SELECT = 'id, editor_draft_id, created_at, published_at'
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function normalizeDraft(row: unknown): PublisherDraftRecord {
+  const record = row as Record<string, unknown>
+  return {
+    id: String(record.id),
+    entity_id: String(record.entity_id),
+    entity_slug: String(record.entity_slug),
+    entity_name: String(record.entity_name),
+    entity_type: String(record.entity_type),
+    source_memory_ids: asStringArray(record.source_memory_ids),
+    source_memory_hash: String(record.source_memory_hash),
+    source: nullableString(record.source),
+    source_area: nullableString(record.source_area),
+    action: String(record.action),
+    status: record.status as PublisherDraftRecord['status'],
+    title: nullableString(record.title),
+    angle: nullableString(record.angle),
+    summary: nullableString(record.summary),
+    body: nullableString(record.body),
+    reasoning: typeof record.reasoning === 'string' ? record.reasoning : '',
+    evidence_quality: record.evidence_quality as PublisherDraftRecord['evidence_quality'],
+    priority: nullableNumber(record.priority),
+    confidence: nullableNumber(record.confidence),
+    created_at: String(record.created_at),
+    updated_at: String(record.updated_at),
+  }
+}
+
+function normalizeMemory(row: unknown): PublisherMemoryRecord {
+  const record = row as Record<string, unknown>
+  return {
+    id: String(record.id),
+    source: String(record.source),
+    source_area: String(record.source_area),
+    source_type: String(record.source_type),
+    source_ref_id: String(record.source_ref_id),
+    source_research_id: String(record.source_research_id),
+    title: String(record.title),
+    summary: String(record.summary),
+    evidence: Array.isArray(record.evidence) ? record.evidence : [],
+    context: asRecord(record.context),
+  }
+}
+
+function normalizeEntity(row: unknown): PublisherEntityRecord {
+  const record = row as Record<string, unknown>
+  return {
+    id: String(record.id),
+    slug: String(record.slug),
+    name: String(record.name),
+    type: String(record.type),
+    metadata: asRecord(record.metadata),
+  }
+}
+
+function normalizeNarrative(row: unknown): PublishedNarrativeRecord {
+  const record = row as Record<string, unknown>
+  return {
+    id: String(record.id),
+    editor_draft_id: nullableString(record.editor_draft_id),
+    created_at: nullableString(record.created_at) ?? undefined,
+    published_at: nullableString(record.published_at) ?? undefined,
+  }
+}
+
+function isUniqueViolation(error: { code?: string, message?: string } | null): boolean {
+  if (!error) return false
+  return error.code === '23505' || /duplicate key|unique/i.test(error.message ?? '')
+}
+
+export class SupabasePublisherStore implements PublisherStore {
+  constructor(private readonly db: SupabaseClient) {}
+
+  async fetchEligibleDrafts(batchSize: number): Promise<PublisherDraftRecord[]> {
+    const { data, error } = await this.db
+      .from('editor_drafts')
+      .select(DRAFT_SELECT)
+      .eq('action', 'draft_post')
+      .eq('status', 'drafted')
+      .not('title', 'is', null)
+      .not('body', 'is', null)
+      .order('created_at', { ascending: true })
+      .limit(batchSize)
+
+    if (error) throw new Error(`publisher draft fetch failed: ${error.message}`)
+    return (data ?? []).map(normalizeDraft)
+  }
+
+  async fetchMemories(memoryIds: string[]): Promise<PublisherMemoryRecord[]> {
+    if (memoryIds.length === 0) return []
+    const { data, error } = await this.db
+      .from('entity_memories')
+      .select(MEMORY_SELECT)
+      .in('id', memoryIds)
+
+    if (error) throw new Error(`publisher memory fetch failed: ${error.message}`)
+    return (data ?? []).map(normalizeMemory)
+  }
+
+  async fetchEntity(entityId: string): Promise<PublisherEntityRecord | null> {
+    const { data, error } = await this.db
+      .from('entities')
+      .select(ENTITY_SELECT)
+      .eq('id', entityId)
+      .maybeSingle()
+
+    if (error) throw new Error(`publisher entity fetch failed: ${error.message}`)
+    return data ? normalizeEntity(data) : null
+  }
+
+  async publishDraft(publication: PublishedNarrativeInput): Promise<PublisherWriteResult> {
+    const existing = await this.findPublishedNarrative(publication.editor_draft_id)
+    if (existing) {
+      await this.ensureHistory(existing.id, publication)
+      await this.markDraftPublished(publication.editor_draft_id, publication.published_at)
+      return { narrative: existing, existing: true }
+    }
+
+    const payload = {
+      title: publication.title,
+      content_small: publication.content_small,
+      content_full: publication.content_full,
+      tags: publication.tags,
+      priority: publication.priority,
+      actions: publication.actions,
+      status: publication.status,
+      published_at: publication.published_at,
+      editor_draft_id: publication.editor_draft_id,
+      entity_id: publication.entity_id,
+      entity_slug: publication.entity_slug,
+      entity_name: publication.entity_name,
+      entity_type: publication.entity_type,
+      entity_category: publication.entity_category,
+      source_memory_ids: publication.source_memory_ids,
+      source_memory_hash: publication.source_memory_hash,
+      source: publication.source,
+      area: publication.source_area,
+      source_area: publication.source_area,
+      angle: publication.angle,
+      reasoning: publication.reasoning,
+      evidence_quality: publication.evidence_quality,
+      confidence: publication.confidence,
+    }
+
+    const { data, error } = await this.db
+      .from('published_narratives')
+      .insert(payload)
+      .select(NARRATIVE_SELECT)
+      .single()
+
+    if (error) {
+      if (isUniqueViolation(error)) {
+        const racedExisting = await this.findPublishedNarrative(publication.editor_draft_id)
+        if (racedExisting) {
+          await this.ensureHistory(racedExisting.id, publication)
+          await this.markDraftPublished(publication.editor_draft_id, publication.published_at)
+          return { narrative: racedExisting, existing: true }
+        }
+      }
+      throw new Error(`publisher narrative insert failed: ${error.message}`)
+    }
+
+    const narrative = normalizeNarrative(data)
+    await this.ensureHistory(narrative.id, publication)
+    await this.markDraftPublished(publication.editor_draft_id, publication.published_at)
+    return { narrative, existing: false }
+  }
+
+  private async findPublishedNarrative(editorDraftId: string): Promise<PublishedNarrativeRecord | null> {
+    const { data, error } = await this.db
+      .from('published_narratives')
+      .select(NARRATIVE_SELECT)
+      .eq('editor_draft_id', editorDraftId)
+      .maybeSingle()
+
+    if (error) throw new Error(`publisher existing narrative lookup failed: ${error.message}`)
+    return data ? normalizeNarrative(data) : null
+  }
+
+  private async ensureHistory(narrativeId: string, publication: PublishedNarrativeInput): Promise<void> {
+    const { error } = await this.db
+      .from('entity_published_history')
+      .upsert({
+        published_narrative_id: narrativeId,
+        entity_id: publication.entity_id,
+        entity_slug: publication.entity_slug,
+        title: publication.title,
+        angle: publication.angle,
+        summary: publication.content_small,
+        content: publication.content_full,
+        source: publication.source,
+        source_area: publication.source_area,
+        published_at: publication.published_at,
+      }, { onConflict: 'published_narrative_id' })
+
+    if (error) throw new Error(`publisher history upsert failed: ${error.message}`)
+  }
+
+  private async markDraftPublished(editorDraftId: string, observedAt: string): Promise<void> {
+    const { error } = await this.db
+      .from('editor_drafts')
+      .update({ status: 'published', updated_at: observedAt })
+      .eq('id', editorDraftId)
+
+    if (error) throw new Error(`publisher draft status update failed: ${error.message}`)
+  }
+}

--- a/packages/collectors/src/publisher/types.ts
+++ b/packages/collectors/src/publisher/types.ts
@@ -1,0 +1,103 @@
+import type { EvidenceQuality } from '../editor-draft/types'
+
+export type PublisherDraftStatus =
+  | 'drafted'
+  | 'watching'
+  | 'skipped'
+  | 'needs_more_research'
+  | 'merged'
+  | 'published'
+
+export interface PublisherDraftRecord {
+  id: string
+  entity_id: string
+  entity_slug: string
+  entity_name: string
+  entity_type: string
+  source_memory_ids: string[]
+  source_memory_hash: string
+  source: string | null
+  source_area: string | null
+  action: string
+  status: PublisherDraftStatus
+  title: string | null
+  angle: string | null
+  summary: string | null
+  body: string | null
+  reasoning: string
+  evidence_quality: EvidenceQuality | null
+  priority: number | null
+  confidence: number | null
+  created_at: string
+  updated_at: string
+}
+
+export interface PublisherMemoryRecord {
+  id: string
+  source: string
+  source_area: string
+  source_type: string
+  source_ref_id: string
+  source_research_id: string
+  title: string
+  summary: string
+  evidence: unknown[]
+  context: Record<string, unknown>
+}
+
+export interface PublisherEntityRecord {
+  id: string
+  slug: string
+  name: string
+  type: string
+  metadata: Record<string, unknown>
+}
+
+export type PublishedAction =
+  | { type: 'predict', label: string, slug: string }
+  | { type: 'perps', label: string, venue: string, asset: string }
+  | { type: 'link', label: string, url: string }
+
+export interface PublishedNarrativeInput {
+  editor_draft_id: string
+  title: string
+  content_small: string
+  content_full: string
+  priority: number
+  actions: PublishedAction[]
+  tags: string[]
+  status: 'published'
+  published_at: string
+  entity_id: string
+  entity_slug: string
+  entity_name: string
+  entity_type: string
+  entity_category: string | null
+  source_memory_ids: string[]
+  source_memory_hash: string
+  source: string | null
+  source_area: string | null
+  angle: string | null
+  reasoning: string
+  evidence_quality: EvidenceQuality | null
+  confidence: number | null
+}
+
+export interface PublishedNarrativeRecord {
+  id: string
+  editor_draft_id: string | null
+  created_at?: string
+  published_at?: string
+}
+
+export interface PublisherWriteResult {
+  narrative: PublishedNarrativeRecord
+  existing: boolean
+}
+
+export interface PublisherStore {
+  fetchEligibleDrafts(batchSize: number): Promise<PublisherDraftRecord[]>
+  fetchMemories(memoryIds: string[]): Promise<PublisherMemoryRecord[]>
+  fetchEntity(entityId: string): Promise<PublisherEntityRecord | null>
+  publishDraft(publication: PublishedNarrativeInput): Promise<PublisherWriteResult>
+}

--- a/supabase/migrations/20260703_publisher_v1_editor_drafts.sql
+++ b/supabase/migrations/20260703_publisher_v1_editor_drafts.sql
@@ -1,0 +1,138 @@
+-- Publisher V1: deterministic publishing from editor_drafts into the public feed.
+-- Additive/backwards-compatible for existing published_narratives rows.
+
+ALTER TABLE public.editor_drafts
+  DROP CONSTRAINT IF EXISTS editor_drafts_status_check;
+
+ALTER TABLE public.editor_drafts
+  ADD CONSTRAINT editor_drafts_status_check CHECK (
+    status IN (
+      'drafted',
+      'watching',
+      'skipped',
+      'needs_more_research',
+      'merged',
+      'published'
+    )
+  );
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS title text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS published_at timestamptz;
+
+UPDATE public.published_narratives
+SET published_at = COALESCE(published_at, created_at, now())
+WHERE published_at IS NULL;
+
+ALTER TABLE public.published_narratives
+  ALTER COLUMN published_at SET DEFAULT now();
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'published';
+
+ALTER TABLE public.published_narratives
+  DROP CONSTRAINT IF EXISTS published_narratives_status_check;
+
+ALTER TABLE public.published_narratives
+  ADD CONSTRAINT published_narratives_status_check CHECK (
+    status IN ('published', 'archived')
+  );
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS editor_draft_id uuid REFERENCES public.editor_drafts(id) ON DELETE SET NULL;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS entity_id uuid REFERENCES public.entities(id) ON DELETE SET NULL;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS entity_slug text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS entity_name text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS entity_type text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS entity_category text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS source_memory_ids jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS source_memory_hash text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS source_area text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS angle text;
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS evidence_quality text CHECK (
+    evidence_quality IS NULL OR evidence_quality IN ('strong', 'medium', 'weak')
+  );
+
+ALTER TABLE public.published_narratives
+  ADD COLUMN IF NOT EXISTS confidence numeric CHECK (
+    confidence IS NULL OR (confidence >= 0 AND confidence <= 1)
+  );
+
+WITH duplicate_editor_drafts AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY editor_draft_id
+      ORDER BY published_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+    ) AS duplicate_rank
+  FROM public.published_narratives
+  WHERE editor_draft_id IS NOT NULL
+)
+DELETE FROM public.published_narratives p
+USING duplicate_editor_drafts d
+WHERE p.id = d.id
+  AND d.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS published_narratives_editor_draft_unique_idx
+  ON public.published_narratives (editor_draft_id)
+  WHERE editor_draft_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS published_narratives_status_published_idx
+  ON public.published_narratives (status, published_at DESC, priority DESC);
+
+CREATE INDEX IF NOT EXISTS published_narratives_entity_published_idx
+  ON public.published_narratives (entity_id, published_at DESC)
+  WHERE entity_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS published_narratives_source_memory_ids_v1_idx
+  ON public.published_narratives USING GIN (source_memory_ids);
+
+CREATE TABLE IF NOT EXISTS public.entity_published_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  published_narrative_id uuid NOT NULL REFERENCES public.published_narratives(id) ON DELETE CASCADE,
+  entity_id uuid REFERENCES public.entities(id) ON DELETE SET NULL,
+  entity_slug text,
+  title text,
+  angle text,
+  summary text,
+  content text,
+  source text,
+  source_area text,
+  published_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS entity_published_history_narrative_unique_idx
+  ON public.entity_published_history (published_narrative_id);
+
+CREATE INDEX IF NOT EXISTS entity_published_history_entity_idx
+  ON public.entity_published_history (entity_id, published_at DESC)
+  WHERE entity_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS entity_published_history_slug_idx
+  ON public.entity_published_history (entity_slug, published_at DESC)
+  WHERE entity_slug IS NOT NULL;
+
+ALTER TABLE public.entity_published_history ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

Implements Publisher V1 from `editor_drafts` as a deterministic no-LLM publishing path.

Closes #203.

## What Changed

- Added generic publisher module under `packages/collectors/src/publisher`.
- Publishes eligible `editor_drafts` rows where:
  - `action = draft_post`
  - `status = drafted`
  - title/body are present
- Maps editor draft content directly:
  - `title -> published_narratives.title`
  - `summary -> published_narratives.content_small`
  - `body -> published_narratives.content_full`
- Adds retry-safe publishing keyed by `editor_draft_id`.
- Writes `entity_published_history` for future entity-aware Editor Draft dedupe.
- Marks editor drafts as `published` after successful publish.
- Derives public inspectable actions from source memories, capped at 3 actions.
- Adds no-write publisher preview runner.
- Updates `/narratives` API selects to avoid exposing internal provenance via `select=*`.
- Updates mobile feed mapping to use `title` as headline and `content_small` as preview.
- Adds PM2 config/docs/env for `myboon-publisher`.

## Verification

Passed:

```bash
cd packages/collectors
./node_modules/.bin/tsx --test src/publisher/*.test.ts
./node_modules/.bin/tsc -p tsconfig.json
PUBLISHER_BATCH_SIZE=3 ./node_modules/.bin/tsx src/publisher/preview.ts
```

Passed:

```bash
cd packages/api
./node_modules/.bin/tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck src/index.ts
```

Known unrelated local check failure:

```bash
cd apps/hybrid-expo
./node_modules/.bin/tsc --noEmit -p tsconfig.json
```

Fails on existing unrelated files:

- `e2e/predict-live.spec.ts:81`
- `playwright.predict.config.ts:99`

## Notes

- No Hermes / LLM call is used in Publisher V1.
- Old Polymarket-specific publisher code is left unchanged as historical/source-specific path.
- The live DB migration has not been applied yet.
